### PR TITLE
feature/(BUG-B-002): GET /readings no filtra lecturas eliminadas

### DIFF
--- a/PLAN_BUG_CACHE_SESSION.md
+++ b/PLAN_BUG_CACHE_SESSION.md
@@ -7,6 +7,8 @@
 
 ## 🎯 Resumen Ejecutivo
 
+**Leyenda columna "Estado":** `✅ COMPLETADO` = tarea finalizada y desplegada; `⏳ PENDIENTE` = pendiente de implementación o despliegue.
+
 **3 bugs identificados con causa raíz confirmada:**
 
 | Bug    | Problema                                  | Causa Raíz                             | Solución                                                     | Prioridad | Tiempo | Estado        |
@@ -388,15 +390,29 @@ async findById(
 }
 ```
 
-**Tests agregados:**
+3. **[PR Feedback]** Modificado método `findByShareToken()` para filtrar lecturas eliminadas compartidas:
+
+```typescript
+async findByShareToken(token: string): Promise<TarotReading | null> {
+  return this.readingRepo.findOne({
+    where: { sharedToken: token, isPublic: true, deletedAt: IsNull() },  // ✅ Ahora filtra deletedAt
+    relations: ['cards', 'deck', 'category', 'predefinedQuestion'],
+  });
+}
+```
+
+**Tests agregados/mejorados:**
 
 - Test unitario en `typeorm-reading.repository.spec.ts`:
-  - "should not return soft-deleted readings"
-  - Verifica que `findById()` incluye el filtro `deletedAt: IsNull()`
+  - "should not return soft-deleted readings" (findById)
+  - "should return null when reading is soft-deleted" (findById - comportamiento real)
+  - "should not return soft-deleted readings" (findByShareToken)
+  - Actualizados 4 tests existentes de findById para incluir filtro
+  - Actualizados 3 tests existentes de findByShareToken para incluir filtro
 
 **Validación:**
 
-- ✅ Tests unitarios: 67/67 pasando
+- ✅ Tests unitarios: 69/69 pasando (+2 nuevos)
 - ✅ Tests e2e de soft-delete: 11/20 pasando (los que fallan son por otros issues de límites de plan)
 - ✅ Lint sin errores
 - ✅ Build exitoso
@@ -405,6 +421,7 @@ async findById(
 **Resultado esperado:**
 
 - Las lecturas eliminadas ya NO serán retornadas por `findById()`
+- Las lecturas eliminadas compartidas ya NO serán accesibles vía link público
 - Queries individuales cacheadas no mostrarán lecturas eliminadas
 - Resuelve la causa raíz del Bug #1 en el backend
 

--- a/backend/tarot-app/src/modules/tarot/readings/infrastructure/repositories/typeorm-reading.repository.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/infrastructure/repositories/typeorm-reading.repository.spec.ts
@@ -226,6 +226,20 @@ describe('TypeOrmReadingRepository - BUG HUNTING', () => {
         relations: expect.any(Array) as string[],
       });
     });
+
+    it('should return null when reading is soft-deleted', async () => {
+      // Mock: Reading exists in DB but has deletedAt set
+      // TypeORM's findOne with deletedAt: IsNull() filter returns null
+      mockReadingRepository.findOne.mockResolvedValue(null);
+
+      const result = await repository.findById(1);
+
+      expect(result).toBeNull();
+      expect(mockReadingRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1, deletedAt: IsNull() },
+        relations: expect.any(Array) as string[],
+      });
+    });
   });
 
   describe('findByUserId', () => {
@@ -837,7 +851,7 @@ describe('TypeOrmReadingRepository - BUG HUNTING', () => {
 
       expect(result).toEqual(mockReading);
       expect(mockReadingRepository.findOne).toHaveBeenCalledWith({
-        where: { sharedToken: 'abc123', isPublic: true },
+        where: { sharedToken: 'abc123', isPublic: true, deletedAt: IsNull() },
         relations: ['cards', 'deck', 'category', 'predefinedQuestion'],
       });
     });
@@ -858,7 +872,7 @@ describe('TypeOrmReadingRepository - BUG HUNTING', () => {
 
       expect(result).toBeNull();
       expect(mockReadingRepository.findOne).toHaveBeenCalledWith({
-        where: { sharedToken: '', isPublic: true },
+        where: { sharedToken: '', isPublic: true, deletedAt: IsNull() },
         relations: expect.any(Array) as string[],
       });
     });
@@ -870,7 +884,7 @@ describe('TypeOrmReadingRepository - BUG HUNTING', () => {
       await repository.findByShareToken(null as unknown as string);
 
       expect(mockReadingRepository.findOne).toHaveBeenCalledWith({
-        where: { sharedToken: null, isPublic: true },
+        where: { sharedToken: null, isPublic: true, deletedAt: IsNull() },
         relations: expect.any(Array) as string[],
       });
     });
@@ -883,6 +897,18 @@ describe('TypeOrmReadingRepository - BUG HUNTING', () => {
 
       // TypeORM should escape this, but worth testing
       expect(mockReadingRepository.findOne).toHaveBeenCalled();
+    });
+
+    // BUG-B-002: Should not return soft-deleted readings via share link
+    it('should not return soft-deleted readings', async () => {
+      mockReadingRepository.findOne.mockResolvedValue(null);
+
+      await repository.findByShareToken('abc123');
+
+      expect(mockReadingRepository.findOne).toHaveBeenCalledWith({
+        where: { sharedToken: 'abc123', isPublic: true, deletedAt: IsNull() },
+        relations: expect.any(Array) as string[],
+      });
     });
   });
 

--- a/backend/tarot-app/src/modules/tarot/readings/infrastructure/repositories/typeorm-reading.repository.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/infrastructure/repositories/typeorm-reading.repository.ts
@@ -262,7 +262,7 @@ export class TypeOrmReadingRepository implements IReadingRepository {
   async findByShareToken(token: string): Promise<TarotReading | null> {
     // Optimización: Cargar solo las relaciones necesarias para lectura compartida
     return this.readingRepo.findOne({
-      where: { sharedToken: token, isPublic: true },
+      where: { sharedToken: token, isPublic: true, deletedAt: IsNull() },
       relations: ['cards', 'deck', 'category', 'predefinedQuestion'],
       // Nota: NO cargamos user para proteger privacidad en lecturas compartidas
     });


### PR DESCRIPTION
This pull request resolves Bug #1 by ensuring that soft-deleted readings are no longer returned by the `findById()` method in the backend. The changes update both the repository implementation and its tests to filter out readings where `deletedAt` is not null. Additionally, documentation has been updated to reflect the bug's completion and the technical solution.

**Backend bug fix:**

* Updated `findById()` in `typeorm-reading.repository.ts` to filter out soft-deleted readings by adding `deletedAt: IsNull()` to the query.
* Imported `IsNull` from TypeORM in both the repository and its test file to support the new query filter. [[1]](diffhunk://#diff-f27d89b5ed46c972495c86103523afd7771c2394433a159f3e076a57b53cff85L3-R3) [[2]](diffhunk://#diff-1830c59ac90c9deb408d5891e8ac7cf57a627e55657f4ed14190f74faa910665L3-R3)

**Testing improvements:**

* Modified existing tests and added a new test in `typeorm-reading.repository.spec.ts` to verify that `findById()` does not return soft-deleted readings. [[1]](diffhunk://#diff-1830c59ac90c9deb408d5891e8ac7cf57a627e55657f4ed14190f74faa910665L154-R154) [[2]](diffhunk://#diff-1830c59ac90c9deb408d5891e8ac7cf57a627e55657f4ed14190f74faa910665L169-R169) [[3]](diffhunk://#diff-1830c59ac90c9deb408d5891e8ac7cf57a627e55657f4ed14190f74faa910665L190-R190) [[4]](diffhunk://#diff-1830c59ac90c9deb408d5891e8ac7cf57a627e55657f4ed14190f74faa910665L213-R228)

**Documentation updates:**

* Updated the bug tracking table in `PLAN_BUG_CACHE_SESSION.md` to mark Bug #1 as completed and added a new "Estado" column.
* Added a detailed summary of the implemented solution and validation steps for Bug #1 in the documentation.
* Marked Bug-B-002 as completed in the documentation.