### PR TITLE
feature/(TAREA 1.5): Crear badges de Plan y Status

### DIFF
--- a/frontend/docs/FRONTEND_BACKLOG.md
+++ b/frontend/docs/FRONTEND_BACKLOG.md
@@ -570,8 +570,9 @@ IMPORTANTE: Todos los componentes deben ser genéricos y reutilizables.
 
 ---
 
-### TAREA 1.5: Crear badges de Plan y Status
+### ✅ TAREA 1.5: Crear badges de Plan y Status
 
+**Estado:** ✅ COMPLETADA (2025-12-04)
 **Prioridad:** MEDIA
 **Estimación:** 25 min
 **Dependencias:** 1.1
@@ -579,34 +580,24 @@ IMPORTANTE: Todos los componentes deben ser genéricos y reutilizables.
 **Consigna:**
 Crear componentes Badge para mostrar planes de usuario y estados de sesiones según especificación del diseño.
 
-**Prompt:**
+**Resumen de Implementación:**
 
-```
-Crea dos componentes de badge personalizados:
+- **PlanBadge** (`src/components/ui/plan-badge.tsx`): Componente para mostrar planes de usuario (guest, free, premium, professional) con estilos específicos por plan. Texto en uppercase.
+- **StatusBadge** (`src/components/ui/status-badge.tsx`): Componente para mostrar estados de sesiones (pending, confirmed, completed, cancelled) con colores semánticos y texto traducido al español.
+- Tests con 100% coverage para ambos componentes
+- TDD estricto: tests escritos primero, luego implementación
 
-ARCHIVO 1: src/components/ui/plan-badge.tsx
-- Componente PlanBadge usando Badge de shadcn/ui
-- Props: plan: 'guest' | 'free' | 'premium' | 'professional'
-- Estilos por plan:
-  - guest/free: fondo gris (#F7FAFC), texto oscuro, sin borde
-  - premium: fondo amarillo pálido (#FEFCBF), texto dorado oscuro (#B7791F), borde dorado (#D69E2E)
-  - professional: fondo negro (#1A202C), texto blanco
-- Mostrar texto en uppercase: FREE, PREMIUM, etc.
+**Archivos creados:**
 
-ARCHIVO 2: src/components/ui/status-badge.tsx
-- Componente StatusBadge usando Badge de shadcn/ui
-- Props: status: 'pending' | 'confirmed' | 'completed' | 'cancelled'
-- Colores por estado:
-  - pending: amarillo (#ECC94B)
-  - confirmed: verde (#48BB78)
-  - completed: azul (#4299E1)
-  - cancelled: rojo (#F56565)
-- Mostrar texto traducido: Pendiente, Confirmada, Completada, Cancelada
+- `src/components/ui/plan-badge.tsx` - PlanBadge component
+- `src/components/ui/plan-badge.test.tsx` - 18 tests
+- `src/components/ui/status-badge.tsx` - StatusBadge component
+- `src/components/ui/status-badge.test.tsx` - 15 tests
 
-IMPORTANTE:
-- Usar Badge base de shadcn/ui y aplicar className con estilos custom
-- Usar función cn() de lib/utils para merge de clases
-```
+**Decisiones de diseño:**
+
+- StatusBadge usa texto blanco para todos los estados para mejor contraste/legibilidad sobre fondos de colores
+- Estilos aplicados via inline styles para colores específicos del design system, clases Tailwind para border-transparent
 
 ---
 

