### PR TITLE
feature/(TASK-012): Remover menciones explícitas a IA en textos

### DIFF
--- a/docs/QA_TESTING_REPORT.md
+++ b/docs/QA_TESTING_REPORT.md
@@ -2207,31 +2207,57 @@ La aplicación tiene una **base sólida** en términos de:
 
 ---
 
-### TASK-012: Remover menciones explícitas a IA en textos
+### ✅ TASK-012: Remover menciones explícitas a IA en textos - COMPLETADO
 
 **[FRONTEND]**
 
-**Archivos a modificar:**
+**Estado:** ✅ COMPLETADO (4 Enero 2026)
 
-- `frontend/src/app/page.tsx` (landing)
-- Componentes de planes/suscripciones
-- Tooltips y textos de ayuda
-- Footer/About
+**Archivos modificados:**
 
-**Cambios requeridos:**
+- `frontend/src/components/features/readings/UpgradeBanner.tsx`
+- `frontend/src/components/features/readings/UpgradeModal.tsx`
+- `frontend/src/components/features/home/PremiumBenefitsSection.tsx`
+- `frontend/src/components/features/home/WhatIsTarotSection.tsx`
+- `frontend/src/components/features/conversion/LimitReachedModal.tsx`
+- `frontend/src/components/features/conversion/PremiumPreview.tsx`
+- `frontend/src/components/features/marketplace/TarotistaProfilePage.tsx`
+- `frontend/src/lib/metadata/seo.ts`
 
-1. Cambiar "interpretación con IA" → "interpretación personalizada"
-2. Cambiar "análisis generado por IA" → "análisis detallado"
-3. Remover badges "Powered by AI"
-4. Mantener diferenciación de valor PREMIUM vs FREE sin mencionar "IA"
+**Cambios implementados:**
 
-**Dependencias:** Ninguna
+1. ✅ "interpretación con IA" → "interpretación personalizada"
+2. ✅ "Interpretaciones con IA personalizadas" → "Interpretaciones personalizadas y profundas"
+3. ✅ "inteligencia artificial" → "tecnología avanzada"
+4. ✅ "Lecturas de tarot con IA" → "Lecturas de tarot personalizadas"
+5. ✅ "Accede a interpretaciones personalizadas con IA" → "Accede a interpretaciones personalizadas"
+6. ✅ "Lectura con IA personalizada" → "Lectura personalizada"
 
-**Criterios de aceptación:**
+**Tests actualizados:**
 
-- Textos NO mencionan "IA" o "Inteligencia Artificial"
-- Diferenciación de planes sigue siendo clara
-- Usuarios entienden qué ofrece cada plan
+- UpgradeBanner.test.tsx
+- UpgradeModal.test.tsx
+- PremiumBenefitsSection.test.tsx
+- LimitReachedModal.test.tsx
+- TarotistaProfilePage.test.tsx
+- ReadingExperience.test.tsx
+- ReadingExperience.useAI.test.tsx
+- ReadingExperience.upgrade.test.tsx
+
+**Validación:**
+
+- ✅ Todos los tests pasan (1775 tests)
+- ✅ Lint sin errores
+- ✅ Type check sin errores
+- ✅ Build exitoso
+- ✅ Arquitectura validada
+- ✅ Coverage >80%
+
+**Decisiones técnicas:**
+
+- Se mantuvieron referencias técnicas en tipos TypeScript (reading.types.ts) ya que son documentación interna
+- Se mantuvo la página admin/ai-usage/page.tsx sin cambios (es página técnica de administrador)
+- La diferenciación de valor PREMIUM vs FREE se mantiene clara usando términos como "interpretaciones personalizadas y profundas" y "análisis detallados"
 
 ---
 

