### PR TITLE
feature/(TAREA 9.5): Crear página Mis Sesiones

### DIFF
--- a/frontend/docs/FRONTEND_BACKLOG.md
+++ b/frontend/docs/FRONTEND_BACKLOG.md
@@ -2907,11 +2907,73 @@ IMPORTANTE:
 
 ---
 
-### TAREA 9.5: Crear página Mis Sesiones
+### TAREA 9.5: Crear página Mis Sesiones ✅
 
 **Prioridad:** ALTA
 **Estimación:** 40 min
 **Dependencias:** 9.4, 9.1
+**Estado:** COMPLETADO
+**Fecha de completado:** 13 Diciembre 2025
+
+**Archivos creados/modificados:**
+
+- ✅ `src/app/sesiones/page.tsx` - Página con useRequireAuth y delegación a SessionsList
+- ✅ `src/app/sesiones/page.test.tsx` - Tests completos de la página
+- ✅ `src/components/features/marketplace/SessionsList.tsx` - Componente principal con tabs y filtros
+- ✅ `src/components/features/marketplace/SessionsList.test.tsx` - Tests completos del componente (16 tests)
+- ✅ `src/components/ui/alert-dialog.tsx` - Componente de shadcn para modal de confirmación
+
+**Implementación realizada:**
+
+1. **Página principal** (`src/app/sesiones/page.tsx`):
+   - Client component con `useRequireAuth()`
+   - Loading state durante autenticación
+   - Delegación completa de lógica a `SessionsList`
+
+2. **Componente SessionsList**:
+   - Sistema de tabs para filtrar sesiones:
+     - "Próximas": filtra `pending` y `confirmed`
+     - "Completadas": filtra `completed`
+     - "Canceladas": filtra `cancelled_by_user` y `cancelled_by_tarotist`
+     - "Todas": muestra todas las sesiones
+   - Ordenamiento por fecha ascendente (próximas primero)
+   - Estados de carga con Skeleton
+   - Empty states personalizados por tab
+   - Modal de confirmación para cancelación de sesiones
+   - Integración con `useMySessions()` y `useCancelSession()`
+
+3. **Acciones implementadas**:
+   - **Cancelar**: Modal de confirmación → llamada a `useCancelSession` con reason
+   - **Unirse**: Abre Google Meet en nueva pestaña con `window.open(meetLink, '_blank')`
+   - Reutilización de `SessionCard` existente con callbacks
+
+4. **Coverage de tests**:
+   - 16 tests para SessionsList cubriendo:
+     - Renderizado de tabs
+     - Switching entre tabs
+     - Estados de carga y error
+     - Filtrado por cada tab
+     - Empty states
+     - Acciones de join y cancel
+     - Ordenamiento por fecha
+   - 6 tests para la página
+   - **Coverage total: 90.35%** (superior al 80% requerido)
+
+**Decisiones técnicas:**
+
+- Filtrado client-side en lugar de server-side para mejor UX (evita re-fetching)
+- Uso de `userEvent` en tests en lugar de `fireEvent` para interacciones más realistas con tabs
+- Componente alert-dialog instalado desde shadcn/ui para modal de confirmación
+- Reutilización máxima de SessionCard existente
+
+**Validaciones pasadas:**
+
+- ✅ Lint: 0 errores, 0 warnings
+- ✅ Type-check: sin errores
+- ✅ Build: exitoso
+- ✅ Arquitectura: validación exitosa
+- ✅ Tests: 1073 tests pasando
+- ✅ Coverage: 90.35% (>80%)
 
 **Consigna:**
 Crear lista de sesiones del usuario con filtros por estado.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/src/app/sesiones/page.test.tsx
+++ b/frontend/src/app/sesiones/page.test.tsx
@@ -1,8 +1,23 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import SesionesPage from './page';
 