--- a/frontend/src/components/ui/plan-badge.test.tsx
+++ b/frontend/src/components/ui/plan-badge.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PlanBadge } from './plan-badge';
+
+describe('PlanBadge', () => {
+  describe('rendering', () => {
+    it('should render with guest plan', () => {
+      render(<PlanBadge plan="guest" />);
+
+      expect(screen.getByText('GUEST')).toBeInTheDocument();
+    });
+
+    it('should render with free plan', () => {
+      render(<PlanBadge plan="free" />);
+
+      expect(screen.getByText('FREE')).toBeInTheDocument();
+    });
+
+    it('should render with premium plan', () => {
+      render(<PlanBadge plan="premium" />);
+
+      expect(screen.getByText('PREMIUM')).toBeInTheDocument();
+    });
+
+    it('should render with professional plan', () => {
+      render(<PlanBadge plan="professional" />);
+
+      expect(screen.getByText('PROFESSIONAL')).toBeInTheDocument();
+    });
+  });
+
+  describe('styles by plan', () => {
+    describe('guest plan', () => {
+      it('should have gray background', () => {
+        render(<PlanBadge plan="guest" />);
+
+        const badge = screen.getByText('GUEST');
+        expect(badge).toHaveStyle({ backgroundColor: '#F7FAFC' });
+      });
+
+      it('should have dark text', () => {
+        render(<PlanBadge plan="guest" />);
+
+        const badge = screen.getByText('GUEST');
+        expect(badge).toHaveStyle({ color: '#1A202C' });
+      });
+
+      it('should not have border', () => {
+        render(<PlanBadge plan="guest" />);
+
+        const badge = screen.getByText('GUEST');
+        expect(badge).toHaveClass('border-transparent');
+      });
+    });
+
+    describe('free plan', () => {
+      it('should have gray background', () => {
+        render(<PlanBadge plan="free" />);
+
+        const badge = screen.getByText('FREE');
+        expect(badge).toHaveStyle({ backgroundColor: '#F7FAFC' });
+      });
+
+      it('should have dark text', () => {
+        render(<PlanBadge plan="free" />);
+
+        const badge = screen.getByText('FREE');
+        expect(badge).toHaveStyle({ color: '#1A202C' });
+      });
+
+      it('should not have border', () => {
+        render(<PlanBadge plan="free" />);
+
+        const badge = screen.getByText('FREE');
+        expect(badge).toHaveClass('border-transparent');
+      });
+    });
+
+    describe('premium plan', () => {
+      it('should have pale yellow background', () => {
+        render(<PlanBadge plan="premium" />);
+
+        const badge = screen.getByText('PREMIUM');
+        expect(badge).toHaveStyle({ backgroundColor: '#FEFCBF' });
+      });
+
+      it('should have dark golden text', () => {
+        render(<PlanBadge plan="premium" />);
+
+        const badge = screen.getByText('PREMIUM');
+        expect(badge).toHaveStyle({ color: '#B7791F' });
+      });
+
+      it('should have golden border', () => {
+        render(<PlanBadge plan="premium" />);
+
+        const badge = screen.getByText('PREMIUM');
+        expect(badge).toHaveStyle({ borderColor: '#D69E2E' });
+      });
+    });
+
+    describe('professional plan', () => {
+      it('should have black background', () => {
+        render(<PlanBadge plan="professional" />);
+
+        const badge = screen.getByText('PROFESSIONAL');
+        expect(badge).toHaveStyle({ backgroundColor: '#1A202C' });
+      });
+
+      it('should have white text', () => {
+        render(<PlanBadge plan="professional" />);
+
+        const badge = screen.getByText('PROFESSIONAL');
+        expect(badge).toHaveStyle({ color: '#FFFFFF' });
+      });
+    });
+  });
+
+  describe('text formatting', () => {
+    it('should display text in uppercase', () => {
+      render(<PlanBadge plan="free" />);
+
+      expect(screen.getByText('FREE')).toBeInTheDocument();
+      expect(screen.queryByText('free')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have data-slot attribute for badge', () => {
+      render(<PlanBadge plan="premium" />);
+
+      const badge = screen.getByText('PREMIUM');
+      expect(badge).toHaveAttribute('data-slot', 'badge');
+    });
+  });
+
+  describe('className prop', () => {
+    it('should accept and apply custom className', () => {
+      render(<PlanBadge plan="free" className="custom-class" />);
+
+      const badge = screen.getByText('FREE');
+      expect(badge).toHaveClass('custom-class');
+    });
+  });
+});

--- a/frontend/src/components/ui/plan-badge.tsx
+++ b/frontend/src/components/ui/plan-badge.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+/**
+ * Plan types for user subscription levels
+ */
+export type PlanType = 'guest' | 'free' | 'premium' | 'professional';
+
+export interface PlanBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /**
+   * The user's subscription plan type
+   */
+  plan: PlanType;
+}
+
+/**
+ * Style configurations for each plan type
+ */
+const planStyles: Record<PlanType, React.CSSProperties> = {
+  guest: {
+    backgroundColor: '#F7FAFC',
+    color: '#1A202C',
+  },
+  free: {
+    backgroundColor: '#F7FAFC',
+    color: '#1A202C',
+  },
+  premium: {
+    backgroundColor: '#FEFCBF',
+    color: '#B7791F',
+    borderColor: '#D69E2E',
+  },
+  professional: {
+    backgroundColor: '#1A202C',
+    color: '#FFFFFF',
+  },
+};
+
+/**
+ * Label mappings for each plan type (uppercase)
+ */
+const planLabels: Record<PlanType, string> = {
+  guest: 'GUEST',
+  free: 'FREE',
+  premium: 'PREMIUM',
+  professional: 'PROFESSIONAL',
+};
+
+/**
+ * PlanBadge - Displays user subscription plan as a styled badge
+ *
+ * @example
+ * ```tsx
+ * import { PlanBadge } from '@/components/ui/plan-badge';
+ *
+ * <PlanBadge plan="premium" />
+ * <PlanBadge plan="free" />
+ * <PlanBadge plan="professional" />
+ * ```
+ */
+export function PlanBadge({ plan, className, ...props }: PlanBadgeProps) {
+  const styles = planStyles[plan];
+  const label = planLabels[plan];
+
+  // guest and free have transparent border, premium has golden border
+  const hasBorder = plan === 'premium';
+
+  return (
+    <Badge
+      className={cn(hasBorder ? '' : 'border-transparent', className)}
+      style={styles}
+      {...props}
+    >
+      {label}
+    </Badge>
+  );
+}

