### PR TITLE
fix(capabilities): use string date comparison for daily card limit check

### DIFF
--- a/PLAN_BUG_CACHE_SESSION.md
+++ b/PLAN_BUG_CACHE_SESSION.md
@@ -970,3 +970,73 @@ cd frontend && npm test -- useReadings.test --run
 **Después:** Implementar BUG-F-003 (10 minutos) → **TODOS LOS BUGS CRÍTICOS RESUELTOS** ✅
 
 **Total tiempo de fix crítico:** ~25 minutos
+
+---
+
+## 📋 Bugs Adicionales Descubiertos y Resueltos
+
+### BUG-CAP-001: Carta del día no se reseteaba para usuarios registrados ✅ COMPLETADO
+
+**Fecha:** 15 Enero 2026
+**Rama:** `bugfix/BUG-CAP-001-daily-card-capabilities-date-comparison`
+**Estado:** ✅ COMPLETADO
+
+**Descripción:** Usuarios registrados veían "límite alcanzado" para carta del día aunque su última carta era de ayer.
+
+**Síntomas:**
+- Usuario entra a /carta-del-dia
+- Modal de "límite alcanzado" aparece
+- En historial, última carta tiene fecha de ayer
+- El problema NO afectaba a usuarios anónimos
+
+**Causa Raíz:**
+
+En `UserCapabilitiesService.getCapabilities()`, la consulta usaba:
+```typescript
+// ❌ INCORRECTO - MoreThanOrEqual con Date object en columna DATE
+const today = new Date();
+today.setUTCHours(0, 0, 0, 0);
+readingDate: MoreThanOrEqual(today)
+```
+
+Esto causaba problemas porque:
+- La columna `reading_date` es tipo DATE (solo fecha: "2026-01-15")
+- Se comparaba con un `Date` object (timestamp: "2026-01-15T00:00:00.000Z")
+- PostgreSQL hacía conversión implícita inconsistente
+
+**Solución:**
+
+Usar `createQueryBuilder` con comparación de string, igual que el `CheckUsageLimitGuard`:
+```typescript
+// ✅ CORRECTO - String comparison para columnas DATE
+const todayStr = getTodayUTCDateString(); // "2026-01-15"
+await this.dailyReadingRepository
+  .createQueryBuilder('daily_reading')
+  .where('daily_reading.user_id = :userId', { userId })
+  .andWhere('daily_reading.reading_date = :date', { date: todayStr })
+  .getOne();
+```
+
+**Archivos modificados:**
+- `backend/tarot-app/src/modules/users/application/services/user-capabilities.service.ts`
+- `backend/tarot-app/src/modules/users/application/services/user-capabilities.service.spec.ts`
+
+**Tests agregados:**
+- "should allow daily card creation when last reading was yesterday"
+- "should use createQueryBuilder with string date comparison for DATE column"
+- "should block daily card creation when reading exists for today"
+
+**Validación:**
+- ✅ 17/17 tests unitarios pasando
+- ✅ 2224/2224 tests totales pasando
+- ✅ Tests e2e daily-reading pasando (21/21)
+- ✅ Tests e2e users pasando (63/63)
+- ✅ Lint, format, build exitosos
+- ✅ Validación de arquitectura exitosa
+
+**Documentación actualizada:**
+- `docs/USAGE_LIMITS_SYSTEM.md` - Agregada sección "BUG-CAP-001"
+
+**Regla importante para futuros desarrollos:**
+- Para columnas tipo DATE: usar `getTodayUTCDateString()` con igualdad de string
+- Para columnas tipo TIMESTAMP: usar `getStartOfTodayUTC()` con `MoreThanOrEqual`