--- a/frontend/src/components/features/conversion/LimitReachedModal.test.tsx
+++ b/frontend/src/components/features/conversion/LimitReachedModal.test.tsx
@@ -58,7 +58,7 @@ describe('LimitReachedModal', () => {
     );
 
     expect(screen.getByText(/3 lecturas diarias/i)).toBeInTheDocument();
-    expect(screen.getByText(/Interpretaciones con IA/i)).toBeInTheDocument();
+    expect(screen.getByText(/Interpretaciones personalizadas/i)).toBeInTheDocument();
   });
 
   it('should call onUpgrade when clicking upgrade button', async () => {

--- a/frontend/src/components/features/conversion/LimitReachedModal.tsx
+++ b/frontend/src/components/features/conversion/LimitReachedModal.tsx
@@ -35,7 +35,7 @@ const PREMIUM_BENEFITS_LIMIT = [
   },
   {
     icon: Sparkles,
-    text: 'Interpretaciones con IA',
+    text: 'Interpretaciones personalizadas',
   },
 ] as const;
 

--- a/frontend/src/components/features/conversion/PremiumPreview.tsx
+++ b/frontend/src/components/features/conversion/PremiumPreview.tsx
@@ -23,7 +23,7 @@ export interface PremiumPreviewProps {
  * que invita a actualizar a Premium.
  *
  * Usado para mostrar previews de:
- * - Interpretaciones con IA (blurred)
+ * - Interpretaciones personalizadas (blurred)
  * - Estadísticas avanzadas (blurred)
  * - Features premium en general
  *
@@ -31,7 +31,7 @@ export interface PremiumPreviewProps {
  * ```tsx
  * <PremiumPreview onUpgrade={() => router.push('/registro')}>
  *   <div className="p-4">
- *     <h3>Interpretación con IA</h3>
+ *     <h3>Interpretación personalizada</h3>
  *     <p>Esta es una interpretación profunda...</p>
  *   </div>
  * </PremiumPreview>
@@ -58,7 +58,7 @@ export default function PremiumPreview({
           <div className="space-y-2">
             <h3 className="text-foreground font-serif text-lg font-semibold">{message}</h3>
             <p className="text-muted-foreground text-sm">
-              Accede a interpretaciones personalizadas con IA y todas las funcionalidades avanzadas
+              Accede a interpretaciones personalizadas y todas las funcionalidades avanzadas
             </p>
           </div>
           <Button

--- a/frontend/src/components/features/home/PremiumBenefitsSection.test.tsx
+++ b/frontend/src/components/features/home/PremiumBenefitsSection.test.tsx
@@ -14,12 +14,12 @@ describe('PremiumBenefitsSection', () => {
     expect(title).toBeInTheDocument();
   });
 
-  it('should render AI interpretations benefit', () => {
+  it('should render premium interpretations benefit', () => {
     render(<PremiumBenefitsSection />);
 
-    const aiBenefit = screen.getByText(/interpretaciones con ia personalizadas/i);
+    const interpretationsBenefit = screen.getByText(/interpretaciones personalizadas y profundas/i);
 
-    expect(aiBenefit).toBeInTheDocument();
+    expect(interpretationsBenefit).toBeInTheDocument();
   });
 
   it('should render all spreads benefit', () => {

--- a/frontend/src/components/features/home/PremiumBenefitsSection.tsx
+++ b/frontend/src/components/features/home/PremiumBenefitsSection.tsx
@@ -7,7 +7,7 @@ import { Sparkles, Layers, MessageSquare, BarChart3, ShieldOff } from 'lucide-re
 const benefits = [
   {
     icon: Sparkles,
-    title: 'Interpretaciones con IA personalizadas',
+    title: 'Interpretaciones personalizadas y profundas',
     description: 'Análisis profundos adaptados a tu situación',
   },
   {

--- a/frontend/src/components/features/home/WhatIsTarotSection.tsx
+++ b/frontend/src/components/features/home/WhatIsTarotSection.tsx
@@ -43,8 +43,8 @@ export function WhatIsTarotSection() {
             </Card>
 
             <p className="text-gray-700 dark:text-gray-300">
-              En Auguria, combinamos la sabiduría tradicional del tarot con inteligencia artificial
-              para ofrecerte interpretaciones personalizadas que te ayuden en tu camino de
+              En Auguria, combinamos la sabiduría tradicional del tarot con tecnología avanzada para
+              ofrecerte interpretaciones personalizadas que te ayuden en tu camino de
               autoconocimiento y reflexión.
             </p>
           </div>

--- a/frontend/src/components/features/marketplace/TarotistaProfilePage.test.tsx
+++ b/frontend/src/components/features/marketplace/TarotistaProfilePage.test.tsx
@@ -194,7 +194,7 @@ describe('TarotistaProfilePage', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/oráculo digital/i)).toBeInTheDocument();
-      expect(screen.getByText(/lectura con ia personalizada/i)).toBeInTheDocument();
+      expect(screen.getByText(/lectura personalizada/i)).toBeInTheDocument();
 
       expect(screen.getByText(/sesión privada/i)).toBeInTheDocument();
       expect(screen.getByText(/sesión en vivo/i)).toBeInTheDocument();

--- a/frontend/src/components/features/marketplace/TarotistaProfilePage.tsx
+++ b/frontend/src/components/features/marketplace/TarotistaProfilePage.tsx
@@ -285,7 +285,7 @@ export function TarotistaProfilePage({ id }: TarotistaProfilePageProps) {
                 <Sparkles className="text-primary h-8 w-8" />
               </div>
               <h2 className="font-serif text-2xl font-semibold tracking-tight">Oráculo Digital</h2>
-              <CardDescription className="text-base">Lectura con IA personalizada</CardDescription>
+              <CardDescription className="text-base">Lectura personalizada</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4 text-center">
               <p className="text-gray-600">

--- a/frontend/src/components/features/readings/ReadingExperience.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.test.tsx
@@ -50,7 +50,7 @@ vi.mock('./UpgradeBanner', () => ({
   default: function MockUpgradeBanner({ onUpgradeClick }: { onUpgradeClick: () => void }) {
     return (
       <div data-testid="upgrade-banner">
-        <p>💎 Desbloquea interpretaciones personalizadas con IA</p>
+        <p>💎 Desbloquea interpretaciones personalizadas</p>
         <button onClick={onUpgradeClick}>Upgrade a Premium</button>
       </div>
     );

--- a/frontend/src/components/features/readings/ReadingExperience.upgrade.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.upgrade.test.tsx
@@ -50,7 +50,7 @@ vi.mock('./UpgradeBanner', () => ({
   default: function MockUpgradeBanner({ onUpgradeClick }: { onUpgradeClick: () => void }) {
     return (
       <div data-testid="upgrade-banner">
-        <p>💎 Desbloquea interpretaciones personalizadas con IA</p>
+        <p>💎 Desbloquea interpretaciones personalizadas</p>
         <button onClick={onUpgradeClick}>Upgrade a Premium</button>
       </div>
     );
@@ -260,9 +260,7 @@ describe('ReadingExperience - Upgrade Banner for FREE users', () => {
       expect(screen.getByTestId('upgrade-banner')).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByText(/desbloquea interpretaciones personalizadas con ia/i)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/desbloquea interpretaciones personalizadas/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /upgrade a premium/i })).toBeInTheDocument();
   });
 

--- a/frontend/src/components/features/readings/ReadingExperience.useAI.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.useAI.test.tsx
@@ -48,7 +48,7 @@ vi.mock('./UpgradeBanner', () => ({
   default: function MockUpgradeBanner({ onUpgradeClick }: { onUpgradeClick: () => void }) {
     return (
       <div data-testid="upgrade-banner">
-        <p>💎 Desbloquea interpretaciones personalizadas con IA</p>
+        <p>💎 Desbloquea interpretaciones personalizadas</p>
         <button onClick={onUpgradeClick}>Upgrade a Premium</button>
       </div>
     );

--- a/frontend/src/components/features/readings/UpgradeBanner.test.tsx
+++ b/frontend/src/components/features/readings/UpgradeBanner.test.tsx
@@ -23,9 +23,7 @@ describe('UpgradeBanner', () => {
   it('debe renderizar el banner con el mensaje correcto', () => {
     render(<UpgradeBanner onUpgradeClick={vi.fn()} />);
 
-    expect(
-      screen.getByText(/desbloquea interpretaciones personalizadas con ia/i)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/desbloquea interpretaciones personalizadas/i)).toBeInTheDocument();
     expect(screen.getByText(/upgrade a premium/i)).toBeInTheDocument();
   });
 

--- a/frontend/src/components/features/readings/UpgradeBanner.tsx
+++ b/frontend/src/components/features/readings/UpgradeBanner.tsx
@@ -12,9 +12,7 @@ export default function UpgradeBanner({ onUpgradeClick }: UpgradeBannerProps) {
         <div className="flex items-start gap-3">
           <Gem className="mt-1 h-6 w-6 flex-shrink-0" />
           <div>
-            <h3 className="mb-1 font-semibold">
-              💎 Desbloquea interpretaciones personalizadas con IA
-            </h3>
+            <h3 className="mb-1 font-semibold">💎 Desbloquea interpretaciones personalizadas</h3>
             <p className="text-sm text-white/90">
               Con Premium, obtén análisis detallados, lecturas ilimitadas y acceso a todas las
               tiradas especiales.

--- a/frontend/src/components/features/readings/UpgradeModal.test.tsx
+++ b/frontend/src/components/features/readings/UpgradeModal.test.tsx
@@ -25,7 +25,7 @@ describe('UpgradeModal', () => {
     it('should render all premium benefits', () => {
       render(<UpgradeModal open={true} onClose={mockOnClose} />);
 
-      expect(screen.getByText(/Interpretaciones con IA personalizadas/i)).toBeInTheDocument();
+      expect(screen.getByText(/Interpretaciones personalizadas y profundas/i)).toBeInTheDocument();
       expect(screen.getByText(/Todas las tiradas disponibles/i)).toBeInTheDocument();
       expect(screen.getByText(/Preguntas personalizadas/i)).toBeInTheDocument();
       expect(screen.getByText(/Sin publicidad/i)).toBeInTheDocument();
@@ -102,7 +102,7 @@ describe('UpgradeModal', () => {
 
       const benefits = screen.getAllByRole('listitem');
 
-      expect(benefits[0]).toHaveTextContent(/IA/i);
+      expect(benefits[0]).toHaveTextContent(/personalizadas y profundas/i);
       expect(benefits[1]).toHaveTextContent(/tiradas/i);
       expect(benefits[2]).toHaveTextContent(/preguntas/i);
       expect(benefits[3]).toHaveTextContent(/publicidad/i);

--- a/frontend/src/components/features/readings/UpgradeModal.tsx
+++ b/frontend/src/components/features/readings/UpgradeModal.tsx
@@ -26,7 +26,7 @@ export interface UpgradeModalProps {
 const PREMIUM_BENEFITS = [
   {
     icon: Sparkles,
-    text: 'Interpretaciones con IA personalizadas',
+    text: 'Interpretaciones personalizadas y profundas',
     description: 'Análisis profundos adaptados a tu situación',
   },
   {
@@ -76,7 +76,7 @@ export default function UpgradeModal({ open, onClose }: UpgradeModalProps) {
             Desbloquea todo el potencial del Tarot
           </DialogTitle>
           <DialogDescription className="text-center text-base">
-            Accede a interpretaciones personalizadas con IA y todas las funcionalidades avanzadas
+            Accede a interpretaciones personalizadas y todas las funcionalidades avanzadas
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/src/lib/metadata/seo.ts
+++ b/frontend/src/lib/metadata/seo.ts
@@ -79,7 +79,7 @@ export const defaultMetadata: Metadata = {
 export const homeMetadata: Metadata = {
   title: 'Tu guía espiritual',
   description:
-    'Lecturas de tarot con IA y sesiones con tarotistas profesionales. Descubre tu destino y conecta con guías espirituales.',
+    'Lecturas de tarot personalizadas y sesiones con tarotistas profesionales. Descubre tu destino y conecta con guías espirituales.',
   openGraph: {
     title: `${SITE_NAME} - Tu guía espiritual`,
     description:


### PR DESCRIPTION
This pull request focuses on removing explicit mentions of "IA" (Artificial Intelligence) from user-facing texts across the frontend, replacing them with terms like "personalizadas", "personalizadas y profundas", or "tecnología avanzada". The intent is to clarify the value proposition without referencing AI, while ensuring the distinction between FREE and PREMIUM plans remains clear. All related tests, documentation, and metadata have been updated to reflect these changes, and technical references to AI remain only in internal/admin areas.

**User-facing text and UI updates:**

- Replaced all references to "IA" or "inteligencia artificial" with neutral terms such as "personalizadas", "personalizadas y profundas", or "tecnología avanzada" in components like `UpgradeBanner`, `UpgradeModal`, `PremiumBenefitsSection`, `WhatIsTarotSection`, `LimitReachedModal`, `PremiumPreview`, and `TarotistaProfilePage`. [[1]](diffhunk://#diff-ddcdd1254b33710c5d05a45ec56f412d3de64baff8a5400a3e099ef871f4486eL15-R15) [[2]](diffhunk://#diff-b21e3de6ca6df3f83c8e6f77a2ca445fa9811d49d797cc0224eadaca95f1fd4aL29-R29) [[3]](diffhunk://#diff-1e44c37a06fac4f1a4d65941f2fd7667467c6bc09c75fce666c71460246fb8f5L10-R10) [[4]](diffhunk://#diff-d6dd718af961b35b9b5d41cb584bcc11b508fcd1aaabac326fb89e56b9785ef6L46-R47) [[5]](diffhunk://#diff-1f1d67bbb6702d1aa9f0a4ba1fbf3c139ffc0595ca442c8a081578ac7c9fbcf9L38-R38) [[6]](diffhunk://#diff-b3a6673105bd93fcebf38b362773813540abc24e6433152da081b63c61a41453L288-R288) [[7]](diffhunk://#diff-7650f19c3b73c0d31e20f53af44531dc894ed97270024d6b69b2abf2ee172bb1L26-R34) [[8]](diffhunk://#diff-7650f19c3b73c0d31e20f53af44531dc894ed97270024d6b69b2abf2ee172bb1L61-R61) [[9]](diffhunk://#diff-657edc80c03bbea38e9cf59842f571d66ac5e5a643f4716ff30728a72026a1aaL82-R82)

**Test and documentation updates:**

- Updated all relevant test files to match new wording, ensuring assertions and descriptions no longer reference "IA". All tests pass, with coverage remaining above 80%. [[1]](diffhunk://#diff-4eef6a611d9fed9316c1f4d56041ab90181b4574de4d7f83d19c1044a6003ba7L26-R26) [[2]](diffhunk://#diff-723539705aa3c9b314d2912043938739a21ebda98af223eb55491d0aae7afd75L28-R28) [[3]](diffhunk://#diff-723539705aa3c9b314d2912043938739a21ebda98af223eb55491d0aae7afd75L105-R105) [[4]](diffhunk://#diff-182f4f61d66e6152765db91f4fa60274ed4e7ae134f20e476b5c589605083b6aL17-R22) [[5]](diffhunk://#diff-e513a54800b783f58a36612db7d2b6c2bc3dd9b86293f380a6d79b24f00d7b20L61-R61) [[6]](diffhunk://#diff-9c575626960436b244698a29b8c2d4da2c835135f483fc1212c7cd318ecefebcL51-R51) [[7]](diffhunk://#diff-39b9db7241287aaa7b0f70e8a3ad70b32540f5fe5a0b330db88aed892048c5e6L53-R53) [[8]](diffhunk://#diff-f9baff9bf6038fa874746f8f2bdd9243b44335eb95871c63440e786c1b8a5443L53-R53) [[9]](diffhunk://#diff-f9baff9bf6038fa874746f8f2bdd9243b44335eb95871c63440e786c1b8a5443L263-R263) [[10]](diffhunk://#diff-e21b4d26b19fdbc743f6d2089e59778e6b849d5fdef6156129eabe3cefe9c74eL197-R197)

**Metadata and SEO improvements:**

- Updated SEO metadata in `seo.ts` to remove "IA" from descriptions, now emphasizing personalized tarot readings.

**Project documentation:**

- Marked TASK-012 as completed in `QA_TESTING_REPORT.md`, detailing the files changed, acceptance criteria, validation steps, and technical decisions (such as keeping technical AI references in internal files only).

**Technical decisions:**

- Internal/admin and TypeScript type references to AI remain unchanged, as they are not user-facing. The admin page related to AI usage is also left intact.