### PR TITLE
feature/(TAREA 11.1): Crear página 404 custom

### DIFF
--- a/frontend/docs/FRONTEND_BACKLOG.md
+++ b/frontend/docs/FRONTEND_BACKLOG.md
@@ -4515,10 +4515,31 @@ IMPORTANTE:
 
 ## ✅ FASE 11: EXTRAS Y POLISH
 
-### TAREA 11.1: Crear página 404 custom
+### TAREA 11.1: Crear página 404 custom ✅
 
 **Prioridad:** BAJA
 **Estimación:** 20 min
+**Estado:** COMPLETADA
+**Fecha:** 15 de Diciembre, 2025
+
+**Implementación:**
+
+- ✅ Página 404 con temática mística
+- ✅ Ícono SVG de carta boca abajo con colores primary y secondary
+- ✅ Título con font-serif responsive (4xl en mobile, 5xl en desktop)
+- ✅ Mensaje místico con color text-muted
+- ✅ Botón "Volver al inicio" que navega a "/"
+- ✅ Layout centrado vertical y horizontalmente
+- ✅ Fondo bg-main
+- ✅ Padding responsive para mobile
+- ✅ Tests completos (9 tests, 100% coverage)
+- ✅ Validación de arquitectura exitosa
+- ✅ Build exitoso
+
+**Archivos creados:**
+
+- `src/app/not-found.tsx` - Componente principal
+- `src/app/not-found.test.tsx` - Tests completos
 
 **Prompt:**
 

--- a/frontend/src/app/not-found.test.tsx
+++ b/frontend/src/app/not-found.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useRouter } from 'next/navigation';
+import NotFound from './not-found';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+}));
+
+describe('NotFound Page', () => {
+  const mockPush = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useRouter as ReturnType<typeof vi.fn>).mockReturnValue({
+      push: mockPush,
+    });
+  });
+
+  it('should render the 404 title with mystical theme', () => {
+    render(<NotFound />);
+    expect(screen.getByText('404 - Camino no encontrado')).toBeInTheDocument();
+  });
+
+  it('should display mystical message', () => {
+    render(<NotFound />);
+    expect(screen.getByText('Los astros no reconocen este destino')).toBeInTheDocument();
+  });
+
+  it('should have a "Volver al inicio" button', () => {
+    render(<NotFound />);
+    const button = screen.getByRole('button', { name: /volver al inicio/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('should have a card icon', () => {
+    render(<NotFound />);
+    const icon = screen.getByTestId('card-icon');
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('should have background color bg-main', () => {
+    const { container } = render(<NotFound />);
+    const mainDiv = container.firstChild as HTMLElement;
+    expect(mainDiv).toHaveClass('bg-bg-main');
+  });
+
+  it('should have centered content vertically and horizontally', () => {
+    const { container } = render(<NotFound />);
+    const mainDiv = container.firstChild as HTMLElement;
+    expect(mainDiv).toHaveClass('flex', 'items-center', 'justify-center');
+  });
+
+  it('should have font-serif on title', () => {
+    render(<NotFound />);
+    const title = screen.getByText('404 - Camino no encontrado');
+    expect(title).toHaveClass('font-serif');
+  });
+
+  it('should navigate to home when button is clicked', async () => {
+    render(<NotFound />);
+    const user = userEvent.setup();
+    const button = screen.getByRole('button', { name: /volver al inicio/i });
+
+    await user.click(button);
+
+    expect(mockPush).toHaveBeenCalledWith('/');
+  });
+
+  it('should have minimum height of screen', () => {
+    const { container } = render(<NotFound />);
+    const mainDiv = container.firstChild as HTMLElement;
+    expect(mainDiv).toHaveClass('min-h-screen');
+  });
+});

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+/**
+ * Página 404 personalizada con temática mística.
+ * Muestra un mensaje de error cuando se accede a una ruta inexistente.
+ */
+export default function NotFound() {
+  const router = useRouter();
+
+  const handleGoHome = () => {
+    router.push('/');
+  };
+
+  return (
+    <div className="bg-bg-main flex min-h-screen items-center justify-center p-4">
+      <div className="text-center">
+        {/* Ícono de carta boca abajo */}
+        <div data-testid="card-icon" className="mx-auto mb-8">
+          <svg
+            width="120"
+            height="180"
+            viewBox="0 0 120 180"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="mx-auto drop-shadow-lg"
+            aria-hidden="true"
+          >
+            {/* Borde de la carta con colores místicos */}
+            <rect
+              x="2"
+              y="2"
+              width="116"
+              height="176"
+              rx="12"
+              fill="#805AD5"
+              fillOpacity="0.1"
+              stroke="#D69E2E"
+              strokeWidth="2"
+            />
+            {/* Flecha hacia arriba (carta boca abajo) */}
+            <path
+              d="M40 70L60 50L80 70M60 50V130"
+              stroke="#D69E2E"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+
+        {/* Título principal con tipografía serif */}
+        <h1 className="text-text-primary mb-4 font-serif text-4xl font-bold md:text-5xl">
+          404 - Camino no encontrado
+        </h1>
+
+        {/* Mensaje místico */}
+        <p className="text-text-muted mb-8 text-lg md:text-xl">
+          Los astros no reconocen este destino
+        </p>
+
+        {/* Botón para volver al inicio */}
+        <Button onClick={handleGoHome} variant="default" size="lg">
+          Volver al inicio
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request implements a fully custom 404 page with a mystical theme for the frontend, including comprehensive testing and documentation updates. The main changes are the creation of the new `not-found` page component, the addition of complete tests for it, and the update of the project backlog to reflect the completion of this task.

**New 404 Page Implementation:**

- Added `src/app/not-found.tsx`, a custom 404 page with a mystical theme. Features include a themed SVG card icon, responsive serif title, mystical message, "Volver al inicio" button that navigates home, centered layout, themed background, responsive padding, and accessibility considerations.

**Testing:**

- Added `src/app/not-found.test.tsx` with 9 tests covering rendering, layout, theme, navigation, and accessibility, achieving 100% coverage.

**Documentation:**

- Updated `frontend/docs/FRONTEND_BACKLOG.md` to mark the 404 page task as completed, detailing implementation, testing, and build status.