### PR TITLE
fix/(BUG FIX 2.4): Ocultar "Mis Sesiones" sin funcionalidad

### DIFF
--- a/frontend/docs/BUG_FIXES_BACKLOG.md
+++ b/frontend/docs/BUG_FIXES_BACKLOG.md
@@ -481,16 +481,30 @@ La opción "Explorar" está visible en el navbar pero el MVP solo debe trabajar 
 
 ---
 
-### ✅ BUG FIX 2.4: Ocultar "Mis Sesiones" sin funcionalidad (#A007)
+### ✅ BUG FIX 2.4: Ocultar "Mis Sesiones" sin funcionalidad (#A007) - **COMPLETADO ✅**
 
 **Prioridad:** 🟠 ALTO  
 **Área:** Frontend - Navigation  
 **Estimación:** 15-20 min  
-**Dependencias:** Ninguna
+**Tiempo Real:** 10 min  
+**Dependencias:** Ninguna  
+**Branch:** `fix/A007-hide-sessions-link`  
+**Commit:** (pendiente)
 
 #### Descripción del Bug
 
 La opción "Mis Sesiones" lleva a una página vacía sin datos. Si no está funcional, no debe mostrarse.
+
+#### Análisis Realizado
+
+**Investigación de endpoints de sesiones:**
+
+- Los endpoints de sesiones SÍ existen en el backend: `/tarotist/scheduling/sessions`
+- Sin embargo, son **exclusivos para tarotistas** (rol tarotista)
+- NO hay endpoints de sesiones para usuarios normales implementados en el MVP
+- La funcionalidad de "Mis Sesiones" para usuarios está pendiente de implementación
+
+**Decisión:** Ocultar el link "Mis Sesiones" siguiendo el mismo patrón de "Explorar" (#A006).
 
 #### Tareas de Corrección
 
@@ -500,17 +514,40 @@ La opción "Mis Sesiones" lleva a una página vacía sin datos. Si no está func
   - Revisar si backend tiene endpoints de sesiones
   - Revisar si hay datos de sesiones en BD
   - Decidir: ¿Ocultar o implementar estado vacío apropiado?
+- **Resultado:**
+  - [x] Endpoints existen solo para tarotistas (`/tarotist/scheduling/sessions`)
+  - [x] Para usuarios normales NO hay funcionalidad de sesiones
+  - [x] Decisión: Ocultar link hasta implementar feature
 
 **TAREA 2.4.2: Ocultar "Mis Sesiones" del navbar** (Frontend)
 
-- **Archivo:** `frontend/src/components/layout/Header.tsx` o navbar component
+- **Archivo:** `frontend/src/components/layout/Header.tsx`
 - **Acción:**
-  - Comentar o eliminar el link "Mis Sesiones"
-  - O mostrar con badge "Próximamente" (disabled)
+  - Comentado link "Mis Sesiones" con documentación clara
+  - Preservado código para futura reactivación
+  - Agregado comentario explicando que endpoints son solo para tarotistas
 - **Criterios de aceptación:**
-  - [ ] Link NO visible o claramente marcado como "próximamente"
+  - [x] Link NO visible en navbar
+  - [x] Test actualizado y pasando
+  - [x] Código comentado con explicación clara
+  - [x] TODO agregado para futura implementación
 
-**Estimación:** 15-20 min
+**Tests Verificados:**
+
+- ✅ 1530/1530 tests pasando
+- ✅ Coverage: 82.74% (>80%)
+- ✅ Header.test.tsx: 17/17 tests pasando
+- ✅ Test específico verifica que "Mis Sesiones" NO se muestra
+
+**Calidad:**
+
+- ✅ Lint: 0 errors, 0 warnings
+- ✅ Type-check: sin errores
+- ✅ Arquitectura: validación exitosa
+- ✅ Build: exitoso
+
+**Estimación:** 15-20 min  
+**Tiempo Real:** 10 min
 
 ---
 

--- a/frontend/src/components/layout/Header.test.tsx
+++ b/frontend/src/components/layout/Header.test.tsx
@@ -111,10 +111,12 @@ describe('Header', () => {
       expect(screen.queryByRole('link', { name: /explorar/i })).not.toBeInTheDocument();
     });
 
-    it('should show "Mis Sesiones" link when authenticated', () => {
+    it('should NOT show "Mis Sesiones" link (MVP: user sessions not implemented)', () => {
       render(<Header />);
 
-      expect(screen.getByRole('link', { name: /mis sesiones/i })).toBeInTheDocument();
+      // Sessions endpoints exist only for tarotistas
+      // User sessions feature is not implemented yet in MVP
+      expect(screen.queryByRole('link', { name: /mis sesiones/i })).not.toBeInTheDocument();
     });
 
     it('should NOT show "Iniciar Sesión" link when authenticated', () => {

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -55,12 +55,15 @@ export function Header() {
               >
                 Explorar
               </Link> */}
-              <Link
+              {/* "Mis Sesiones" link hidden in MVP - no user sessions implemented yet */}
+              {/* Sessions endpoints exist only for tarotistas (/tarotist/scheduling/sessions) */}
+              {/* TODO: Enable when user sessions feature is implemented */}
+              {/* <Link
                 href="/sesiones"
                 className="text-text-primary hover:text-primary text-sm font-medium transition-colors"
               >
                 Mis Sesiones
-              </Link>
+              </Link> */}
             </>
           )}
         </div>


### PR DESCRIPTION
This pull request addresses the bug where the "Mis Sesiones" link was visible in the navbar despite the feature not being implemented for regular users in the MVP. The main change is to hide the "Mis Sesiones" link for users until the feature is available, following the same approach as with the "Explorar" link. The implementation includes clear documentation, code comments, and updated tests to ensure the link does not appear.

Frontend changes (Navigation & UI):

* The "Mis Sesiones" link in the `Header` component (`Header.tsx`) is now commented out with clear documentation, indicating that session endpoints are only available for tarotistas and the feature is not implemented for users in the MVP. A TODO comment is included for future reactivation.
* The corresponding test in `Header.test.tsx` is updated to assert that the "Mis Sesiones" link does NOT appear in the navbar for users, with comments explaining the MVP status.

Documentation and process:

* The bug fix entry in `BUG_FIXES_BACKLOG.md` is updated to mark the task as completed, provide a detailed analysis of the backend endpoints, clarify the decision to hide the link, and document the steps taken, including test and code quality checks. [[1]](diffhunk://#diff-0a3689337ca8dd18f8c99e5a506eeceb4edeac90d3e86b1ea1dd84ca80c27c0eL484-R508) [[2]](diffhunk://#diff-0a3689337ca8dd18f8c99e5a506eeceb4edeac90d3e86b1ea1dd84ca80c27c0eR517-R550)