--- a/frontend/src/components/ui/status-badge.test.tsx
+++ b/frontend/src/components/ui/status-badge.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { StatusBadge } from './status-badge';
+
+describe('StatusBadge', () => {
+  describe('rendering', () => {
+    it('should render with pending status', () => {
+      render(<StatusBadge status="pending" />);
+
+      expect(screen.getByText('Pendiente')).toBeInTheDocument();
+    });
+
+    it('should render with confirmed status', () => {
+      render(<StatusBadge status="confirmed" />);
+
+      expect(screen.getByText('Confirmada')).toBeInTheDocument();
+    });
+
+    it('should render with completed status', () => {
+      render(<StatusBadge status="completed" />);
+
+      expect(screen.getByText('Completada')).toBeInTheDocument();
+    });
+
+    it('should render with cancelled status', () => {
+      render(<StatusBadge status="cancelled" />);
+
+      expect(screen.getByText('Cancelada')).toBeInTheDocument();
+    });
+  });
+
+  describe('styles by status', () => {
+    describe('pending status', () => {
+      it('should have yellow background', () => {
+        render(<StatusBadge status="pending" />);
+
+        const badge = screen.getByText('Pendiente');
+        expect(badge).toHaveStyle({ backgroundColor: '#ECC94B' });
+      });
+    });
+
+    describe('confirmed status', () => {
+      it('should have green background', () => {
+        render(<StatusBadge status="confirmed" />);
+
+        const badge = screen.getByText('Confirmada');
+        expect(badge).toHaveStyle({ backgroundColor: '#48BB78' });
+      });
+    });
+
+    describe('completed status', () => {
+      it('should have blue background', () => {
+        render(<StatusBadge status="completed" />);
+
+        const badge = screen.getByText('Completada');
+        expect(badge).toHaveStyle({ backgroundColor: '#4299E1' });
+      });
+    });
+
+    describe('cancelled status', () => {
+      it('should have red background', () => {
+        render(<StatusBadge status="cancelled" />);
+
+        const badge = screen.getByText('Cancelada');
+        expect(badge).toHaveStyle({ backgroundColor: '#F56565' });
+      });
+    });
+  });
+
+  describe('text translations', () => {
+    it('should display "Pendiente" for pending status', () => {
+      render(<StatusBadge status="pending" />);
+
+      expect(screen.getByText('Pendiente')).toBeInTheDocument();
+    });
+
+    it('should display "Confirmada" for confirmed status', () => {
+      render(<StatusBadge status="confirmed" />);
+
+      expect(screen.getByText('Confirmada')).toBeInTheDocument();
+    });
+
+    it('should display "Completada" for completed status', () => {
+      render(<StatusBadge status="completed" />);
+
+      expect(screen.getByText('Completada')).toBeInTheDocument();
+    });
+
+    it('should display "Cancelada" for cancelled status', () => {
+      render(<StatusBadge status="cancelled" />);
+
+      expect(screen.getByText('Cancelada')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should have data-slot attribute for badge', () => {
+      render(<StatusBadge status="pending" />);
+
+      const badge = screen.getByText('Pendiente');
+      expect(badge).toHaveAttribute('data-slot', 'badge');
+    });
+  });
+
+  describe('className prop', () => {
+    it('should accept and apply custom className', () => {
+      render(<StatusBadge status="completed" className="custom-class" />);
+
+      const badge = screen.getByText('Completada');
+      expect(badge).toHaveClass('custom-class');
+    });
+  });
+
+  describe('text color contrast', () => {
+    it('should have white text for all statuses for readability', () => {
+      const statuses = ['pending', 'confirmed', 'completed', 'cancelled'] as const;
+      const labels = ['Pendiente', 'Confirmada', 'Completada', 'Cancelada'];
+
+      statuses.forEach((status, index) => {
+        const { unmount } = render(<StatusBadge status={status} />);
+        const badge = screen.getByText(labels[index]);
+        expect(badge).toHaveStyle({ color: '#FFFFFF' });
+        unmount();
+      });
+    });
+  });
+});

--- a/frontend/src/components/ui/status-badge.tsx
+++ b/frontend/src/components/ui/status-badge.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+/**
+ * Status types for session states
+ */
+export type StatusType = 'pending' | 'confirmed' | 'completed' | 'cancelled';
+
+export interface StatusBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /**
+   * The session status type
+   */
+  status: StatusType;
+}
+
+/**
+ * Style configurations for each status type
+ */
+const statusStyles: Record<StatusType, React.CSSProperties> = {
+  pending: {
+    backgroundColor: '#ECC94B',
+    color: '#FFFFFF',
+  },
+  confirmed: {
+    backgroundColor: '#48BB78',
+    color: '#FFFFFF',
+  },
+  completed: {
+    backgroundColor: '#4299E1',
+    color: '#FFFFFF',
+  },
+  cancelled: {
+    backgroundColor: '#F56565',
+    color: '#FFFFFF',
+  },
+};
+
+/**
+ * Label mappings for each status type (translated to Spanish)
+ */
+const statusLabels: Record<StatusType, string> = {
+  pending: 'Pendiente',
+  confirmed: 'Confirmada',
+  completed: 'Completada',
+  cancelled: 'Cancelada',
+};
+
+/**
+ * StatusBadge - Displays session status as a colored badge
+ *
+ * @example
+ * ```tsx
+ * import { StatusBadge } from '@/components/ui/status-badge';
+ *
+ * <StatusBadge status="pending" />
+ * <StatusBadge status="confirmed" />
+ * <StatusBadge status="completed" />
+ * <StatusBadge status="cancelled" />
+ * ```
+ */
+export function StatusBadge({ status, className, ...props }: StatusBadgeProps) {
+  const styles = statusStyles[status];
+  const label = statusLabels[status];
+
+  return (
+    <Badge className={cn('border-transparent', className)} style={styles} {...props}>
+      {label}
+    </Badge>
+  );
+}


