### PR TITLE
feature/(TASK-006): Modificar frontend para enviar flag useAI según plan

### DIFF
--- a/docs/QA_TESTING_REPORT.md
+++ b/docs/QA_TESTING_REPORT.md
@@ -1747,6 +1747,75 @@ La aplicación tiene una **base sólida** en términos de:
 
 ---
 
+### TASK-006: Modificar frontend para enviar flag useAI según plan ✅
+
+**Estado:** ✅ COMPLETADO - 3 Enero 2026
+
+**[FRONTEND]**
+
+**Archivos modificados:**
+
+- `frontend/src/types/reading.types.ts`
+- `frontend/src/components/features/readings/ReadingExperience.tsx`
+- `frontend/src/hooks/utils/useConversionTracking.ts` (corrección arquitectura)
+- Creado: `frontend/src/components/features/readings/ReadingExperience.useAI.test.tsx`
+
+**Cambios implementados:**
+
+1. ✅ **Actualizado tipo CreateReadingDto:**
+   - Campo `generateInterpretation` reemplazado por `useAI`
+   - Documentación actualizada con comportamiento por plan
+
+2. ✅ **Modificado componente ReadingExperience:**
+   - Detecta plan del usuario con `useUserPlanFeatures()`
+   - Envía `useAI: true` para usuarios PREMIUM
+   - Envía `useAI: false` para usuarios FREE
+   - Agrega `canUseAI` a las dependencias del useCallback
+
+3. ✅ **Agregados mensajes de UI condicionales:**
+   - PREMIUM: "✨ Recibirás interpretación personalizada"
+   - FREE: "Verás las cartas y sus significados"
+   - Mensajes se muestran en estado de selección de cartas
+
+4. ✅ **Tests implementados:**
+   - 6 tests nuevos en ReadingExperience.useAI.test.tsx
+   - Verifica envío correcto de flag useAI según plan
+   - Verifica mensajes de UI según plan
+   - Verifica upgrade banner para usuarios FREE
+   - Todos los tests pasando (32 + 6 = 38 tests)
+
+5. ✅ **Corrección de problemas de arquitectura pre-existentes:**
+   - Eliminados comentarios `eslint-disable-next-line` en useConversionTracking.ts
+   - Agregado `void _plan` y `void _action` para referenciar parámetros reservados
+   - Validador de arquitectura ahora pasa sin errores
+
+**Ciclo de calidad:**
+
+- ✅ Lint: 0 errores, 2 warnings (pre-existentes en archivos no relacionados)
+- ✅ Type-check: Passed
+- ✅ Format: Applied
+- ✅ Build: Successful (Next.js 16.0.6)
+- ✅ Tests: 1732 passed | 2 skipped (1734)
+- ✅ Architecture validation: ✅ VALIDACIÓN EXITOSA - Sin errores críticos
+
+**Dependencias:** TASK-004 ✅, TASK-005 ✅
+
+**Criterios de aceptación cumplidos:**
+
+- ✅ Usuario FREE crea lecturas sin IA correctamente (useAI: false)
+- ✅ Usuario PREMIUM crea lecturas con IA correctamente (useAI: true)
+- ✅ Mensajes en UI reflejan el tipo de lectura que recibirán
+- ✅ Error 403 ya no ocurre para usuarios FREE (backend lo maneja)
+- ✅ Problemas de arquitectura pre-existentes resueltos
+
+**Rama:** `feature/TASK-006-useai-flag-by-plan`
+
+**Commit:** (próximo)
+
+**Fecha de completación:** 3 Enero 2026
+
+---
+
 ### TASK-006: Modificar frontend para enviar flag useAI según plan
 
 **[FRONTEND]**