+// Mock useRequireAuth
+const mockUseRequireAuth = vi.fn(() => ({ isLoading: false }));
+vi.mock('@/hooks/useRequireAuth', () => ({
+  useRequireAuth: () => mockUseRequireAuth(),
+}));
+
+// Mock SessionsList component
+vi.mock('@/components/features/marketplace/SessionsList', () => ({
+  SessionsList: vi.fn(() => <div data-testid="sessions-list">SessionsList Component</div>),
+}));
+
 describe('SesionesPage', () => {
+  beforeEach(() => {
+    mockUseRequireAuth.mockReturnValue({ isLoading: false });
+  });
+
   it('should render sesiones page with correct title', () => {
     render(<SesionesPage />);
 
@@ -28,5 +43,19 @@ describe('SesionesPage', () => {
 
     const heading = screen.getByRole('heading', { level: 1 });
     expect(heading).toHaveClass('font-serif');
+  });
+
+  it('should render SessionsList component', () => {
+    render(<SesionesPage />);
+
+    expect(screen.getByTestId('sessions-list')).toBeInTheDocument();
+  });
+
+  it('should show loading state when auth is loading', () => {
+    mockUseRequireAuth.mockReturnValueOnce({ isLoading: true });
+
+    render(<SesionesPage />);
+
+    expect(screen.getByTestId('auth-loading')).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/sesiones/page.tsx
+++ b/frontend/src/app/sesiones/page.tsx
@@ -1,7 +1,35 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+
+import { useRequireAuth } from '@/hooks/useRequireAuth';
+import { SessionsList } from '@/components/features/marketplace/SessionsList';
+
+/**
+ * Sesiones Page - My Sessions
+ *
+ * Protected page that displays user's session reservations with filters.
+ * All business logic is delegated to SessionsList component.
+ */
 export default function SesionesPage() {
+  const { isLoading: isAuthLoading } = useRequireAuth();
+
+  // Show auth loading state
+  if (isAuthLoading) {
+    return (
+      <div
+        data-testid="auth-loading"
+        className="bg-bg-main flex min-h-screen items-center justify-center"
+      >
+        <Loader2 className="text-primary h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
   return (
-    <div className="bg-bg-main min-h-screen p-8">
-      <h1 className="font-serif text-3xl">Mis Sesiones</h1>
+    <div className="bg-bg-main min-h-screen px-4 py-8 md:px-8">
+      <h1 className="mb-8 font-serif text-3xl">Mis Sesiones</h1>
+      <SessionsList />
     </div>
   );
 }

--- a/frontend/src/components/features/marketplace/SessionsList.test.tsx
+++ b/frontend/src/components/features/marketplace/SessionsList.test.tsx
@@ -1,0 +1,405 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SessionsList } from './SessionsList';
+import type { SessionDetail } from '@/types/session.types';
+
+// Mock hooks
+const mockUseMySessions = vi.fn();
+const mockMutate = vi.fn();
+const mockUseCancelSession = vi.fn(() => ({
+  mutate: mockMutate,
+  isPending: false,
+}));
+
+vi.mock('@/hooks/api/useSessions', () => ({
+  useMySessions: () => mockUseMySessions(),
+  useCancelSession: () => mockUseCancelSession(),
+}));
+
+// Mock SessionCard
+vi.mock('./SessionCard', () => ({
+  SessionCard: ({
+    session,
+    onCancel,
+    onJoin,
+  }: {
+    session: SessionDetail;
+    onCancel?: (id: number) => void;
+    onJoin?: (link: string) => void;
+  }) => (
+    <div data-testid={`session-card-${session.id}`}>
+      <span>{session.sessionDate}</span>
+      <span>{session.status}</span>
+      {onCancel && <button onClick={() => onCancel(session.id)}>Cancelar</button>}
+      {onJoin && <button onClick={() => onJoin(session.googleMeetLink)}>Unirse</button>}
+    </div>
+  ),
+}));
+
+const createMockSession = (overrides: Partial<SessionDetail> = {}): SessionDetail => ({
+  id: 1,
+  tarotistaId: 1,
+  userId: 1,
+  sessionDate: '2025-12-15',
+  sessionTime: '10:00',
+  durationMinutes: 60,
+  sessionType: 'TAROT_READING',
+  status: 'pending',
+  priceUsd: 50,
+  paymentStatus: 'PENDING',
+  googleMeetLink: 'https://meet.google.com/abc-def-ghi',
+  userEmail: 'user@example.com',
+  createdAt: '2025-12-13',
+  updatedAt: '2025-12-13',
+  tarotista: {
+    id: 1,
+    nombre: 'Flavia',
+    foto: 'https://example.com/photo.jpg',
+  },
+  ...overrides,
+});
+
+describe('SessionsList', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.clearAllMocks();
+    mockUseMySessions.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  describe('Tabs Rendering', () => {
+    it('should render all tab triggers', () => {
+      mockUseMySessions.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+      });
+
+      render(<SessionsList />, { wrapper });
+
+      expect(screen.getByRole('tab', { name: /próximas/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /completadas/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /canceladas/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /todas/i })).toBeInTheDocument();
+    });
+
+    it('should switch between tabs when clicked', async () => {
+      mockUseMySessions.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+      });
+
+      const user = userEvent.setup();
+      render(<SessionsList />, { wrapper });
+
+      const completadasTab = screen.getByRole('tab', { name: /completadas/i });
+      await user.click(completadasTab);
+
+      await waitFor(() => {
+        expect(completadasTab).toHaveAttribute('data-state', 'active');
+      });
+    });
+  });
+
+  describe('Data Fetching', () => {
+    it('should show loading state initially', () => {
+      mockUseMySessions.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      });
+
+      render(<SessionsList />, { wrapper });
+
+      expect(screen.getAllByTestId(/skeleton/).length).toBeGreaterThan(0);
+    });
+
+    it('should fetch all sessions by default (Próximas tab)', () => {
+      mockUseMySessions.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+      });
+
+      render(<SessionsList />, { wrapper });
+
+      expect(mockUseMySessions).toHaveBeenCalled();
+    });
+  });
+
+  describe('Session List Rendering', () => {
+    it('should render sessions in date order (upcoming first)', () => {
+      const sessions = [
+        createMockSession({ id: 1, sessionDate: '2025-12-20', status: 'confirmed' }),
+        createMockSession({ id: 2, sessionDate: '2025-12-15', status: 'pending' }),
+        createMockSession({ id: 3, sessionDate: '2025-12-25', status: 'confirmed' }),
+      ];
+
+      mockUseMySessions.mockReturnValue({
+        data: sessions,
+        isLoading: false,
+        error: null,
+      });
+
+      render(<SessionsList />, { wrapper });
+
+      const cards = screen.getAllByTestId(/session-card/);
+      expect(cards).toHaveLength(3);
+      // Should be ordered by date ascending
+      expect(cards[0]).toHaveAttribute('data-testid', 'session-card-2');
+      expect(cards[1]).toHaveAttribute('data-testid', 'session-card-1');
+      expect(cards[2]).toHaveAttribute('data-testid', 'session-card-3');
+    });
+
+    it('should pass correct props to SessionCard', () => {
+      const session = createMockSession();
+
+      mockUseMySessions.mockReturnValue({
+        data: [session],
+        isLoading: false,
+        error: null,
+      });
+
+      render(<SessionsList />, { wrapper });
+
+      // Verify card is rendered with session data
+      expect(screen.getByTestId(`session-card-${session.id}`)).toBeInTheDocument();
+    });
+  });
+
+  describe('Filtering by Tab', () => {
+    it('should filter pending and confirmed sessions in "Próximas" tab', () => {
+      const sessions = [
+        createMockSession({ id: 1, status: 'pending' }),
+        createMockSession({ id: 2, status: 'confirmed' }),
+        createMockSession({ id: 3, status: 'completed' }),
+        createMockSession({ id: 4, status: 'cancelled_by_user' }),
+      ];
+
+      mockUseMySessions.mockReturnValue({
+        data: sessions,
+        isLoading: false,
+        error: null,
+      });
+
+      render(<SessionsList />, { wrapper });
+
+      // Default tab is "Próximas" - should show only pending and confirmed
+      expect(screen.getByTestId('session-card-1')).toBeInTheDocument();
+      expect(screen.getByTestId('session-card-2')).toBeInTheDocument();
+      expect(screen.queryByTestId('session-card-3')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('session-card-4')).not.toBeInTheDocument();
+    });
+
+    it('should filter completed sessions in "Completadas" tab', async () => {
+      const sessions = [
+        createMockSession({ id: 1, status: 'pending' }),
+        createMockSession({ id: 2, status: 'completed' }),
+        createMockSession({ id: 3, status: 'completed' }),
+      ];
+
+      mockUseMySessions.mockReturnValue({
+        data: sessions,
+        isLoading: false,
+        error: null,
+      });
+
+      const user = userEvent.setup();
+      render(<SessionsList />, { wrapper });
+
+      await user.click(screen.getByRole('tab', { name: /completadas/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('session-card-2')).toBeInTheDocument();
+        expect(screen.getByTestId('session-card-3')).toBeInTheDocument();
+        expect(screen.queryByTestId('session-card-1')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should filter cancelled sessions in "Canceladas" tab', async () => {
+      const sessions = [
+        createMockSession({ id: 1, status: 'pending' }),
+        createMockSession({ id: 2, status: 'cancelled_by_user' }),
+        createMockSession({ id: 3, status: 'cancelled_by_tarotist' }),
+      ];
+
+      mockUseMySessions.mockReturnValue({
+        data: sessions,
+        isLoading: false,
+        error: null,
+      });
+
+      const user = userEvent.setup();
+      render(<SessionsList />, { wrapper });
+
+      await user.click(screen.getByRole('tab', { name: /canceladas/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('session-card-2')).toBeInTheDocument();
+        expect(screen.getByTestId('session-card-3')).toBeInTheDocument();
+        expect(screen.queryByTestId('session-card-1')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should show all sessions in "Todas" tab', async () => {
+      const sessions = [
+        createMockSession({ id: 1, status: 'pending' }),
+        createMockSession({ id: 2, status: 'completed' }),
+        createMockSession({ id: 3, status: 'cancelled_by_user' }),
+      ];
+
+      mockUseMySessions.mockReturnValue({
+        data: sessions,
+        isLoading: false,
+        error: null,
+      });
+
+      const user = userEvent.setup();
+      render(<SessionsList />, { wrapper });
+
+      await user.click(screen.getByRole('tab', { name: /todas/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('session-card-1')).toBeInTheDocument();
+        expect(screen.getByTestId('session-card-2')).toBeInTheDocument();
+        expect(screen.getByTestId('session-card-3')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Empty States', () => {
+    it('should show empty state for "Próximas" tab when no upcoming sessions', () => {
+      mockUseMySessions.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+      });
+
+      render(<SessionsList />, { wrapper });
+
+      expect(screen.getByText(/no tienes sesiones programadas/i)).toBeInTheDocument();
+    });
+
+    it('should show empty state for "Completadas" tab', async () => {
+      mockUseMySessions.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+      });
+
+      const user = userEvent.setup();
+      render(<SessionsList />, { wrapper });
+
+      await user.click(screen.getByRole('tab', { name: /completadas/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/aún no has tenido sesiones/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show empty state for "Canceladas" tab', async () => {
+      mockUseMySessions.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+      });
+
+      const user = userEvent.setup();
+      render(<SessionsList />, { wrapper });
+
+      await user.click(screen.getByRole('tab', { name: /canceladas/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/no tienes sesiones canceladas/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Actions', () => {
+    it('should call onJoin with meet link when join button clicked', async () => {
+      const session = createMockSession({
+        status: 'confirmed',
+        googleMeetLink: 'https://meet.google.com/test',
+      });
+
+      mockUseMySessions.mockReturnValue({
+        data: [session],
+        isLoading: false,
+        error: null,
+      });
+
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      const user = userEvent.setup();
+      render(<SessionsList />, { wrapper });
+
+      const joinButton = screen.getByText('Unirse');
+      await user.click(joinButton);
+
+      expect(openSpy).toHaveBeenCalledWith('https://meet.google.com/test', '_blank');
+    });
+
+    it('should call cancel mutation when cancel button clicked', async () => {
+      const session = createMockSession({ status: 'pending' });
+
+      mockUseMySessions.mockReturnValue({
+        data: [session],
+        isLoading: false,
+        error: null,
+      });
+
+      const user = userEvent.setup();
+      render(<SessionsList />, { wrapper });
+
+      const cancelButton = screen.getByText('Cancelar');
+      await user.click(cancelButton);
+
+      // Should show confirmation modal
+      await waitFor(() => {
+        expect(screen.getByText(/¿estás seguro/i)).toBeInTheDocument();
+      });
+
+      // Confirm cancellation
+      const confirmButton = screen.getByRole('button', { name: /confirmar/i });
+      await user.click(confirmButton);
+
+      await waitFor(() => {
+        expect(mockMutate).toHaveBeenCalledWith(
+          { id: session.id, reason: 'Cancelado por el usuario' },
+          expect.objectContaining({
+            onSuccess: expect.any(Function),
+            onError: expect.any(Function),
+          })
+        );
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should display error message when fetch fails', () => {
+      mockUseMySessions.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('Failed to fetch sessions'),
+      });
+
+      render(<SessionsList />, { wrapper });
+
+      expect(screen.getByText(/error al cargar las sesiones/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/features/marketplace/SessionsList.tsx
+++ b/frontend/src/components/features/marketplace/SessionsList.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useState } from 'react';
+import { parseISO } from 'date-fns';
+import { toast } from 'sonner';
+
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { SessionCard } from './SessionCard';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useMySessions, useCancelSession } from '@/hooks/api/useSessions';
+import type { SessionDetail } from '@/types/session.types';
+
+/**
+ * Type definition for tab values
+ */
+type TabValue = 'upcoming' | 'completed' | 'cancelled' | 'all';
+
+/**
+ * Filter sessions by tab selection
+ */
+function filterSessionsByTab(sessions: SessionDetail[], tab: TabValue): SessionDetail[] {
+  switch (tab) {
+    case 'upcoming':
+      return sessions.filter((s) => s.status === 'pending' || s.status === 'confirmed');
+    case 'completed':
+      return sessions.filter((s) => s.status === 'completed');
+    case 'cancelled':
+      return sessions.filter(
+        (s) => s.status === 'cancelled_by_user' || s.status === 'cancelled_by_tarotist'
+      );
+    case 'all':
+    default:
+      return sessions;
+  }
+}
+
+/**
+ * Sort sessions by date ascending (upcoming first)
+ */
+function sortSessionsByDate(sessions: SessionDetail[]): SessionDetail[] {
+  return [...sessions].sort((a, b) => {
+    const dateA = parseISO(`${a.sessionDate}T${a.sessionTime}`);
+    const dateB = parseISO(`${b.sessionDate}T${b.sessionTime}`);
+    return dateA.getTime() - dateB.getTime();
+  });
+}
+
+/**
+ * Get empty state message based on active tab
+ */
+function getEmptyStateMessage(tab: TabValue): string {
+  switch (tab) {
+    case 'upcoming':
+      return 'No tienes sesiones programadas';
+    case 'completed':
+      return 'Aún no has tenido sesiones';
+    case 'cancelled':
+      return 'No tienes sesiones canceladas';
+    case 'all':
+    default:
+      return 'No tienes sesiones';
+  }
+}
+
+/**
+ * SessionsList Component
+ *
+ * Displays user's sessions with tab filters and actions.
+ *
+ * Features:
+ * - Tab filters: Próximas, Completadas, Canceladas, Todas
+ * - Sessions sorted by date (upcoming first)
+ * - Cancel action with confirmation modal
+ * - Join action opens Google Meet in new tab
+ * - Loading and error states
+ * - Empty states per tab
+ */
+export function SessionsList() {
+  const [activeTab, setActiveTab] = useState<TabValue>('upcoming');
+  const [sessionToCancel, setSessionToCancel] = useState<number | null>(null);
+
+  // Fetch all sessions (filtering happens client-side)
+  const { data: sessions, isLoading, error } = useMySessions();
+  const { mutate: cancelSession, isPending: isCancelling } = useCancelSession();
+
+  /**
+   * Handle cancel button click - shows confirmation modal
+   */
+  const handleCancelClick = (id: number) => {
+    setSessionToCancel(id);
+  };
+
+  /**
+   * Handle cancel confirmation
+   */
+  const handleConfirmCancel = () => {
+    if (sessionToCancel === null) return;
+
+    cancelSession(
+      { id: sessionToCancel, reason: 'Cancelado por el usuario' },
+      {
+        onSuccess: () => {
+          toast.success('Sesión cancelada correctamente');
+          setSessionToCancel(null);
+        },
+        onError: (error) => {
+          toast.error(`Error al cancelar: ${error.message}`);
+        },
+      }
+    );
+  };
+
+  /**
+   * Handle join button click - opens Google Meet in new tab
+   */
+  const handleJoinClick = (meetLink: string) => {
+    window.open(meetLink, '_blank');
+  };
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} data-testid={`skeleton-${i}`} className="h-32 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="border-destructive bg-destructive/10 rounded-lg border p-8 text-center">
+        <p className="text-destructive">Error al cargar las sesiones</p>
+        <p className="text-muted-foreground mt-2 text-sm">{error.message}</p>
+      </div>
+    );
+  }
+
+  // Filter and sort sessions
+  const filteredSessions = filterSessionsByTab(sessions || [], activeTab);
+  const sortedSessions = sortSessionsByDate(filteredSessions);
+
+  return (
+    <>
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as TabValue)}>
+        <TabsList>
+          <TabsTrigger value="upcoming">Próximas</TabsTrigger>
+          <TabsTrigger value="completed">Completadas</TabsTrigger>
+          <TabsTrigger value="cancelled">Canceladas</TabsTrigger>
+          <TabsTrigger value="all">Todas</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value={activeTab} className="mt-6">
+          {sortedSessions.length === 0 ? (
+            <div className="bg-muted/50 rounded-lg p-12 text-center">
+              <p className="text-muted-foreground">{getEmptyStateMessage(activeTab)}</p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {sortedSessions.map((session) => (
+                <SessionCard
+                  key={session.id}
+                  session={session}
+                  onCancel={handleCancelClick}
+                  onJoin={handleJoinClick}
+                />
+              ))}
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+
+      {/* Cancel Confirmation Modal */}
+      <AlertDialog open={sessionToCancel !== null} onOpenChange={() => setSessionToCancel(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Estás seguro?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Esta acción cancelará tu sesión. Si la sesión está confirmada y es dentro de las
+              próximas 24 horas, es posible que no puedas cancelarla.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isCancelling}>Volver</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmCancel} disabled={isCancelling}>
+              {isCancelling ? 'Cancelando...' : 'Confirmar'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import * as React from 'react';
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+
+import { cn } from '@/lib/utils';
+import { buttonVariants } from '@/components/ui/button';
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn('text-lg font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return <AlertDialogPrimitive.Action className={cn(buttonVariants(), className)} {...props} />;
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: 'outline' }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -6088,6 +6088,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -9789,6 +9790,52 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",


### PR DESCRIPTION
This pull request implements the "Mis Sesiones" (My Sessions) page, providing users with a filtered, interactive list of their session reservations. The implementation includes a new main page, a feature-rich `SessionsList` component with tabs, client-side filtering, modal confirmation for cancellation, and comprehensive test coverage. Additionally, a reusable alert dialog UI component is introduced and the necessary dependency is added.

**Feature: My Sessions Page Implementation**

* Created the `Mis Sesiones` page at `src/app/sesiones/page.tsx` as a protected route using `useRequireAuth`, which delegates all session logic to the new `SessionsList` component and displays a loading spinner during authentication. [[1]](diffhunk://#diff-18485196e126e5ada3c68f5d5f56891ca52cd29464f007c41da552fd423b2530R1-R32)], [[2]](diffhunk://#diff-95639bc2efe9e9d7b34e5a3144c38720719ab2d61b68be32dc16003a9f8a59f2L2910-R2976)])
* Added comprehensive tests for the page and its loading/auth states in `src/app/sesiones/page.test.tsx`, including mocks for authentication and the `SessionsList` component. [[1]](diffhunk://#diff-7d62257c246bcd6845f1f715b140785e3562b294629e2239b5f4ad7e334f7f39L1-R20)], [[2]](diffhunk://#diff-7d62257c246bcd6845f1f715b140785e3562b294629e2239b5f4ad7e334f7f39R47-R60)], [[3]](diffhunk://#diff-95639bc2efe9e9d7b34e5a3144c38720719ab2d61b68be32dc16003a9f8a59f2L2910-R2976)])

**Feature: SessionsList Component**

* Implemented `SessionsList` (`src/components/features/marketplace/SessionsList.tsx`) with:
  - Tabbed filtering (Próximas, Completadas, Canceladas, Todas) and client-side filtering for better UX.
  - Sorting by date (upcoming first), loading/error/empty states, and integration with `useMySessions` and `useCancelSession`.
  - Modal confirmation for cancellation using a new alert dialog component.
  - Actions for joining sessions (opens Google Meet) and canceling with feedback.
  - Reuse of the existing `SessionCard` component.
  - 16 unit tests covering all behaviors and states, with overall test coverage above 90%. [[1]](diffhunk://#diff-c5e38a4891038226169894bd9de8f811e6e37cb8c677e15f1a4642ac3c8628b2R1-R205)], [[2]](diffhunk://#diff-95639bc2efe9e9d7b34e5a3144c38720719ab2d61b68be32dc16003a9f8a59f2L2910-R2976)])

**UI Components and Dependencies**

* Added a reusable `alert-dialog` UI component (`src/components/ui/alert-dialog.tsx`) based on `@radix-ui/react-alert-dialog`, used for session cancellation confirmation modals. [[1]](diffhunk://#diff-2db34f11c9f89977dc7af1d39521bda2a529a91dc694e59ef3325cf6a26ec85fR1-R135)], [[2]](diffhunk://#diff-95639bc2efe9e9d7b34e5a3144c38720719ab2d61b68be32dc16003a9f8a59f2L2910-R2976)])
* Installed the `@radix-ui/react-alert-dialog` dependency in `package.json` to support the new modal component. ([[frontend/package.jsonR20](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R20)])

**Documentation and Validation**

* Updated the backlog documentation to mark the task as complete, list all created/modified files, summarize the implementation, technical decisions, and validation results (lint, type-check, build, architecture, tests, and coverage). ([[frontend/docs/FRONTEND_BACKLOG.mdL2910-R2976](diffhunk://#diff-95639bc2efe9e9d7b34e5a3144c38720719ab2d61b68be32dc16003a9f8a59f2L2910-R2976)])

All changes have passed linting, type-checking, build, architecture review, and testing requirements.

---

**References:**  
[[1]](diffhunk://#diff-18485196e126e5ada3c68f5d5f56891ca52cd29464f007c41da552fd423b2530R1-R32) [[2]](diffhunk://#diff-95639bc2efe9e9d7b34e5a3144c38720719ab2d61b68be32dc16003a9f8a59f2L2910-R2976) [[3]](diffhunk://#diff-7d62257c246bcd6845f1f715b140785e3562b294629e2239b5f4ad7e334f7f39L1-R20) [[4]](diffhunk://#diff-7d62257c246bcd6845f1f715b140785e3562b294629e2239b5f4ad7e334f7f39R47-R60) [[5]](diffhunk://#diff-c5e38a4891038226169894bd9de8f811e6e37cb8c677e15f1a4642ac3c8628b2R1-R205) [[6]](diffhunk://#diff-2db34f11c9f89977dc7af1d39521bda2a529a91dc694e59ef3325cf6a26ec85fR1-R135) [[7]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R20)