### PR TITLE
feat:(TASK-008): Crear Seeders de Categorías con Iconos y Descripciones

### DIFF
--- a/backend/tarot-app/docs/project_backlog.md
+++ b/backend/tarot-app/docs/project_backlog.md
@@ -1107,7 +1107,7 @@ Crear seeder con las 6 categorías predefinidas incluyendo iconos (emoji o refer
 
 **Tests necesarios:**
 
-- [ ] **Tests unitarios:**
+- [x] **Tests unitarios:**
   - Seeder inserta exactamente 6 categorías
   - Idempotencia: no duplica en múltiples ejecuciones
   - Todas las categorías tienen icono, color, descripción y orden
@@ -1117,23 +1117,23 @@ Crear seeder con las 6 categorías predefinidas incluyendo iconos (emoji o refer
 
 #### ✅ Tareas específicas
 
-- [ ] Crear seeder para las 6 categorías:
+- [x] Crear seeder para las 6 categorías:
   - **❤️ Amor y Relaciones** (`#FF6B9D`)
   - **💼 Carrera y Trabajo** (`#4A90E2`)
   - **💰 Dinero y Finanzas** (`#F5A623`)
   - **🏥 Salud y Bienestar** (`#7ED321`)
   - **✨ Crecimiento Espiritual** (`#9013FE`)
   - **🌟 Consulta General** (`#50E3C2`)
-- [ ] Escribir descripciones atractivas para cada categoría (1-2 oraciones)
-- [ ] Asignar orden de visualización apropiado (`order: 1-6`)
-- [ ] Implementar validación que evite duplicar categorías en múltiples ejecuciones
-- [ ] Todas las categorías deben iniciarse como `is_active: true`
+- [x] Escribir descripciones atractivas para cada categoría (1-2 oraciones)
+- [x] Asignar orden de visualización apropiado (`order: 1-6`)
+- [x] Implementar validación que evite duplicar categorías en múltiples ejecuciones
+- [x] Todas las categorías deben iniciarse como `is_active: true`
 
 #### 🎯 Criterios de aceptación
 
-- ✓ Existen exactamente 6 categorías después del seed
-- ✓ Cada categoría tiene icono, color y descripción completa
-- ✓ El seeder es idempotente
+- ✅ Existen exactamente 6 categorías después del seed
+- ✅ Cada categoría tiene icono, color y descripción completa
+- ✅ El seeder es idempotente
 
 ---
 

--- a/backend/tarot-app/src/database/seeds/reading-categories.seeder.spec.ts
+++ b/backend/tarot-app/src/database/seeds/reading-categories.seeder.spec.ts
@@ -1,0 +1,287 @@
+import { Repository } from 'typeorm';
+import { ReadingCategory } from '../../modules/categories/entities/reading-category.entity';
+import { seedReadingCategories } from './reading-categories.seeder';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+
+describe('ReadingCategoriesSeeder', () => {
+  let mockCategoryRepository: jest.Mocked<Repository<ReadingCategory>>;
+
+  beforeEach(() => {
+    mockCategoryRepository = {
+      count: jest.fn(),
+      save: jest.fn(),
+    } as unknown as jest.Mocked<Repository<ReadingCategory>>;
+  });
+
+  describe('seedReadingCategories', () => {
+    it('should seed exactly 6 categories when database is empty', async () => {
+      // Arrange
+      mockCategoryRepository.count.mockResolvedValue(0);
+      const savedCategories = Array.from({ length: 6 }, (_, i) => ({
+        id: i + 1,
+        name: `Category ${i + 1}`,
+        slug: `category-${i + 1}`,
+        description: `Description ${i + 1}`,
+        icon: '❤️',
+        color: '#FF6B9D',
+        order: i + 1,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })) as ReadingCategory[];
+      mockCategoryRepository.save.mockResolvedValue(
+        savedCategories as ReadingCategory & ReadingCategory[],
+      );
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      expect(mockCategoryRepository.count).toHaveBeenCalledTimes(1);
+      expect(mockCategoryRepository.save).toHaveBeenCalledTimes(1);
+      expect(mockCategoryRepository.save).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ name: expect.any(String) }),
+        ]),
+      );
+      const savedData = mockCategoryRepository.save.mock
+        .calls[0][0] as ReadingCategory[];
+      expect(savedData).toHaveLength(6);
+    });
+
+    it('should skip seeding if categories already exist (idempotency)', async () => {
+      // Arrange
+      mockCategoryRepository.count.mockResolvedValue(6);
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      expect(mockCategoryRepository.count).toHaveBeenCalledTimes(1);
+      expect(mockCategoryRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should seed all categories with required icon, color, description, and order', async () => {
+      // Arrange
+      mockCategoryRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.save.mockResolvedValue([] as any);
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      const savedData = mockCategoryRepository.save.mock
+        .calls[0][0] as ReadingCategory[];
+      savedData.forEach((category) => {
+        expect(category.icon).toBeDefined();
+        expect(category.icon).not.toBe('');
+        expect(category.color).toBeDefined();
+        expect(category.color).toMatch(/^#[0-9A-F]{6}$/i);
+        expect(category.description).toBeDefined();
+        expect(category.description.length).toBeGreaterThan(10);
+        expect(category.order).toBeDefined();
+        expect(category.order).toBeGreaterThanOrEqual(1);
+        expect(category.order).toBeLessThanOrEqual(6);
+      });
+    });
+
+    it('should seed all categories with isActive set to true', async () => {
+      // Arrange
+      mockCategoryRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.save.mockResolvedValue([] as any);
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      const savedData = mockCategoryRepository.save.mock
+        .calls[0][0] as ReadingCategory[];
+      savedData.forEach((category) => {
+        expect(category.isActive).toBe(true);
+      });
+    });
+
+    it('should seed Amor y Relaciones category with correct data', async () => {
+      // Arrange
+      mockCategoryRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.save.mockResolvedValue([] as any);
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      const savedData = mockCategoryRepository.save.mock
+        .calls[0][0] as ReadingCategory[];
+      const amorCategory = savedData.find((c) => c.slug === 'amor-relaciones');
+      expect(amorCategory).toBeDefined();
+      expect(amorCategory?.name).toBe('Amor y Relaciones');
+      expect(amorCategory?.icon).toBe('❤️');
+      expect(amorCategory?.color).toBe('#FF6B9D');
+      expect(amorCategory?.order).toBe(1);
+      expect(amorCategory?.description).toContain('amor');
+    });
+
+    it('should seed Carrera y Trabajo category with correct data', async () => {
+      // Arrange
+      mockCategoryRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.save.mockResolvedValue([] as any);
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      const savedData = mockCategoryRepository.save.mock
+        .calls[0][0] as ReadingCategory[];
+      const carreraCategory = savedData.find(
+        (c) => c.slug === 'carrera-trabajo',
+      );
+      expect(carreraCategory).toBeDefined();
+      expect(carreraCategory?.name).toBe('Carrera y Trabajo');
+      expect(carreraCategory?.icon).toBe('💼');
+      expect(carreraCategory?.color).toBe('#4A90E2');
+      expect(carreraCategory?.order).toBe(2);
+      expect(carreraCategory?.description).toContain('carrera');
+    });
+
+    it('should seed Dinero y Finanzas category with correct data', async () => {
+      // Arrange
+      mockCategoryRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.save.mockResolvedValue([] as any);
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      const savedData = mockCategoryRepository.save.mock
+        .calls[0][0] as ReadingCategory[];
+      const dineroCategory = savedData.find(
+        (c) => c.slug === 'dinero-finanzas',
+      );
+      expect(dineroCategory).toBeDefined();
+      expect(dineroCategory?.name).toBe('Dinero y Finanzas');
+      expect(dineroCategory?.icon).toBe('💰');
+      expect(dineroCategory?.color).toBe('#F5A623');
+      expect(dineroCategory?.order).toBe(3);
+      expect(dineroCategory?.description).toContain('dinero');
+    });
+
+    it('should seed Salud y Bienestar category with correct data', async () => {
+      // Arrange
+      mockCategoryRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.save.mockResolvedValue([] as any);
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      const savedData = mockCategoryRepository.save.mock
+        .calls[0][0] as ReadingCategory[];
+      const saludCategory = savedData.find((c) => c.slug === 'salud-bienestar');
+      expect(saludCategory).toBeDefined();
+      expect(saludCategory?.name).toBe('Salud y Bienestar');
+      expect(saludCategory?.icon).toBe('🏥');
+      expect(saludCategory?.color).toBe('#7ED321');
+      expect(saludCategory?.order).toBe(4);
+      expect(saludCategory?.description).toContain('salud');
+    });
+
+    it('should seed Crecimiento Espiritual category with correct data', async () => {
+      // Arrange
+      mockCategoryRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.save.mockResolvedValue([] as any);
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      const savedData = mockCategoryRepository.save.mock
+        .calls[0][0] as ReadingCategory[];
+      const espiritualCategory = savedData.find(
+        (c) => c.slug === 'crecimiento-espiritual',
+      );
+      expect(espiritualCategory).toBeDefined();
+      expect(espiritualCategory?.name).toBe('Crecimiento Espiritual');
+      expect(espiritualCategory?.icon).toBe('✨');
+      expect(espiritualCategory?.color).toBe('#9013FE');
+      expect(espiritualCategory?.order).toBe(5);
+      expect(espiritualCategory?.description).toContain('espiritual');
+    });
+
+    it('should seed Consulta General category with correct data', async () => {
+      // Arrange
+      mockCategoryRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.save.mockResolvedValue([] as any);
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      const savedData = mockCategoryRepository.save.mock
+        .calls[0][0] as ReadingCategory[];
+      const generalCategory = savedData.find(
+        (c) => c.slug === 'consulta-general',
+      );
+      expect(generalCategory).toBeDefined();
+      expect(generalCategory?.name).toBe('Consulta General');
+      expect(generalCategory?.icon).toBe('🌟');
+      expect(generalCategory?.color).toBe('#50E3C2');
+      expect(generalCategory?.order).toBe(6);
+      expect(generalCategory?.description).toContain('general');
+    });
+
+    it('should have unique order values for each category', async () => {
+      // Arrange
+      mockCategoryRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.save.mockResolvedValue([] as any);
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      const savedData = mockCategoryRepository.save.mock
+        .calls[0][0] as ReadingCategory[];
+      const orders = savedData.map((c) => c.order);
+      const uniqueOrders = new Set(orders);
+      expect(uniqueOrders.size).toBe(6);
+    });
+
+    it('should have unique slug values for each category', async () => {
+      // Arrange
+      mockCategoryRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.save.mockResolvedValue([] as any);
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      const savedData = mockCategoryRepository.save.mock
+        .calls[0][0] as ReadingCategory[];
+      const slugs = savedData.map((c) => c.slug);
+      const uniqueSlugs = new Set(slugs);
+      expect(uniqueSlugs.size).toBe(6);
+    });
+
+    it('should log the seeding process', async () => {
+      // Arrange
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+      mockCategoryRepository.count.mockResolvedValue(0);
+      mockCategoryRepository.save.mockResolvedValue([] as any);
+
+      // Act
+      await seedReadingCategories(mockCategoryRepository);
+
+      // Assert
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Starting Reading Categories seeding'),
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Successfully seeded 6 categories'),
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/backend/tarot-app/src/database/seeds/reading-categories.seeder.ts
+++ b/backend/tarot-app/src/database/seeds/reading-categories.seeder.ts
@@ -1,0 +1,116 @@
+import { Repository } from 'typeorm';
+import { ReadingCategory } from '../../modules/categories/entities/reading-category.entity';
+
+/**
+ * Reading Categories Data
+ * Defines the 6 predefined categories for tarot readings
+ */
+const READING_CATEGORIES_DATA = [
+  {
+    name: 'Amor y Relaciones',
+    slug: 'amor-relaciones',
+    description:
+      'Consultas sobre amor, relaciones de pareja, vínculos afectivos y conexiones románticas. Descubre el camino de tu corazón.',
+    icon: '❤️',
+    color: '#FF6B9D',
+    order: 1,
+    isActive: true,
+  },
+  {
+    name: 'Carrera y Trabajo',
+    slug: 'carrera-trabajo',
+    description:
+      'Guía sobre tu carrera profesional, oportunidades laborales, proyectos y desarrollo en el ámbito del trabajo.',
+    icon: '💼',
+    color: '#4A90E2',
+    order: 2,
+    isActive: true,
+  },
+  {
+    name: 'Dinero y Finanzas',
+    slug: 'dinero-finanzas',
+    description:
+      'Orientación sobre dinero, finanzas personales, inversiones y abundancia material. Claridad en tus decisiones económicas.',
+    icon: '💰',
+    color: '#F5A623',
+    order: 3,
+    isActive: true,
+  },
+  {
+    name: 'Salud y Bienestar',
+    slug: 'salud-bienestar',
+    description:
+      'Consultas sobre salud física, bienestar emocional y equilibrio en tu vida. El tarot como guía para tu bienestar integral.',
+    icon: '🏥',
+    color: '#7ED321',
+    order: 4,
+    isActive: true,
+  },
+  {
+    name: 'Crecimiento Espiritual',
+    slug: 'crecimiento-espiritual',
+    description:
+      'Exploración espiritual, autoconocimiento, propósito de vida y desarrollo personal. Descubre tu camino interior.',
+    icon: '✨',
+    color: '#9013FE',
+    order: 5,
+    isActive: true,
+  },
+  {
+    name: 'Consulta General',
+    slug: 'consulta-general',
+    description:
+      'Lectura general para obtener orientación sobre múltiples aspectos de tu vida. Ideal cuando buscas una visión amplia.',
+    icon: '🌟',
+    color: '#50E3C2',
+    order: 6,
+    isActive: true,
+  },
+];
+
+/**
+ * Seed Reading Categories
+ * This seeder populates the database with the 6 predefined reading categories
+ *
+ * Features:
+ * - Idempotent: Can be run multiple times without duplicating data
+ * - Each category includes icon, color, description, and display order
+ * - All categories start as active (isActive: true)
+ */
+export async function seedReadingCategories(
+  categoryRepository: Repository<ReadingCategory>,
+): Promise<void> {
+  console.log('📚 Starting Reading Categories seeding process...');
+
+  // Check if categories already exist (idempotency)
+  const existingCategoriesCount = await categoryRepository.count();
+  if (existingCategoriesCount > 0) {
+    console.log(
+      `✅ Categories already seeded (found ${existingCategoriesCount} category/categories). Skipping...`,
+    );
+    return;
+  }
+
+  // Create category entities from data
+  const categories = READING_CATEGORIES_DATA.map((data) => {
+    const category = new ReadingCategory();
+    category.name = data.name;
+    category.slug = data.slug;
+    category.description = data.description;
+    category.icon = data.icon;
+    category.color = data.color;
+    category.order = data.order;
+    category.isActive = data.isActive;
+    return category;
+  });
+
+  // Save all categories
+  console.log(`💾 Saving ${categories.length} categories...`);
+  await categoryRepository.save(categories);
+
+  console.log('✅ Successfully seeded 6 categories!');
+  console.log('   Categories:');
+  READING_CATEGORIES_DATA.forEach((cat) => {
+    console.log(`   ${cat.icon} ${cat.name} (order: ${cat.order})`);
+  });
+}

--- a/backend/tarot-app/src/database/seeds/seed-data.ts
+++ b/backend/tarot-app/src/database/seeds/seed-data.ts
@@ -4,10 +4,11 @@ import { Repository, DataSource } from 'typeorm';
 import { AppModule } from '../../app.module';
 import { TarotDeck } from '../../modules/tarot/decks/entities/tarot-deck.entity';
 import { TarotCard } from '../../modules/tarot/cards/entities/tarot-card.entity';
+import { ReadingCategory } from '../../modules/categories/entities/reading-category.entity';
 import { seedTarotDecks } from './tarot-decks.seeder';
 import { seedTarotCards } from './tarot-cards.seeder';
 import { seedTarotSpreads } from './tarot-spreads.seeder';
-import { seedReadingCategories } from './reading-categories.seed';
+import { seedReadingCategories } from './reading-categories.seeder';
 
 async function bootstrap() {
   const app = await NestFactory.createApplicationContext(AppModule);
@@ -18,12 +19,15 @@ async function bootstrap() {
   const cardRepository = app.get<Repository<TarotCard>>(
     getRepositoryToken(TarotCard),
   );
+  const categoryRepository = app.get<Repository<ReadingCategory>>(
+    getRepositoryToken(ReadingCategory),
+  );
 
   try {
     console.log('🌱 Starting database seeding process...\n');
 
     // Seed Reading Categories first
-    await seedReadingCategories(dataSource);
+    await seedReadingCategories(categoryRepository);
 
     // Seed Decks first (required for cards)
     await seedTarotDecks(deckRepository);


### PR DESCRIPTION
This pull request introduces a comprehensive seeder for the six predefined tarot reading categories, ensuring each category is created with the correct attributes and that the process is idempotent. It adds robust unit tests to guarantee the integrity of the seeding logic and integrates the new seeder into the main database seeding workflow. Documentation has also been updated to reflect the completion of these tasks.

**Seeder implementation and data integrity:**

* Added `reading-categories.seeder.ts` to define and seed six categories, each with a unique name, slug, description, icon, color, order, and `isActive: true`. The seeder is idempotent and logs its process.
* Updated the main seeding script (`seed-data.ts`) to use the new `seedReadingCategories` function and inject the correct repository, ensuring categories are seeded before other data. [[1]](diffhunk://#diff-0ba2972e51dec7ef19ae505410abbbd4fc89504bf1e27db930f3789f2680886cR7-R11) [[2]](diffhunk://#diff-0ba2972e51dec7ef19ae505410abbbd4fc89504bf1e27db930f3789f2680886cR22-R30)

**Testing:**

* Added `reading-categories.seeder.spec.ts` with extensive unit tests to verify:
  - Exactly six categories are seeded
  - Idempotency (no duplicates on multiple runs)
  - All required fields (icon, color, description, order, isActive) are present and correct for each category
  - Each category's data matches the specification (name, slug, icon, color, order, etc.)
  - Uniqueness of `order` and `slug` fields
  - Logging of the seeding process

**Documentation:**

* Updated the project backlog to mark the seeder and its tests as complete, reflecting that all requirements for category seeding have been fulfilled. [[1]](diffhunk://#diff-de831616ab919523ea299377695f734c38e9100c5bbd7ea96c2eb8761cc61c06L1110-R1110) [[2]](diffhunk://#diff-de831616ab919523ea299377695f734c38e9100c5bbd7ea96c2eb8761cc61c06L1120-R1136)