### PR TITLE
feature/(TAREA 7.3): Crear página Explorar Tarotistas

### DIFF
--- a/frontend/docs/FRONTEND_BACKLOG.md
+++ b/frontend/docs/FRONTEND_BACKLOG.md
@@ -2186,16 +2186,61 @@ IMPORTANTE:
 
 ---
 
-### TAREA 7.3: Crear página Explorar Tarotistas
+### ✅ TAREA 7.3: Crear página Explorar Tarotistas
 
 **Prioridad:** ALTA
 **Estimación:** 55 min
 **Dependencias:** 7.2, 7.1
+**Estado:** ✅ COMPLETADA (11 Dic 2025)
 
 **Consigna:**
 Crear marketplace con grid de tarotistas, filtros y búsqueda.
 
-**Prompt:**
+**Implementación realizada:**
+
+✅ **Componente TarotistasExplorer creado** (`components/features/marketplace/TarotistasExplorer.tsx`):
+
+- Header con título y subtítulo
+- Filtros de búsqueda con debounce (300ms)
+- Chips de especialidades clicables
+- Grid responsive (1/2/3 columnas)
+- Loading skeletons
+- Empty state con "Limpiar filtros"
+
+✅ **Página Explorar** (`app/explorar/page.tsx`):
+
+- Delega toda la lógica al componente TarotistasExplorer
+- Solo maneja navegación a perfil de tarotista
+
+✅ **Tests completos** (17 tests pasando):
+
+- Header y subtítulos
+- Filtros de búsqueda y especialidades
+- Grid responsive
+- Loading states
+- Empty states
+- Navegación
+
+✅ **Dependencia instalada:**
+
+- `use-debounce` para debounce en búsqueda
+
+✅ **Arquitectura:**
+
+- Lógica extraída a feature component (sin lógica en app/)
+- Nomenclatura correcta
+- Coverage > 80%
+- Build exitoso
+
+**Archivos creados/modificados:**
+
+- `src/components/features/marketplace/TarotistasExplorer.tsx` (nuevo)
+- `src/components/features/marketplace/index.ts` (actualizado)
+- `src/app/explorar/page.tsx` (refactorizado)
+- `src/app/explorar/page.test.tsx` (actualizado)
+- `package.json` (dependencia use-debounce)
+
+**Prompt original:**
 
 ```
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "react-markdown": "^10.1.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
+    "use-debounce": "^10.0.6",
     "zod": "^3.25.76",
     "zustand": "^5.0.9"
   },

--- a/frontend/src/app/explorar/page.test.tsx
+++ b/frontend/src/app/explorar/page.test.tsx
@@ -1,32 +1,415 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import ExplorarPage from './page';
+import type { Tarotista } from '@/types';
+
+// Mock Next.js router
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+}));
+
+// Mock useTarotistas hook
+vi.mock('@/hooks/api/useTarotistas', () => ({
+  useTarotistas: vi.fn(),
+}));
+
+const mockTarotistas: Tarotista[] = [
+  {
+    id: 1,
+    nombrePublico: 'Luna Mística',
+    bio: 'Experta en lecturas de amor con más de 10 años de experiencia',
+    especialidades: ['Amor', 'Espiritual'],
+    fotoPerfil: 'https://example.com/photo1.jpg',
+    ratingPromedio: 4.8,
+    totalLecturas: 150,
+    totalReviews: 80,
+    añosExperiencia: 10,
+    idiomas: ['Español', 'Inglés'],
+    createdAt: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    nombrePublico: 'Sol Radiante',
+    bio: 'Especialista en temas de dinero y carrera profesional',
+    especialidades: ['Dinero', 'Carrera'],
+    fotoPerfil: 'https://example.com/photo2.jpg',
+    ratingPromedio: 4.5,
+    totalLecturas: 120,
+    totalReviews: 60,
+    añosExperiencia: 8,
+    idiomas: ['Español'],
+    createdAt: '2024-01-15T00:00:00Z',
+  },
+  {
+    id: 3,
+    nombrePublico: 'Estrella Guía',
+    bio: 'Guía espiritual con amplia experiencia en salud y bienestar',
+    especialidades: ['Salud', 'Espiritual'],
+    fotoPerfil: 'https://example.com/photo3.jpg',
+    ratingPromedio: 4.9,
+    totalLecturas: 200,
+    totalReviews: 100,
+    añosExperiencia: 15,
+    idiomas: ['Español', 'Portugués'],
+    createdAt: '2023-12-01T00:00:00Z',
+  },
+];
+
+// Helper to create a fresh QueryClient for each test
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}
+
+// Wrapper component with providers
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = createTestQueryClient();
+
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
 
 describe('ExplorarPage', () => {
-  it('should render explorar page with correct title', () => {
-    render(<ExplorarPage />);
+  const mockPush = vi.fn();
 
-    expect(screen.getByRole('heading', { level: 1, name: /explorar/i })).toBeInTheDocument();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useRouter as ReturnType<typeof vi.fn>).mockReturnValue({
+      push: mockPush,
+    });
   });
 
-  it('should have min-h-screen class', () => {
-    const { container } = render(<ExplorarPage />);
+  describe('Header Section', () => {
+    it('should display main title "Nuestros Guías Espirituales"', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
 
-    const mainDiv = container.firstChild as HTMLElement;
-    expect(mainDiv).toHaveClass('min-h-screen');
+      renderWithProviders(<ExplorarPage />);
+
+      expect(screen.getByText('Nuestros Guías Espirituales')).toBeInTheDocument();
+    });
+
+    it('should display subtitle "Encuentra al mentor ideal para tu camino"', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<ExplorarPage />);
+
+      expect(screen.getByText('Encuentra al mentor ideal para tu camino')).toBeInTheDocument();
+    });
+
+    it('should use font-serif for main title', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<ExplorarPage />);
+
+      const title = screen.getByText('Nuestros Guías Espirituales');
+      expect(title.className).toContain('font-serif');
+    });
   });
 
-  it('should have bg-bg-main class', () => {
-    const { container } = render(<ExplorarPage />);
+  describe('Filters Section', () => {
+    it('should display search input with placeholder', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
 
-    const mainDiv = container.firstChild as HTMLElement;
-    expect(mainDiv).toHaveClass('bg-bg-main');
+      renderWithProviders(<ExplorarPage />);
+
+      const searchInput = screen.getByPlaceholderText(/buscar/i);
+      expect(searchInput).toBeInTheDocument();
+    });
+
+    it('should display all specialty filter chips', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<ExplorarPage />);
+
+      const filterButtons = screen.getAllByRole('button');
+      const filterTexts = filterButtons.map((btn) => btn.textContent);
+
+      expect(filterTexts).toContain('Todos');
+      expect(filterTexts).toContain('Amor');
+      expect(filterTexts).toContain('Dinero');
+      expect(filterTexts).toContain('Carrera');
+      expect(filterTexts).toContain('Salud');
+      expect(filterTexts).toContain('Espiritual');
+    });
+
+    it('should highlight "Todos" chip as selected by default', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<ExplorarPage />);
+
+      const todosChip = screen.getByText('Todos');
+      expect(todosChip.className).toContain('bg-primary');
+    });
+
+    it('should change selected chip when clicking on specialty', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<ExplorarPage />);
+
+      const filterButtons = screen.getAllByRole('button');
+      const amorChip = filterButtons.find((btn) => btn.textContent === 'Amor');
+
+      if (!amorChip) throw new Error('Amor chip not found');
+
+      fireEvent.click(amorChip);
+
+      await waitFor(() => {
+        expect(amorChip.className).toContain('bg-primary');
+      });
+    });
   });
 
-  it('should have font-serif class on heading', () => {
-    render(<ExplorarPage />);
+  describe('Tarotistas Grid', () => {
+    it('should display loading skeletons while fetching data', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      });
 
-    const heading = screen.getByRole('heading', { level: 1 });
-    expect(heading).toHaveClass('font-serif');
+      renderWithProviders(<ExplorarPage />);
+
+      const skeletons = screen.getAllByTestId('skeleton-tarotist-photo');
+      expect(skeletons.length).toBeGreaterThan(0);
+    });
+
+    it('should display tarotista cards after loading', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<ExplorarPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Luna Mística')).toBeInTheDocument();
+        expect(screen.getByText('Sol Radiante')).toBeInTheDocument();
+        expect(screen.getByText('Estrella Guía')).toBeInTheDocument();
+      });
+    });
+
+    it('should use responsive grid layout', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
+
+      const { container } = renderWithProviders(<ExplorarPage />);
+
+      const grid = container.querySelector('.grid');
+      expect(grid?.className).toContain('grid-cols-1');
+      expect(grid?.className).toContain('md:grid-cols-2');
+      expect(grid?.className).toContain('lg:grid-cols-3');
+    });
+
+    it('should navigate to tarotista detail page when clicking on card', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<ExplorarPage />);
+
+      await waitFor(() => {
+        const verPerfilButtons = screen.getAllByText('Ver Perfil');
+        fireEvent.click(verPerfilButtons[0]);
+
+        expect(mockPush).toHaveBeenCalledWith('/tarotistas/1');
+      });
+    });
+  });
+
+  describe('Empty State', () => {
+    it('should display empty state when no tarotistas match filters', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: [], total: 0, page: 1, limit: 10, totalPages: 0 },
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<ExplorarPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('No encontramos guías con ese criterio')).toBeInTheDocument();
+      });
+    });
+
+    it('should display "Limpiar filtros" button in empty state', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: [], total: 0, page: 1, limit: 10, totalPages: 0 },
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<ExplorarPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Limpiar filtros')).toBeInTheDocument();
+      });
+    });
+
+    it('should clear filters when clicking "Limpiar filtros" button', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      (useTarotistas as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { data: [], total: 0, page: 1, limit: 10, totalPages: 0 },
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<ExplorarPage />);
+
+      await waitFor(() => {
+        const clearButton = screen.getByText('Limpiar filtros');
+        fireEvent.click(clearButton);
+
+        // Should reset to "Todos" specialty
+        const todosChip = screen.getByText('Todos');
+        expect(todosChip.className).toContain('bg-primary');
+      });
+    });
+  });
+
+  describe('Search Functionality', () => {
+    it('should filter tarotistas by search term (debounced)', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      const mockUseTarotistas = vi.fn().mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
+
+      (useTarotistas as ReturnType<typeof vi.fn>).mockImplementation(mockUseTarotistas);
+
+      renderWithProviders(<ExplorarPage />);
+
+      const searchInput = screen.getByPlaceholderText(/buscar/i);
+      fireEvent.change(searchInput, { target: { value: 'Luna' } });
+
+      // Wait for debounce (300ms)
+      await waitFor(
+        () => {
+          expect(mockUseTarotistas).toHaveBeenCalledWith(
+            expect.objectContaining({ search: 'Luna' })
+          );
+        },
+        { timeout: 500 }
+      );
+    });
+  });
+
+  describe('Specialty Filter Functionality', () => {
+    it('should filter tarotistas by selected specialty', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      const mockUseTarotistas = vi.fn().mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
+
+      (useTarotistas as ReturnType<typeof vi.fn>).mockImplementation(mockUseTarotistas);
+
+      renderWithProviders(<ExplorarPage />);
+
+      const filterButtons = screen.getAllByRole('button');
+      const amorChip = filterButtons.find((btn) => btn.textContent === 'Amor');
+
+      if (!amorChip) throw new Error('Amor chip not found');
+
+      fireEvent.click(amorChip);
+
+      await waitFor(() => {
+        expect(mockUseTarotistas).toHaveBeenCalledWith(
+          expect.objectContaining({ especialidad: 'Amor' })
+        );
+      });
+    });
+
+    it('should show all tarotistas when "Todos" is selected', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      const mockUseTarotistas = vi.fn().mockReturnValue({
+        data: { data: mockTarotistas, total: 3, page: 1, limit: 10, totalPages: 1 },
+        isLoading: false,
+        error: null,
+      });
+
+      (useTarotistas as ReturnType<typeof vi.fn>).mockImplementation(mockUseTarotistas);
+
+      renderWithProviders(<ExplorarPage />);
+
+      // Select a specialty first
+      const filterButtons = screen.getAllByRole('button');
+      const amorChip = filterButtons.find((btn) => btn.textContent === 'Amor');
+
+      if (!amorChip) throw new Error('Amor chip not found');
+
+      fireEvent.click(amorChip);
+
+      await waitFor(() => {
+        expect(mockUseTarotistas).toHaveBeenCalledWith(
+          expect.objectContaining({ especialidad: 'Amor' })
+        );
+      });
+
+      // Then click "Todos"
+      const todosChip = filterButtons.find((btn) => btn.textContent === 'Todos');
+
+      if (!todosChip) throw new Error('Todos chip not found');
+
+      fireEvent.click(todosChip);
+
+      await waitFor(() => {
+        expect(mockUseTarotistas).toHaveBeenCalledWith(expect.objectContaining({}));
+      });
+    });
   });
 });

--- a/frontend/src/app/explorar/page.tsx
+++ b/frontend/src/app/explorar/page.tsx
@@ -1,7 +1,24 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { TarotistasExplorer } from '@/components/features/marketplace';
+
+/**
+ * Explorar Page - Tarotistas Marketplace
+ *
+ * Public page that displays the marketplace of tarotistas.
+ * All business logic is delegated to TarotistasExplorer component.
+ */
 export default function ExplorarPage() {
+  const router = useRouter();
+
+  const handleViewProfile = (id: number) => {
+    router.push(`/tarotistas/${id}`);
+  };
+
   return (
     <div className="bg-bg-main min-h-screen p-8">
-      <h1 className="font-serif text-3xl">Explorar</h1>
+      <TarotistasExplorer onViewProfile={handleViewProfile} />
     </div>
   );
 }

--- a/frontend/src/components/features/marketplace/TarotistasExplorer.tsx
+++ b/frontend/src/components/features/marketplace/TarotistasExplorer.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState } from 'react';
+import { Search } from 'lucide-react';
+import { useDebounce } from 'use-debounce';
+import { useTarotistas } from '@/hooks/api/useTarotistas';
+import { TarotistaCard } from './TarotistaCard';
+import { SkeletonCard } from '@/components/ui/skeleton-card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+const SPECIALTIES = ['Todos', 'Amor', 'Dinero', 'Carrera', 'Salud', 'Espiritual'] as const;
+
+/**
+ * TarotistasExplorer Component Props
+ */
+export interface TarotistasExplorerProps {
+  /** Callback when a tarotista profile is clicked */
+  onViewProfile: (id: number) => void;
+}
+
+/**
+ * TarotistasExplorer Component
+ *
+ * Marketplace explorer with filters, search, and grid of tarotistas.
+ *
+ * Features:
+ * - Search input with debounce (300ms)
+ * - Specialty filter chips
+ * - Responsive grid (1/2/3 columns)
+ * - Loading skeleton states
+ * - Empty state with clear filters action
+ */
+export function TarotistasExplorer({ onViewProfile }: TarotistasExplorerProps) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedSpecialty, setSelectedSpecialty] = useState<string>('Todos');
+
+  // Debounce search term (300ms)
+  const [debouncedSearch] = useDebounce(searchTerm, 300);
+
+  // Build filters for API
+  const filters = {
+    search: debouncedSearch || undefined,
+    especialidad: selectedSpecialty !== 'Todos' ? selectedSpecialty : undefined,
+  };
+
+  // Fetch tarotistas with filters
+  const { data, isLoading } = useTarotistas(filters);
+
+  const handleClearFilters = () => {
+    setSearchTerm('');
+    setSelectedSpecialty('Todos');
+  };
+
+  const tarotistas = data?.data || [];
+  const isEmpty = !isLoading && tarotistas.length === 0;
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <header className="text-center">
+        <h1 className="mb-2 font-serif text-4xl font-bold text-gray-800">
+          Nuestros Guías Espirituales
+        </h1>
+        <p className="text-lg text-gray-600">Encuentra al mentor ideal para tu camino</p>
+      </header>
+
+      {/* Filters */}
+      <div className="space-y-4">
+        {/* Search Input */}
+        <div className="relative mx-auto max-w-md">
+          <Search className="absolute top-1/2 left-3 h-5 w-5 -translate-y-1/2 text-gray-400" />
+          <Input
+            type="text"
+            placeholder="Buscar guía espiritual..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="pl-10"
+          />
+        </div>
+
+        {/* Specialty Chips */}
+        <div className="flex flex-wrap justify-center gap-2">
+          {SPECIALTIES.map((specialty) => {
+            const isSelected = selectedSpecialty === specialty;
+            return (
+              <button
+                key={specialty}
+                onClick={() => setSelectedSpecialty(specialty)}
+                className={cn(
+                  'rounded-full px-4 py-2 text-sm font-medium transition-colors',
+                  isSelected
+                    ? 'bg-primary text-white'
+                    : 'hover:border-primary hover:text-primary border border-gray-300 text-gray-700'
+                )}
+              >
+                {specialty}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Loading State */}
+      {isLoading && (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <SkeletonCard key={i} variant="tarotist" />
+          ))}
+        </div>
+      )}
+
+      {/* Empty State */}
+      {isEmpty && (
+        <div className="flex flex-col items-center justify-center px-4 py-16">
+          <Search className="mb-4 h-16 w-16 text-gray-300" />
+          <p className="mb-4 text-lg text-gray-600">No encontramos guías con ese criterio</p>
+          <Button onClick={handleClearFilters} variant="outline">
+            Limpiar filtros
+          </Button>
+        </div>
+      )}
+
+      {/* Tarotistas Grid */}
+      {!isLoading && !isEmpty && (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {tarotistas.map((tarotista) => (
+            <TarotistaCard key={tarotista.id} tarotista={tarotista} onViewProfile={onViewProfile} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/features/marketplace/index.ts
+++ b/frontend/src/components/features/marketplace/index.ts
@@ -6,3 +6,6 @@
 
 export { TarotistaCard } from './TarotistaCard';
 export type { TarotistaCardProps } from './TarotistaCard';
+
+export { TarotistasExplorer } from './TarotistasExplorer';
+export type { TarotistasExplorerProps } from './TarotistasExplorer';

--- a/package-lock.json
+++ b/package-lock.json
@@ -6106,6 +6106,7 @@
         "react-markdown": "^10.1.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
+        "use-debounce": "^10.0.6",
         "zod": "^3.25.76",
         "zustand": "^5.0.9"
       },
@@ -24136,6 +24137,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.6.tgz",
+      "integrity": "sha512-C5OtPyhAZgVoteO9heXMTdW7v/IbFI+8bSVKYCJrSmiWWCLsbUxiBSp4t9v0hNBTGY97bT72ydDIDyGSFWfwXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/use-sidecar": {


### PR DESCRIPTION
This pull request completes the implementation of the "Explorar Tarotistas" marketplace page in the frontend. The main change is the addition of a fully-featured `TarotistasExplorer` component, which handles all business logic, including search, filtering, responsive grid display, loading/empty states, and navigation. Supporting changes include a refactor of the page to delegate logic, addition of tests, and installation of the `use-debounce` dependency.

**Marketplace page implementation:**

* Added the new `TarotistasExplorer` component in `components/features/marketplace/TarotistasExplorer.tsx`, featuring a search input with debounce, specialty filter chips, responsive grid, loading skeletons, and empty state handling.
* Refactored `app/explorar/page.tsx` to delegate all logic to `TarotistasExplorer` and handle navigation to tarotista profiles.

**Testing and architecture:**

* Implemented comprehensive tests (17 passing) for header, filters, grid, loading, empty states, and navigation; ensured coverage > 80% and successful build.

**Dependencies and exports:**

* Added `use-debounce` to `package.json` for debounced search functionality.
* Updated `components/features/marketplace/index.ts` to export the new component and its props type.