### PR DESCRIPTION
This pull request implements two new reusable UI components, `PlanBadge` and `StatusBadge`, for displaying user plan types and session statuses with consistent styling, as well as comprehensive test suites for both. The badges use specific color schemes and text formats according to the design system, and all code is fully covered by tests. The implementation follows strict TDD and is documented for reusability.

**New badge components:**

- Added `PlanBadge` component (`src/components/ui/plan-badge.tsx`) for displaying user subscription plans with distinct styles for each plan (guest, free, premium, professional), using uppercase text and custom colors.
- Added `StatusBadge` component (`src/components/ui/status-badge.tsx`) for displaying session statuses (pending, confirmed, completed, cancelled) with semantic background colors and Spanish translations, ensuring white text for readability.

**Testing and quality:**

- Added comprehensive tests for `PlanBadge` (`src/components/ui/plan-badge.test.tsx`) covering rendering, styles, text formatting, accessibility, and custom className support, achieving 100% coverage.
- Added comprehensive tests for `StatusBadge` (`src/components/ui/status-badge.test.tsx`) covering rendering, color schemes, translations, accessibility, and contrast, achieving 100% coverage.

**Documentation and backlog update:**

- Updated the project backlog to mark the badge components task as complete, summarized implementation details, design decisions, and listed new files.