--- a/backend/tarot-app/src/modules/users/application/services/user-capabilities.service.spec.ts
+++ b/backend/tarot-app/src/modules/users/application/services/user-capabilities.service.spec.ts
@@ -18,6 +18,13 @@ describe('UserCapabilitiesService', () => {
   let dailyReadingRepository: jest.Mocked<Repository<DailyReading>>;
   let tarotReadingRepository: jest.Mocked<Repository<TarotReading>>;
 
+  // Mock for createQueryBuilder chain
+  let mockQueryBuilder: {
+    where: jest.Mock;
+    andWhere: jest.Mock;
+    getOne: jest.Mock;
+  };
+
   const mockUser = {
     id: 1,
     email: 'test@example.com',
@@ -40,6 +47,13 @@ describe('UserCapabilitiesService', () => {
   };
 
   beforeEach(async () => {
+    // Setup mock query builder chain
+    mockQueryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(null),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UserCapabilitiesService,
@@ -66,6 +80,7 @@ describe('UserCapabilitiesService', () => {
           useValue: {
             findOne: jest.fn(),
             count: jest.fn(),
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
           },
         },
         {
@@ -125,7 +140,8 @@ describe('UserCapabilitiesService', () => {
         const fingerprint = 'abc123def456';
 
         // Mock: anonymous user has already used daily card (reading exists)
-        dailyReadingRepository.findOne.mockResolvedValue({
+        // BUG-CAP-001: Now uses createQueryBuilder instead of findOne
+        mockQueryBuilder.getOne.mockResolvedValue({
           id: 1,
           anonymousFingerprint: fingerprint,
           readingDate: new Date(),
@@ -133,7 +149,9 @@ describe('UserCapabilitiesService', () => {
 
         const result = await service.getCapabilities(null, fingerprint);
 
-        expect(dailyReadingRepository.findOne).toHaveBeenCalled();
+        expect(dailyReadingRepository.createQueryBuilder).toHaveBeenCalledWith(
+          'daily_reading',
+        );
         expect(result.dailyCard.used).toBe(1);
         expect(result.dailyCard.canUse).toBe(false);
         expect(result.canCreateDailyReading).toBe(false);
@@ -143,7 +161,7 @@ describe('UserCapabilitiesService', () => {
         const fingerprint = 'abc123def456';
 
         // Mock: anonymous user has NOT used daily card (no reading found)
-        dailyReadingRepository.findOne.mockResolvedValue(null);
+        mockQueryBuilder.getOne.mockResolvedValue(null);
 
         const result = await service.getCapabilities(null, fingerprint);
 
@@ -153,7 +171,7 @@ describe('UserCapabilitiesService', () => {
       });
 
       it('should not call user services when userId is null', async () => {
-        dailyReadingRepository.findOne.mockResolvedValue(null);
+        mockQueryBuilder.getOne.mockResolvedValue(null);
 
         await service.getCapabilities(null, 'fingerprint123');
 
@@ -170,7 +188,8 @@ describe('UserCapabilitiesService', () => {
           mockPlanConfig as any,
         );
         // No daily reading found (hasn't used daily card)
-        dailyReadingRepository.findOne.mockResolvedValue(null);
+        // BUG-CAP-001: Now uses createQueryBuilder
+        mockQueryBuilder.getOne.mockResolvedValue(null);
         // No tarot readings used
         tarotReadingRepository.count.mockResolvedValue(0);
 
@@ -202,8 +221,10 @@ describe('UserCapabilitiesService', () => {
         expect(planConfigService.findByPlanType).toHaveBeenCalledWith(
           UserPlan.FREE,
         );
-        // Should check daily_reading table
-        expect(dailyReadingRepository.findOne).toHaveBeenCalled();
+        // Should check daily_reading table using createQueryBuilder
+        expect(dailyReadingRepository.createQueryBuilder).toHaveBeenCalledWith(
+          'daily_reading',
+        );
         // Should check tarot_reading table (not usageLimitsService)
         expect(tarotReadingRepository.count).toHaveBeenCalled();
       });
@@ -214,12 +235,13 @@ describe('UserCapabilitiesService', () => {
           mockPlanConfig as any,
         );
         // Daily reading exists (already used today)
-        dailyReadingRepository.findOne.mockResolvedValue({
+        // BUG-CAP-001: Now uses createQueryBuilder
+        mockQueryBuilder.getOne.mockResolvedValue({
           id: 1,
           userId: 1,
           readingDate: new Date(),
         } as DailyReading);
-        usageLimitsService.getUsage.mockResolvedValue(0);
+        tarotReadingRepository.count.mockResolvedValue(0);
 
         const result = await service.getCapabilities(1);
 
@@ -237,7 +259,7 @@ describe('UserCapabilitiesService', () => {
         planConfigService.findByPlanType.mockResolvedValue(
           mockPlanConfig as any,
         );
-        dailyReadingRepository.findOne.mockResolvedValue(null);
+        mockQueryBuilder.getOne.mockResolvedValue(null);
         // Tarot reading used once (limit = 1)
         tarotReadingRepository.count.mockResolvedValue(1);
 
@@ -260,12 +282,13 @@ describe('UserCapabilitiesService', () => {
         // Edge case: user has TWO daily readings somehow (shouldn't happen but test edge case)
         // Since we query daily_reading directly, we can only get 0 or 1
         // So this test is for when daily reading exists
-        dailyReadingRepository.findOne.mockResolvedValue({
+        // BUG-CAP-001: Now uses createQueryBuilder
+        mockQueryBuilder.getOne.mockResolvedValue({
           id: 1,
           userId: 1,
           readingDate: new Date(),
         } as DailyReading);
-        usageLimitsService.getUsage.mockResolvedValue(0);
+        tarotReadingRepository.count.mockResolvedValue(0);
 
         const result = await service.getCapabilities(1);
 
@@ -302,7 +325,8 @@ describe('UserCapabilitiesService', () => {
           premiumPlanConfig as any,
         );
         // Premium user has used daily card multiple times (but unlimited)
-        dailyReadingRepository.findOne.mockResolvedValue({
+        // BUG-CAP-001: Now uses createQueryBuilder
+        mockQueryBuilder.getOne.mockResolvedValue({
           id: 5,
           userId: 1,
           readingDate: new Date(),
@@ -339,7 +363,7 @@ describe('UserCapabilitiesService', () => {
         planConfigService.findByPlanType.mockResolvedValue(
           premiumPlanConfig as any,
         );
-        dailyReadingRepository.findOne.mockResolvedValue(null);
+        mockQueryBuilder.getOne.mockResolvedValue(null);
         tarotReadingRepository.count.mockResolvedValue(3); // Limit reached
 
         const result = await service.getCapabilities(1);
@@ -377,10 +401,81 @@ describe('UserCapabilitiesService', () => {
       });
     });
 
+    describe('Daily Card Date Comparison (BUG-CAP-001)', () => {
+      it('should allow daily card creation when last reading was yesterday', async () => {
+        // This test verifies the fix for BUG-CAP-001:
+        // User has a daily reading from YESTERDAY, should be able to create TODAY
+        usersService.findById.mockResolvedValue(mockUser as any);
+        planConfigService.findByPlanType.mockResolvedValue(
+          mockPlanConfig as any,
+        );
+
+        // Simulate: no reading found for today (yesterday's reading should NOT match)
+        // The createQueryBuilder with string date comparison should return null
+        mockQueryBuilder.getOne.mockResolvedValue(null);
+        tarotReadingRepository.count.mockResolvedValue(0);
+
+        const result = await service.getCapabilities(1);
+
+        // User should be able to create daily reading
+        expect(result.canCreateDailyReading).toBe(true);
+        expect(result.dailyCard.canUse).toBe(true);
+        expect(result.dailyCard.used).toBe(0);
+      });
+
+      it('should use createQueryBuilder with string date comparison for DATE column', async () => {
+        // This test ensures the query uses createQueryBuilder with string comparison
+        // The fix uses getTodayUTCDateString() format: 'YYYY-MM-DD'
+        usersService.findById.mockResolvedValue(mockUser as any);
+        planConfigService.findByPlanType.mockResolvedValue(
+          mockPlanConfig as any,
+        );
+        mockQueryBuilder.getOne.mockResolvedValue(null);
+        tarotReadingRepository.count.mockResolvedValue(0);
+
+        await service.getCapabilities(1);
+
+        // Verify createQueryBuilder was called instead of findOne
+        expect(dailyReadingRepository.createQueryBuilder).toHaveBeenCalledWith(
+          'daily_reading',
+        );
+        // Verify the query chain was called correctly
+        expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+          'daily_reading.user_id = :userId',
+          { userId: 1 },
+        );
+        expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+          'daily_reading.reading_date = :date',
+          expect.objectContaining({ date: expect.any(String) }),
+        );
+        expect(mockQueryBuilder.getOne).toHaveBeenCalled();
+      });
+
+      it('should block daily card creation when reading exists for today', async () => {
+        usersService.findById.mockResolvedValue(mockUser as any);
+        planConfigService.findByPlanType.mockResolvedValue(
+          mockPlanConfig as any,
+        );
+
+        // Today's reading exists
+        mockQueryBuilder.getOne.mockResolvedValue({
+          id: 1,
+          userId: 1,
+          readingDate: new Date(), // Today
+        } as DailyReading);
+        tarotReadingRepository.count.mockResolvedValue(0);
+
+        const result = await service.getCapabilities(1);
+
+        expect(result.canCreateDailyReading).toBe(false);
+        expect(result.dailyCard.canUse).toBe(false);
+        expect(result.dailyCard.used).toBe(1);
+      });
+    });
+
     describe('resetAt calculation', () => {
       it('should return next midnight UTC', async () => {
-        dailyReadingRepository.findOne.mockResolvedValue(null);
-
+        // No fingerprint provided, so no query is made
         const result = await service.getCapabilities(null, null);
         const resetDate = new Date(result.dailyCard.resetAt);
 
@@ -403,7 +498,7 @@ describe('UserCapabilitiesService', () => {
         planConfigService.findByPlanType.mockResolvedValue(
           mockPlanConfig as any,
         );
-        dailyReadingRepository.findOne.mockResolvedValue(null);
+        mockQueryBuilder.getOne.mockResolvedValue(null);
         tarotReadingRepository.count.mockResolvedValue(0);
 
         const result = await service.getCapabilities(1);

--- a/backend/tarot-app/src/modules/users/application/services/user-capabilities.service.ts
+++ b/backend/tarot-app/src/modules/users/application/services/user-capabilities.service.ts
@@ -11,6 +11,10 @@ import {
   UserPlanType,
 } from '../dto/user-capabilities.dto';
 import { UserPlan } from '../../entities/user.entity';
+import {
+  getTodayUTCDateString,
+  getStartOfTodayUTC,
+} from '../../../../common/utils/date.utils';
 
 @Injectable()
 export class UserCapabilitiesService {
@@ -50,24 +54,26 @@ export class UserCapabilitiesService {
 
     // Obtener uso actual de carta del día consultando directamente daily_reading
     // Esto garantiza consistencia con la tabla real de lecturas
-    const today = new Date();
-    today.setUTCHours(0, 0, 0, 0);
+    // BUG-CAP-001 FIX: Use string comparison for DATE column (not MoreThanOrEqual with Date object)
+    // The readingDate column is type DATE (YYYY-MM-DD), so we must use string equality
+    const todayStr = getTodayUTCDateString();
 
-    const existingDailyReading = await this.dailyReadingRepository.findOne({
-      where: {
-        userId,
-        readingDate: MoreThanOrEqual(today),
-      },
-    });
+    const existingDailyReading = await this.dailyReadingRepository
+      .createQueryBuilder('daily_reading')
+      .where('daily_reading.user_id = :userId', { userId })
+      .andWhere('daily_reading.reading_date = :date', { date: todayStr })
+      .getOne();
 
     const dailyCardUsage = existingDailyReading ? 1 : 0;
 
     // Obtener uso de tiradas de tarot consultando directamente la tabla tarot_reading
     // Esto garantiza consistencia con la tabla real de lecturas
+    // For TIMESTAMP columns, MoreThanOrEqual with Date object works correctly
+    const startOfToday = getStartOfTodayUTC();
     const tarotReadingsCount = await this.tarotReadingRepository.count({
       where: {
         user: { id: userId },
-        createdAt: MoreThanOrEqual(today),
+        createdAt: MoreThanOrEqual(startOfToday),
         deletedAt: IsNull(), // Solo contar lecturas no eliminadas
       },
     });
@@ -130,15 +136,16 @@ export class UserCapabilitiesService {
     // Solo verificar si tenemos fingerprint válido
     if (fingerprint && fingerprint.length > 0) {
       // Query the daily_reading table directly for today's reading
-      const today = new Date();
-      today.setUTCHours(0, 0, 0, 0);
+      // BUG-CAP-001 FIX: Use string comparison for DATE column
+      const todayStr = getTodayUTCDateString();
 
-      const existingReading = await this.dailyReadingRepository.findOne({
-        where: {
-          anonymousFingerprint: fingerprint,
-          readingDate: MoreThanOrEqual(today),
-        },
-      });
+      const existingReading = await this.dailyReadingRepository
+        .createQueryBuilder('daily_reading')
+        .where('daily_reading.anonymous_fingerprint = :fingerprint', {
+          fingerprint,
+        })
+        .andWhere('daily_reading.reading_date = :date', { date: todayStr })
+        .getOne();
 
       if (existingReading) {
         dailyCardUsed = 1;

--- a/docs/USAGE_LIMITS_SYSTEM.md
+++ b/docs/USAGE_LIMITS_SYSTEM.md
@@ -350,8 +350,37 @@ describe('parseDateString', () => {
 1. El servidor está en timezone diferente al UTC
 2. La columna de fecha usa tipo incorrecto (TIMESTAMP vs DATE)
 3. La consulta no usa las funciones centralizadas
+4. **BUG-CAP-001 (resuelto):** Se usaba `MoreThanOrEqual(Date)` en columnas DATE
 
 **Solución:** Verificar que se usen `getTodayUTCDateString()` y `getStartOfTodayUTC()`.
+
+### 4. BUG-CAP-001: Carta del día no se reseteaba para usuarios registrados
+
+**Problema:** Usuarios registrados veían "límite alcanzado" para carta del día aunque su última carta era de ayer.
+
+**Causa:** En `UserCapabilitiesService.getCapabilities()`, la consulta usaba:
+```typescript
+// ❌ INCORRECTO - MoreThanOrEqual con Date object en columna DATE
+readingDate: MoreThanOrEqual(today) // today = Date object
+```
+
+Esto causaba problemas de comparación entre `Date` (TIMESTAMP) y columna `reading_date` (DATE).
+
+**Solución (2026-01-15):** Usar `createQueryBuilder` con comparación de string:
+```typescript
+// ✅ CORRECTO - String comparison para columnas DATE
+const todayStr = getTodayUTCDateString(); // "2026-01-15"
+await this.dailyReadingRepository
+  .createQueryBuilder('daily_reading')
+  .where('daily_reading.user_id = :userId', { userId })
+  .andWhere('daily_reading.reading_date = :date', { date: todayStr })
+  .getOne();
+```
+
+**Archivos afectados:**
+- `backend/tarot-app/src/modules/users/application/services/user-capabilities.service.ts`
+
+**Regla importante:** Para columnas tipo DATE siempre usar `getTodayUTCDateString()` con igualdad de string. Para columnas tipo TIMESTAMP usar `getStartOfTodayUTC()` con `MoreThanOrEqual`.
 
 ### 3. Usuario Anónimo Tiene Límite Incorrecto
 


### PR DESCRIPTION
BUG-CAP-001: Users saw "limit reached" for daily card even when their last card was from yesterday. The issue was in UserCapabilitiesService which used MoreThanOrEqual(Date) on a DATE column, causing PostgreSQL to do implicit type conversion that failed inconsistently.

Root cause:
- reading_date column is type DATE ("2026-01-15")
- Query used MoreThanOrEqual(today) where today is a Date object
- PostgreSQL's implicit DATE vs TIMESTAMP comparison was unreliable

Solution:
- Use createQueryBuilder with string equality comparison
- Use getTodayUTCDateString() for DATE columns (returns "YYYY-MM-DD")
- Use getStartOfTodayUTC() for TIMESTAMP columns (returns Date object)

This aligns with how CheckUsageLimitGuard already does the comparison correctly.

Files changed:
- user-capabilities.service.ts: Fixed queries for both authenticated and anonymous users
- user-capabilities.service.spec.ts: Updated tests to use createQueryBuilder mock
- USAGE_LIMITS_SYSTEM.md: Documented the bug and solution
- PLAN_BUG_CACHE_SESSION.md: Added BUG-CAP-001 to resolved bugs