--- a/frontend/src/components/features/readings/ReadingExperience.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.tsx
@@ -322,7 +322,10 @@ export function ReadingExperience({
         cardPositions,
         ...(questionId ? { predefinedQuestionId: questionId } : {}),
         ...(customQuestion ? { customQuestion } : {}),
-        generateInterpretation: true,
+        // TASK-006: Send useAI flag based on user plan
+        // - PREMIUM: useAI: true (generates AI interpretation)
+        // - FREE/ANONYMOUS: useAI: false (DB info only)
+        useAI: canUseAI,
       };
 
       const result = await createReading(createDto);
@@ -333,7 +336,16 @@ export function ReadingExperience({
       setState('error');
       setError('Error al crear la lectura. Por favor, intenta de nuevo.');
     }
-  }, [selectedCards, cardsCount, spread, spreadId, questionId, customQuestion, createReading]);
+  }, [
+    selectedCards,
+    cardsCount,
+    spread,
+    spreadId,
+    questionId,
+    customQuestion,
+    createReading,
+    canUseAI,
+  ]);
 
   // Action handlers
   const handleRegenerate = useCallback(() => {
@@ -415,6 +427,15 @@ export function ReadingExperience({
           <p className="text-text-muted mb-6 text-center text-sm">
             Elige {cardsCount} carta{cardsCount > 1 ? 's' : ''} del mazo
           </p>
+
+          {/* TASK-006: Show different message based on user plan */}
+          <div className="text-text-muted mb-6 text-center text-sm">
+            {canUseAI ? (
+              <p className="text-primary font-medium">✨ Recibirás interpretación personalizada</p>
+            ) : (
+              <p>Verás las cartas y sus significados</p>
+            )}
+          </div>
 
           {/* Full Deck Grid - 78 cards */}
           <div className="mx-auto mb-8 w-full max-w-6xl px-2 sm:px-4">

--- a/frontend/src/components/features/readings/ReadingExperience.useAI.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.useAI.test.tsx
@@ -1,0 +1,392 @@
+/**
+ * Tests for ReadingExperience - useAI flag based on user plan
+ * TASK-006: Ensure that useAI flag is sent correctly based on user plan
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReadingExperience } from './ReadingExperience';
+import type { Spread, ReadingDetail, ReadingCard, Interpretation } from '@/types/reading.types';
+
+// Mock Next.js router
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+// Mock Next.js Image
+vi.mock('next/image', () => ({
+  default: function MockImage({
+    src,
+    alt,
+    className,
+  }: {
+    src: string;
+    alt: string;
+    className?: string;
+  }) {
+    return <img src={src} alt={alt} className={className} data-testid="next-image" />;
+  },
+}));
+
+// Mock react-markdown
+vi.mock('react-markdown', () => ({
+  default: function MockReactMarkdown({ children }: { children: string }) {
+    return <div data-testid="markdown-content">{children}</div>;
+  },
+}));
+
+// Mock UpgradeBanner
+vi.mock('./UpgradeBanner', () => ({
+  default: function MockUpgradeBanner({ onUpgradeClick }: { onUpgradeClick: () => void }) {
+    return (
+      <div data-testid="upgrade-banner">
+        <p>💎 Desbloquea interpretaciones personalizadas con IA</p>
+        <button onClick={onUpgradeClick}>Upgrade a Premium</button>
+      </div>
+    );
+  },
+}));
+
+// Mock UpgradeModal
+vi.mock('./UpgradeModal', () => ({
+  default: function MockUpgradeModal({
+    open,
+    onOpenChange,
+  }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  }) {
+    if (!open) return null;
+    return (
+      <div role="dialog" data-testid="upgrade-modal">
+        <button onClick={() => onOpenChange(false)}>Close</button>
+      </div>
+    );
+  },
+}));
+
+// Mock toast
+vi.mock('@/hooks/utils/useToast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+// Test data
+const mockSpread: Spread = {
+  id: 2,
+  name: 'Tres Cartas',
+  description: 'Pasado, presente, futuro',
+  cardCount: 3,
+  positions: [
+    { position: 1, name: 'Pasado', description: 'Lo que dejaste atrás' },
+    { position: 2, name: 'Presente', description: 'Tu situación actual' },
+    { position: 3, name: 'Futuro', description: 'Lo que vendrá' },
+  ],
+  difficulty: 'beginner',
+};
+
+const mockReadingCards: ReadingCard[] = [
+  {
+    id: 1,
+    name: 'El Loco',
+    arcana: 'major',
+    number: 0,
+    suit: null,
+    orientation: 'upright',
+    position: 1,
+    positionName: 'Pasado',
+    imageUrl: '/cards/the-fool.jpg',
+  },
+  {
+    id: 2,
+    name: 'El Mago',
+    arcana: 'major',
+    number: 1,
+    suit: null,
+    orientation: 'upright',
+    position: 2,
+    positionName: 'Presente',
+    imageUrl: '/cards/the-magician.jpg',
+  },
+  {
+    id: 3,
+    name: 'La Sacerdotisa',
+    arcana: 'major',
+    number: 2,
+    suit: null,
+    orientation: 'reversed',
+    position: 3,
+    positionName: 'Futuro',
+    imageUrl: '/cards/high-priestess.jpg',
+  },
+];
+
+const mockInterpretation: Interpretation = {
+  id: 1,
+  generalInterpretation: '**Tu lectura revela** un momento de nuevos comienzos...',
+  cardInterpretations: [
+    { cardId: 1, interpretation: 'El Loco indica un nuevo viaje...' },
+    { cardId: 2, interpretation: 'El Mago muestra tu poder creativo...' },
+    { cardId: 3, interpretation: 'La Sacerdotisa invertida sugiere confusión...' },
+  ],
+  aiProvider: 'groq',
+  model: 'llama-3.1-70b-versatile',
+};
+
+const mockReadingDetail: ReadingDetail = {
+  id: 123,
+  userId: 1,
+  spreadId: 2,
+  question: '¿Qué debo esperar en el amor?',
+  cards: mockReadingCards,
+  interpretation: mockInterpretation,
+  createdAt: '2025-12-07T10:00:00Z',
+  shareToken: null,
+};
+
+// Mock implementations for hooks
+const mockCreateReadingMutateAsync = vi.fn();
+const mockUseSpreads = vi.fn();
+const mockUsePredefinedQuestions = vi.fn();
+const mockUseUserPlanFeatures = vi.fn();
+
+// Default mock implementations
+vi.mock('@/hooks/api/useReadings', () => ({
+  useSpreads: () => mockUseSpreads(),
+  usePredefinedQuestions: () => mockUsePredefinedQuestions(),
+  useCreateReading: () => ({
+    mutate: vi.fn(),
+    mutateAsync: mockCreateReadingMutateAsync,
+    isPending: false,
+  }),
+  useRegenerateInterpretation: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+  useShareReading: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => ({
+    user: {
+      id: 1,
+      email: 'test@example.com',
+      plan: 'premium',
+    },
+    isAuthenticated: true,
+  }),
+}));
+
+vi.mock('@/hooks/utils/useUserPlanFeatures', () => ({
+  useUserPlanFeatures: () => mockUseUserPlanFeatures(),
+}));
+
+// Query client for tests
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createTestQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+describe('ReadingExperience - useAI flag (TASK-006)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateReadingMutateAsync.mockReset();
+
+    // Default mocks
+    mockUseSpreads.mockReturnValue({
+      data: [mockSpread],
+      isLoading: false,
+    });
+
+    mockUsePredefinedQuestions.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+  });
+
+  describe('PREMIUM user - useAI: true', () => {
+    beforeEach(() => {
+      mockUseUserPlanFeatures.mockReturnValue({
+        plan: 'premium',
+        planLabel: 'PREMIUM',
+        canUseAI: true,
+        canUseCategories: true,
+        canUseCustomQuestions: true,
+        canShare: true,
+        isPremium: true,
+        isFree: false,
+        isAnonymous: false,
+        dailyReadingsLimit: 3,
+      });
+
+      mockCreateReadingMutateAsync.mockResolvedValue(mockReadingDetail);
+    });
+
+    it('should send useAI: true when PREMIUM user creates reading', async () => {
+      renderWithProviders(<ReadingExperience spreadId={2} questionId={1} customQuestion={null} />);
+
+      // Select 3 cards
+      const cards = screen.getAllByTestId('selectable-card');
+      fireEvent.click(cards[0]);
+      fireEvent.click(cards[1]);
+      fireEvent.click(cards[2]);
+
+      // Click reveal button
+      const revealButton = screen.getByRole('button', { name: /Revelar mi destino/i });
+      fireEvent.click(revealButton);
+
+      await waitFor(() => {
+        expect(mockCreateReadingMutateAsync).toHaveBeenCalledTimes(1);
+      });
+
+      // Verify useAI: true was sent
+      const callArgs = mockCreateReadingMutateAsync.mock.calls[0][0];
+      expect(callArgs).toHaveProperty('useAI', true);
+    });
+
+    it('should display "Recibirás interpretación personalizada" for PREMIUM user', () => {
+      renderWithProviders(<ReadingExperience spreadId={2} questionId={1} customQuestion={null} />);
+
+      expect(screen.getByText(/Recibirás interpretación personalizada/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('FREE user - useAI: false', () => {
+    beforeEach(() => {
+      mockUseUserPlanFeatures.mockReturnValue({
+        plan: 'free',
+        planLabel: 'GRATUITO',
+        canUseAI: false,
+        canUseCategories: false,
+        canUseCustomQuestions: false,
+        canShare: true,
+        isPremium: false,
+        isFree: true,
+        isAnonymous: false,
+        dailyReadingsLimit: 2,
+      });
+
+      mockCreateReadingMutateAsync.mockResolvedValue(mockReadingDetail);
+    });
+
+    it('should send useAI: false when FREE user creates reading', async () => {
+      renderWithProviders(<ReadingExperience spreadId={2} questionId={1} customQuestion={null} />);
+
+      // Select 3 cards
+      const cards = screen.getAllByTestId('selectable-card');
+      fireEvent.click(cards[0]);
+      fireEvent.click(cards[1]);
+      fireEvent.click(cards[2]);
+
+      // Click reveal button
+      const revealButton = screen.getByRole('button', { name: /Revelar mi destino/i });
+      fireEvent.click(revealButton);
+
+      await waitFor(() => {
+        expect(mockCreateReadingMutateAsync).toHaveBeenCalledTimes(1);
+      });
+
+      // Verify useAI: false was sent
+      const callArgs = mockCreateReadingMutateAsync.mock.calls[0][0];
+      expect(callArgs).toHaveProperty('useAI', false);
+    });
+
+    it('should display "Verás las cartas y sus significados" for FREE user', () => {
+      renderWithProviders(<ReadingExperience spreadId={2} questionId={1} customQuestion={null} />);
+
+      expect(screen.getByText(/Verás las cartas y sus significados/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('UI Messages by Plan', () => {
+    it('should show upgrade banner after reveal for FREE user', async () => {
+      mockUseUserPlanFeatures.mockReturnValue({
+        plan: 'free',
+        planLabel: 'GRATUITO',
+        canUseAI: false,
+        canUseCategories: false,
+        canUseCustomQuestions: false,
+        canShare: true,
+        isPremium: false,
+        isFree: true,
+        isAnonymous: false,
+        dailyReadingsLimit: 2,
+      });
+
+      mockCreateReadingMutateAsync.mockResolvedValue(mockReadingDetail);
+
+      renderWithProviders(<ReadingExperience spreadId={2} questionId={1} customQuestion={null} />);
+
+      // Select 3 cards
+      const cards = screen.getAllByTestId('selectable-card');
+      fireEvent.click(cards[0]);
+      fireEvent.click(cards[1]);
+      fireEvent.click(cards[2]);
+
+      // Click reveal button
+      const revealButton = screen.getByRole('button', { name: /Revelar mi destino/i });
+      fireEvent.click(revealButton);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('upgrade-banner')).toBeInTheDocument();
+      });
+    });
+
+    it('should NOT show upgrade banner for PREMIUM user', async () => {
+      mockUseUserPlanFeatures.mockReturnValue({
+        plan: 'premium',
+        planLabel: 'PREMIUM',
+        canUseAI: true,
+        canUseCategories: true,
+        canUseCustomQuestions: true,
+        canShare: true,
+        isPremium: true,
+        isFree: false,
+        isAnonymous: false,
+        dailyReadingsLimit: 3,
+      });
+
+      mockCreateReadingMutateAsync.mockResolvedValue(mockReadingDetail);
+
+      renderWithProviders(<ReadingExperience spreadId={2} questionId={1} customQuestion={null} />);
+
+      // Select 3 cards
+      const cards = screen.getAllByTestId('selectable-card');
+      fireEvent.click(cards[0]);
+      fireEvent.click(cards[1]);
+      fireEvent.click(cards[2]);
+
+      // Click reveal button
+      const revealButton = screen.getByRole('button', { name: /Revelar mi destino/i });
+      fireEvent.click(revealButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Tu lectura del Tarot/i })).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTestId('upgrade-banner')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/hooks/utils/useConversionTracking.ts
+++ b/frontend/src/hooks/utils/useConversionTracking.ts
@@ -96,7 +96,6 @@ export default function useConversionTracking(): UseConversionTrackingReturn {
    * @param location - Where the CTA was shown
    * @param _plan - User plan (reserved for future Google Analytics integration)
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const trackCTAShown = useCallback((location: CTALocation, _plan: string) => {
     if (!isLocalStorageAvailable()) return;
 
@@ -104,6 +103,8 @@ export default function useConversionTracking(): UseConversionTrackingReturn {
     localStorage.setItem(`cta_shown_${location}`, timestamp);
 
     // Integration point for analytics
+    // Reserved parameter for future use: _plan
+    void _plan; // Prevent unused variable warning
     if (process.env.NODE_ENV === 'production') {
       // gtag('event', 'cta_shown', { location, plan: _plan });
     }
@@ -115,7 +116,6 @@ export default function useConversionTracking(): UseConversionTrackingReturn {
    * @param location - Where the CTA was clicked
    * @param _action - Action taken (reserved for future Google Analytics integration)
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const trackCTAClicked = useCallback((location: CTALocation, _action: CTAAction) => {
     if (!isLocalStorageAvailable()) return;
 
@@ -123,6 +123,8 @@ export default function useConversionTracking(): UseConversionTrackingReturn {
     localStorage.setItem(`cta_clicked_${location}`, timestamp);
 
     // Integration point for analytics
+    // Reserved parameter for future use: _action
+    void _action; // Prevent unused variable warning
     if (process.env.NODE_ENV === 'production') {
       // gtag('event', 'cta_clicked', { location, action: _action });
     }

--- a/frontend/src/types/reading.types.ts
+++ b/frontend/src/types/reading.types.ts
@@ -180,8 +180,9 @@ export interface CardPositionDto {
  * DTO for creating a new reading
  * Matches backend CreateReadingDto
  *
- * @property generateInterpretation - Solo true para usuarios Premium (default: false)
- * ACTUALIZADO: Default cambiado de true a false para reflejar cambio en backend
+ * @property useAI - Indica si se debe usar IA para generar interpretación
+ * ACTUALIZADO (TASK-006): Campo 'generateInterpretation' reemplazado por 'useAI'
+ * Default: undefined (backend determina según plan)
  */
 export interface CreateReadingDto {
   spreadId: number;
@@ -192,10 +193,12 @@ export interface CreateReadingDto {
   customQuestion?: string;
   /**
    * Solicitar interpretación IA al crear lectura
-   * @default false
-   * Solo true para usuarios Premium
+   * - true: Generar interpretación con IA (solo PREMIUM)
+   * - false: Solo info de cartas de DB (FREE/ANONYMOUS)
+   * - undefined: Backend decide según plan del usuario
+   * @default undefined
    */
-  generateInterpretation?: boolean;
+  useAI?: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
This pull request implements TASK-006, updating the frontend to send a `useAI` flag when creating a reading, based on the user's plan (PREMIUM or FREE). It replaces the previous `generateInterpretation` field, updates UI messages to reflect the user's plan, adds comprehensive tests to verify the new logic, and resolves pre-existing architectural issues in utility hooks. The changes ensure that PREMIUM users receive AI-generated interpretations, while FREE users see standard card meanings, with the UI and backend now fully aligned.

**Feature: Plan-based AI Interpretation**

* Replaced the `generateInterpretation` field with a new `useAI` flag in the `CreateReadingDto` type, including updated documentation to clarify its behavior for different user plans. (`frontend/src/types/reading.types.ts`) [[1]](diffhunk://#diff-4cf16d5f5e3af309280316bbbb823c9d42b799517e1fc9f554cfd14a48f62e4fL183-R185) [[2]](diffhunk://#diff-4cf16d5f5e3af309280316bbbb823c9d42b799517e1fc9f554cfd14a48f62e4fL195-R201)
* Updated the `ReadingExperience` component to detect the user's plan and send `useAI: true` for PREMIUM users and `useAI: false` for FREE users when creating a reading. (`frontend/src/components/features/readings/ReadingExperience.tsx`)

**UI Updates**

* Added conditional UI messages in `ReadingExperience` to inform users whether they will receive a personalized AI interpretation (PREMIUM) or standard card meanings (FREE). (`frontend/src/components/features/readings/ReadingExperience.tsx`)
* Ensured that the UI updates correctly by adding `canUseAI` to the dependencies of relevant hooks. (`frontend/src/components/features/readings/ReadingExperience.tsx`)

**Testing**

* Added a new test suite (`ReadingExperience.useAI.test.tsx`) with 6 tests to verify correct flag transmission, UI messaging, and upgrade banner display for FREE users. All tests are passing. (`frontend/src/components/features/readings/ReadingExperience.useAI.test.tsx`)

**Architecture & Code Quality**

* Removed unnecessary `eslint-disable-next-line` comments and referenced reserved parameters with `void` to resolve architecture validation issues in `useConversionTracking.ts`. (`frontend/src/hooks/utils/useConversionTracking.ts`) [[1]](diffhunk://#diff-ee20b2d624dff5229a83a7a68faec4a7577f7f3873ad2d7a9da7f29fb68fae2eL99-R107) [[2]](diffhunk://#diff-ee20b2d624dff5229a83a7a68faec4a7577f7f3873ad2d7a9da7f29fb68fae2eL118-R127)

**Documentation**

* Updated QA/testing report to reflect the completion, dependencies, acceptance criteria, and quality cycle for TASK-006. (`docs/QA_TESTING_REPORT.md`)