### PR TITLE
feat(tarot): T-FR-B02 - Capa de Aplicacion: CardFreeInterpretationService, validateCategoryAccess y flujo FREE en CreateReadingUseCase

### DIFF
--- a/backend/tarot-app/src/modules/tarot/cards/card-free-interpretation.service.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/cards/card-free-interpretation.service.spec.ts
@@ -1,0 +1,246 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CardFreeInterpretationService } from './card-free-interpretation.service';
+import { ICardFreeInterpretationRepository } from './domain/interfaces/card-free-interpretation-repository.interface';
+import { CardFreeInterpretation } from './entities/card-free-interpretation.entity';
+import { TarotCard } from './entities/tarot-card.entity';
+
+type CardPosition = { cardId: number; position: string; isReversed: boolean };
+
+const buildCard = (id: number, overrides: Partial<TarotCard> = {}): TarotCard =>
+  ({
+    id,
+    name: `Carta ${id}`,
+    number: id,
+    category: 'arcanos_mayores',
+    imageUrl: '',
+    reversedImageUrl: null,
+    meaningUpright: `Significado derecho de carta ${id}`,
+    meaningReversed: `Significado invertido de carta ${id}`,
+    description: '',
+    keywords: '',
+    deckId: 1,
+    dailyFreeUpright: null,
+    dailyFreeReversed: null,
+    deck: { id: 1, name: 'Test Deck' } as TarotCard['deck'],
+    readings: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }) as TarotCard;
+
+const buildInterpretation = (
+  cardId: number,
+  categoryId: number,
+  orientation: 'upright' | 'reversed',
+  content: string,
+): CardFreeInterpretation =>
+  ({
+    id: Math.random(),
+    cardId,
+    categoryId,
+    orientation,
+    content,
+    card: { id: cardId } as CardFreeInterpretation['card'],
+    category: { id: categoryId } as CardFreeInterpretation['category'],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }) as CardFreeInterpretation;
+
+describe('CardFreeInterpretationService', () => {
+  let service: CardFreeInterpretationService;
+  let mockRepo: jest.Mocked<ICardFreeInterpretationRepository>;
+
+  const mockCards: TarotCard[] = [buildCard(1), buildCard(3), buildCard(7)];
+
+  const mockPositions: CardPosition[] = [
+    { cardId: 1, position: 'pasado', isReversed: false },
+    { cardId: 3, position: 'presente', isReversed: true },
+    { cardId: 7, position: 'futuro', isReversed: false },
+  ];
+
+  const categoryId = 2;
+
+  beforeEach(async () => {
+    mockRepo = {
+      findByCardsAndCategory: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CardFreeInterpretationService,
+        {
+          provide: 'ICardFreeInterpretationRepository',
+          useValue: mockRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CardFreeInterpretationService>(
+      CardFreeInterpretationService,
+    );
+    jest.clearAllMocks();
+  });
+
+  describe('findByCardsAndCategory', () => {
+    it('debería retornar un mapa indexado por posición con los textos encontrados', async () => {
+      mockRepo.findByCardsAndCategory.mockResolvedValue([
+        buildInterpretation(1, categoryId, 'upright', 'El Loco en amor...'),
+        buildInterpretation(
+          3,
+          categoryId,
+          'reversed',
+          'La Torre invertida en amor...',
+        ),
+        buildInterpretation(7, categoryId, 'upright', 'El Sol en amor...'),
+      ]);
+
+      const result = await service.findByCardsAndCategory(
+        mockCards,
+        mockPositions,
+        categoryId,
+      );
+
+      // pasado: cardId=1, upright → 'El Loco en amor...'
+      expect(result[0]).toEqual({ content: 'El Loco en amor...' });
+      // presente: cardId=3, reversed → 'La Torre invertida en amor...'
+      expect(result[1]).toEqual({ content: 'La Torre invertida en amor...' });
+      // futuro: cardId=7, upright → 'El Sol en amor...'
+      expect(result[2]).toEqual({ content: 'El Sol en amor...' });
+    });
+
+    it('debería llamar al repositorio con los cardIds, orientaciones y categoryId correctos', async () => {
+      mockRepo.findByCardsAndCategory.mockResolvedValue([]);
+
+      await service.findByCardsAndCategory(
+        mockCards,
+        mockPositions,
+        categoryId,
+      );
+
+      expect(mockRepo.findByCardsAndCategory).toHaveBeenCalledWith(
+        [1, 3, 7],
+        ['upright', 'reversed', 'upright'],
+        categoryId,
+      );
+    });
+
+    it('debería usar meaningUpright como fallback cuando no hay interpretación pre-escrita para una carta upright', async () => {
+      // Solo retorna interpretación para la carta 1, no para 3 y 7
+      mockRepo.findByCardsAndCategory.mockResolvedValue([
+        buildInterpretation(1, categoryId, 'upright', 'El Loco en amor...'),
+      ]);
+
+      const result = await service.findByCardsAndCategory(
+        mockCards,
+        mockPositions,
+        categoryId,
+      );
+
+      // pasado: tiene interpretación
+      expect(result[0]).toEqual({ content: 'El Loco en amor...' });
+      // presente: cardId=3, reversed → usa meaningReversed de la carta (fallback)
+      expect(result[1]).toEqual({
+        content: 'Significado invertido de carta 3',
+      });
+      // futuro: cardId=7, upright → usa meaningUpright de la carta (fallback)
+      expect(result[2]).toEqual({ content: 'Significado derecho de carta 7' });
+    });
+
+    it('debería usar meaningReversed como fallback cuando la carta es reversed y no hay interpretación', async () => {
+      mockRepo.findByCardsAndCategory.mockResolvedValue([]);
+
+      const positionsAllReversed: CardPosition[] = [
+        { cardId: 1, position: 'pasado', isReversed: true },
+      ];
+      const cardsSubset = [buildCard(1)];
+
+      const result = await service.findByCardsAndCategory(
+        cardsSubset,
+        positionsAllReversed,
+        categoryId,
+      );
+
+      expect(result[0]).toEqual({
+        content: 'Significado invertido de carta 1',
+      });
+    });
+
+    it('debería manejar correctamente una tirada de 1 carta', async () => {
+      const singleCard = [buildCard(5)];
+      const singlePosition: CardPosition[] = [
+        { cardId: 5, position: 'carta', isReversed: false },
+      ];
+
+      mockRepo.findByCardsAndCategory.mockResolvedValue([
+        buildInterpretation(
+          5,
+          categoryId,
+          'upright',
+          'Texto único de la carta 5',
+        ),
+      ]);
+
+      const result = await service.findByCardsAndCategory(
+        singleCard,
+        singlePosition,
+        categoryId,
+      );
+
+      expect(Object.keys(result)).toHaveLength(1);
+      expect(result[0]).toEqual({ content: 'Texto único de la carta 5' });
+    });
+
+    it('debería indexar por posición (índice 0..N-1) en el orden de cardPositions', async () => {
+      const cards = [buildCard(10), buildCard(20)];
+      const positions: CardPosition[] = [
+        { cardId: 10, position: 'primera', isReversed: false },
+        { cardId: 20, position: 'segunda', isReversed: false },
+      ];
+
+      mockRepo.findByCardsAndCategory.mockResolvedValue([
+        buildInterpretation(10, categoryId, 'upright', 'Texto carta 10'),
+        buildInterpretation(20, categoryId, 'upright', 'Texto carta 20'),
+      ]);
+
+      const result = await service.findByCardsAndCategory(
+        cards,
+        positions,
+        categoryId,
+      );
+
+      expect(result[0]).toEqual({ content: 'Texto carta 10' });
+      expect(result[1]).toEqual({ content: 'Texto carta 20' });
+    });
+
+    it('debería manejar cartas duplicadas en diferentes posiciones', async () => {
+      // Tirada donde la misma carta aparece dos veces (improbable pero posible)
+      const cards = [buildCard(1), buildCard(1)];
+      const positions: CardPosition[] = [
+        { cardId: 1, position: 'primera', isReversed: false },
+        { cardId: 1, position: 'segunda', isReversed: true },
+      ];
+
+      mockRepo.findByCardsAndCategory.mockResolvedValue([
+        buildInterpretation(1, categoryId, 'upright', 'Carta 1 upright'),
+        buildInterpretation(1, categoryId, 'reversed', 'Carta 1 reversed'),
+      ]);
+
+      const result = await service.findByCardsAndCategory(
+        cards,
+        positions,
+        categoryId,
+      );
+
+      expect(result[0]).toEqual({ content: 'Carta 1 upright' });
+      expect(result[1]).toEqual({ content: 'Carta 1 reversed' });
+    });
+
+    it('debería retornar objeto vacío cuando no hay cartas ni posiciones', async () => {
+      const result = await service.findByCardsAndCategory([], [], categoryId);
+
+      expect(result).toEqual({});
+      // El repositorio NO es llamado: guard clause por arrays vacíos
+      expect(mockRepo.findByCardsAndCategory).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/tarot-app/src/modules/tarot/cards/card-free-interpretation.service.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/cards/card-free-interpretation.service.spec.ts
@@ -108,7 +108,7 @@ describe('CardFreeInterpretationService', () => {
       expect(result[2]).toEqual({ content: 'El Sol en amor...' });
     });
 
-    it('debería llamar al repositorio con los cardIds, orientaciones y categoryId correctos', async () => {
+    it('debería llamar al repositorio con los cardIds, orientaciones y categoryId correctos (deduplicados)', async () => {
       mockRepo.findByCardsAndCategory.mockResolvedValue([]);
 
       await service.findByCardsAndCategory(
@@ -117,9 +117,34 @@ describe('CardFreeInterpretationService', () => {
         categoryId,
       );
 
+      // cardIds [1,3,7] ya son únicos; orientaciones ['upright','reversed','upright'] → dedup → ['upright','reversed']
       expect(mockRepo.findByCardsAndCategory).toHaveBeenCalledWith(
         [1, 3, 7],
-        ['upright', 'reversed', 'upright'],
+        ['upright', 'reversed'],
+        categoryId,
+      );
+    });
+
+    it('debería deduplicar cardIds duplicados antes de llamar al repositorio', async () => {
+      const cardsWithDup = [buildCard(1), buildCard(1), buildCard(3)];
+      const positionsWithDup: CardPosition[] = [
+        { cardId: 1, position: 'primera', isReversed: false },
+        { cardId: 1, position: 'segunda', isReversed: false },
+        { cardId: 3, position: 'tercera', isReversed: false },
+      ];
+
+      mockRepo.findByCardsAndCategory.mockResolvedValue([]);
+
+      await service.findByCardsAndCategory(
+        cardsWithDup,
+        positionsWithDup,
+        categoryId,
+      );
+
+      // cardIds [1,1,3] → dedup → [1,3]; orientaciones ['upright','upright','upright'] → dedup → ['upright']
+      expect(mockRepo.findByCardsAndCategory).toHaveBeenCalledWith(
+        [1, 3],
+        ['upright'],
         categoryId,
       );
     });

--- a/backend/tarot-app/src/modules/tarot/cards/card-free-interpretation.service.ts
+++ b/backend/tarot-app/src/modules/tarot/cards/card-free-interpretation.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, Inject } from '@nestjs/common';
+import {
+  ICardFreeInterpretationRepository,
+  CARD_FREE_INTERPRETATION_REPOSITORY,
+} from './domain/interfaces/card-free-interpretation-repository.interface';
+import { TarotCard } from './entities/tarot-card.entity';
+
+type CardPosition = { cardId: number; position: string; isReversed: boolean };
+
+export type FreeInterpretationsMap = Record<number, { content: string }>;
+
+@Injectable()
+export class CardFreeInterpretationService {
+  constructor(
+    @Inject(CARD_FREE_INTERPRETATION_REPOSITORY)
+    private readonly repo: ICardFreeInterpretationRepository,
+  ) {}
+
+  /**
+   * Busca interpretaciones pre-escritas para un conjunto de cartas con sus orientaciones
+   * y una categoría dada. Retorna un mapa indexado por posición (0..N-1) donde cada
+   * entrada contiene el texto a mostrar al usuario FREE.
+   *
+   * Si no existe una interpretación pre-escrita para una combinación
+   * (carta + categoría + orientación), cae al fallback: meaningUpright o meaningReversed
+   * de la entidad TarotCard según la orientación correspondiente.
+   *
+   * @param cards - Cartas de tarot validadas (en el mismo orden que cardPositions)
+   * @param cardPositions - Posiciones y orientaciones de cada carta
+   * @param categoryId - ID de la categoría elegida por el usuario FREE
+   * @returns Mapa { [positionIndex]: { content: string } }
+   */
+  async findByCardsAndCategory(
+    cards: TarotCard[],
+    cardPositions: CardPosition[],
+    categoryId: number,
+  ): Promise<FreeInterpretationsMap> {
+    if (cards.length === 0 || cardPositions.length === 0) {
+      return {};
+    }
+
+    const cardIds = cardPositions.map((p) => p.cardId);
+    const orientations = cardPositions.map((p): 'upright' | 'reversed' =>
+      p.isReversed ? 'reversed' : 'upright',
+    );
+
+    const interpretations = await this.repo.findByCardsAndCategory(
+      cardIds,
+      orientations,
+      categoryId,
+    );
+
+    // Indexar las interpretaciones encontradas por cardId + orientation para lookup O(1)
+    const interpretationIndex = new Map<string, string>();
+    for (const interp of interpretations) {
+      const key = `${interp.cardId}::${interp.orientation}`;
+      interpretationIndex.set(key, interp.content);
+    }
+
+    // Construir mapa indexado por posición
+    const cardById = new Map<number, TarotCard>(cards.map((c) => [c.id, c]));
+
+    const result: FreeInterpretationsMap = {};
+
+    for (let i = 0; i < cardPositions.length; i++) {
+      const pos = cardPositions[i];
+      const orientation: 'upright' | 'reversed' = pos.isReversed
+        ? 'reversed'
+        : 'upright';
+      const key = `${pos.cardId}::${orientation}`;
+
+      const foundContent = interpretationIndex.get(key);
+
+      if (foundContent !== undefined) {
+        result[i] = { content: foundContent };
+      } else {
+        // Fallback: significado crudo de la carta
+        const card = cardById.get(pos.cardId);
+        const fallbackContent =
+          card !== undefined
+            ? pos.isReversed
+              ? card.meaningReversed
+              : card.meaningUpright
+            : '';
+        result[i] = { content: fallbackContent };
+      }
+    }
+
+    return result;
+  }
+}

--- a/backend/tarot-app/src/modules/tarot/cards/card-free-interpretation.service.ts
+++ b/backend/tarot-app/src/modules/tarot/cards/card-free-interpretation.service.ts
@@ -44,9 +44,12 @@ export class CardFreeInterpretationService {
       p.isReversed ? 'reversed' : 'upright',
     );
 
+    const uniqueCardIds = Array.from(new Set(cardIds));
+    const uniqueOrientations = Array.from(new Set(orientations));
+
     const interpretations = await this.repo.findByCardsAndCategory(
-      cardIds,
-      orientations,
+      uniqueCardIds,
+      uniqueOrientations,
       categoryId,
     );
 

--- a/backend/tarot-app/src/modules/tarot/cards/cards.module.ts
+++ b/backend/tarot-app/src/modules/tarot/cards/cards.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CardsController } from './cards.controller';
 import { CardsService } from './cards.service';
 import { CardMeaningService } from './card-meaning.service';
+import { CardFreeInterpretationService } from './card-free-interpretation.service';
 import { TarotCard } from './entities/tarot-card.entity';
 import { CardFreeInterpretation } from './entities/card-free-interpretation.entity';
 import { TarotDeck } from '../decks/entities/tarot-deck.entity';
@@ -23,6 +24,7 @@ import { CARD_FREE_INTERPRETATION_REPOSITORY } from './domain/interfaces/card-fr
   providers: [
     CardsService,
     CardMeaningService,
+    CardFreeInterpretationService,
     {
       provide: CARD_FREE_INTERPRETATION_REPOSITORY,
       useClass: TypeOrmCardFreeInterpretationRepository,
@@ -31,6 +33,7 @@ import { CARD_FREE_INTERPRETATION_REPOSITORY } from './domain/interfaces/card-fr
   exports: [
     CardsService,
     CardMeaningService,
+    CardFreeInterpretationService,
     TypeOrmModule,
     CARD_FREE_INTERPRETATION_REPOSITORY,
   ],

--- a/backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.spec.ts
@@ -11,6 +11,8 @@ import { ReadingValidatorService } from './reading-validator.service';
 import { TarotReading } from '../../entities/tarot-reading.entity';
 import { User, UserPlan } from '../../../../users/entities/user.entity';
 import { PlanConfigService } from '../../../../plan-config/plan-config.service';
+import { CategoriesService } from '../../../../categories/categories.service';
+import { ReadingCategory } from '../../../../categories/entities/reading-category.entity';
 
 // Helper types for test cases
 type PartialUser = Partial<User> & { id: number; plan?: UserPlan | null };
@@ -36,6 +38,10 @@ describe('ReadingValidatorService - BUG HUNTING', () => {
     getReadingsLimit: jest.fn(),
   };
 
+  const mockCategoriesService = {
+    findOne: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -51,6 +57,10 @@ describe('ReadingValidatorService - BUG HUNTING', () => {
         {
           provide: PlanConfigService,
           useValue: mockPlanConfigService,
+        },
+        {
+          provide: CategoriesService,
+          useValue: mockCategoriesService,
         },
       ],
     }).compile();
@@ -859,6 +869,111 @@ describe('ReadingValidatorService - BUG HUNTING', () => {
       expect(() =>
         service.validateSpreadAccess(UserPlan.ANONYMOUS, UserPlan.PREMIUM),
       ).toThrow('Esta tirada requiere plan premium');
+    });
+  });
+
+  describe('validateCategoryAccess', () => {
+    const mockFreeCategory = (slug: string): ReadingCategory =>
+      ({ id: 1, slug, name: slug, isActive: true }) as ReadingCategory;
+
+    it('should allow FREE user to access "amor" category', async () => {
+      mockCategoriesService.findOne.mockResolvedValue(mockFreeCategory('amor'));
+
+      await expect(
+        service.validateCategoryAccess(UserPlan.FREE, 1),
+      ).resolves.not.toThrow();
+    });
+
+    it('should allow FREE user to access "salud" category', async () => {
+      mockCategoriesService.findOne.mockResolvedValue(
+        mockFreeCategory('salud'),
+      );
+
+      await expect(
+        service.validateCategoryAccess(UserPlan.FREE, 2),
+      ).resolves.not.toThrow();
+    });
+
+    it('should allow FREE user to access "dinero" category', async () => {
+      mockCategoriesService.findOne.mockResolvedValue(
+        mockFreeCategory('dinero'),
+      );
+
+      await expect(
+        service.validateCategoryAccess(UserPlan.FREE, 3),
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw ForbiddenException when FREE user accesses "trabajo" category', async () => {
+      mockCategoriesService.findOne.mockResolvedValue(
+        mockFreeCategory('trabajo'),
+      );
+
+      await expect(
+        service.validateCategoryAccess(UserPlan.FREE, 4),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw ForbiddenException when FREE user accesses "espiritual" category', async () => {
+      mockCategoriesService.findOne.mockResolvedValue(
+        mockFreeCategory('espiritual'),
+      );
+
+      await expect(
+        service.validateCategoryAccess(UserPlan.FREE, 5),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw ForbiddenException when FREE user accesses "general" category', async () => {
+      mockCategoriesService.findOne.mockResolvedValue(
+        mockFreeCategory('general'),
+      );
+
+      await expect(
+        service.validateCategoryAccess(UserPlan.FREE, 6),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw ForbiddenException when ANONYMOUS user accesses a restricted category', async () => {
+      mockCategoriesService.findOne.mockResolvedValue(
+        mockFreeCategory('trabajo'),
+      );
+
+      await expect(
+        service.validateCategoryAccess(UserPlan.ANONYMOUS, 4),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should allow PREMIUM user to access any category (trabajo)', async () => {
+      mockCategoriesService.findOne.mockResolvedValue(
+        mockFreeCategory('trabajo'),
+      );
+
+      await expect(
+        service.validateCategoryAccess(UserPlan.PREMIUM, 4),
+      ).resolves.not.toThrow();
+
+      expect(mockCategoriesService.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should allow PREMIUM user to access any category (espiritual)', async () => {
+      mockCategoriesService.findOne.mockResolvedValue(
+        mockFreeCategory('espiritual'),
+      );
+
+      await expect(
+        service.validateCategoryAccess(UserPlan.PREMIUM, 5),
+      ).resolves.not.toThrow();
+    });
+
+    it('should propagate NotFoundException when category does not exist', async () => {
+      mockCategoriesService.findOne.mockRejectedValue(
+        new NotFoundException('Categoría con ID 999 no encontrada'),
+      );
+
+      await expect(
+        service.validateCategoryAccess(UserPlan.FREE, 999),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.spec.ts
@@ -912,6 +912,11 @@ describe('ReadingValidatorService - BUG HUNTING', () => {
       await expect(
         service.validateCategoryAccess(UserPlan.FREE, 4),
       ).rejects.toThrow(ForbiddenException);
+      await expect(
+        service.validateCategoryAccess(UserPlan.FREE, 4),
+      ).rejects.toThrow(
+        'Los usuarios gratuito solo pueden acceder a las categorías: amor, salud, dinero',
+      );
     });
 
     it('should throw ForbiddenException when FREE user accesses "espiritual" category', async () => {
@@ -942,6 +947,11 @@ describe('ReadingValidatorService - BUG HUNTING', () => {
       await expect(
         service.validateCategoryAccess(UserPlan.ANONYMOUS, 4),
       ).rejects.toThrow(ForbiddenException);
+      await expect(
+        service.validateCategoryAccess(UserPlan.ANONYMOUS, 4),
+      ).rejects.toThrow(
+        'Los usuarios anónimo solo pueden acceder a las categorías: amor, salud, dinero',
+      );
     });
 
     it('should allow PREMIUM user to access any category (trabajo)', async () => {

--- a/backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.ts
@@ -275,8 +275,14 @@ export class ReadingValidatorService {
         category.slug,
       )
     ) {
+      const planNames = {
+        [UserPlan.ANONYMOUS]: 'anónimo',
+        [UserPlan.FREE]: 'gratuito',
+        [UserPlan.PREMIUM]: 'premium',
+      };
+
       throw new ForbiddenException(
-        `Los usuarios ${userPlan} solo pueden acceder a las categorías: ${ReadingValidatorService.FREE_ALLOWED_CATEGORY_SLUGS.join(', ')}`,
+        `Los usuarios ${planNames[userPlan]} solo pueden acceder a las categorías: ${ReadingValidatorService.FREE_ALLOWED_CATEGORY_SLUGS.join(', ')}`,
       );
     }
   }

--- a/backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.ts
@@ -11,15 +11,23 @@ import { Repository } from 'typeorm';
 import { TarotReading } from '../../entities/tarot-reading.entity';
 import { User, UserPlan } from '../../../../users/entities/user.entity';
 import { PlanConfigService } from '../../../../plan-config/plan-config.service';
+import { CategoriesService } from '../../../../categories/categories.service';
 
 @Injectable()
 export class ReadingValidatorService {
+  private static readonly FREE_ALLOWED_CATEGORY_SLUGS: string[] = [
+    'amor',
+    'salud',
+    'dinero',
+  ];
+
   constructor(
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
     @InjectRepository(TarotReading)
     private readonly readingRepo: Repository<TarotReading>,
     private readonly planConfigService: PlanConfigService,
+    private readonly categoriesService: CategoriesService,
   ) {}
 
   /**
@@ -237,6 +245,38 @@ export class ReadingValidatorService {
 
       throw new ForbiddenException(
         `Esta tirada requiere plan ${planNames[spreadRequiredPlan]}. Tu plan actual es ${planNames[userPlan]}`,
+      );
+    }
+  }
+
+  /**
+   * Validate that a user has access to a specific reading category.
+   * PREMIUM users have access to all categories.
+   * FREE and ANONYMOUS users can only access: 'amor', 'salud', 'dinero'.
+   *
+   * @param userPlan - The user's subscription plan
+   * @param categoryId - The ID of the category to validate access for
+   * @throws ForbiddenException if user doesn't have access to the category
+   * @throws NotFoundException if category doesn't exist (propagated from CategoriesService)
+   */
+  async validateCategoryAccess(
+    userPlan: UserPlan,
+    categoryId: number,
+  ): Promise<void> {
+    // PREMIUM has unrestricted access — no DB call needed
+    if (userPlan === UserPlan.PREMIUM) {
+      return;
+    }
+
+    const category = await this.categoriesService.findOne(categoryId);
+
+    if (
+      !ReadingValidatorService.FREE_ALLOWED_CATEGORY_SLUGS.includes(
+        category.slug,
+      )
+    ) {
+      throw new ForbiddenException(
+        `Los usuarios ${userPlan} solo pueden acceder a las categorías: ${ReadingValidatorService.FREE_ALLOWED_CATEGORY_SLUGS.join(', ')}`,
       );
     }
   }

--- a/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.spec.ts
@@ -1059,6 +1059,31 @@ describe('CreateReadingUseCase', () => {
       expect(readingRepo.create).not.toHaveBeenCalled();
     });
 
+    it('should NOT call cardFreeInterpretationService when PREMIUM user sends categoryId (guard plan)', async () => {
+      const premiumDtoWithCategory: CreateReadingDto = {
+        ...mockDto,
+        useAI: false,
+        categoryId: 1,
+      };
+      const mockReading = createMockReading();
+
+      validator.validateUser.mockResolvedValue(mockUser);
+      validator.validateCategoryAccess.mockResolvedValue(undefined);
+      decksService.findDeckById.mockResolvedValue(mockDeck);
+      spreadsService.findById.mockResolvedValue(mockSpread);
+      cardsService.findByIds.mockResolvedValue(mockCards);
+      readingRepo.create.mockResolvedValue(mockReading);
+
+      const result = await useCase.execute(mockUser, premiumDtoWithCategory);
+
+      // PREMIUM nunca debe recibir freeInterpretations aunque envíe categoryId
+      expect(
+        cardFreeInterpretationService.findByCardsAndCategory,
+      ).not.toHaveBeenCalled();
+      expect(readingRepo.update).not.toHaveBeenCalled();
+      expect(result).toEqual(mockReading);
+    });
+
     it('should NOT touch the interpretation field in the FREE flow', async () => {
       const mockReading = createMockReading({
         user: mockFreeUser,

--- a/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { CreateReadingUseCase } from './create-reading.use-case';
 import { IReadingRepository } from '../../domain/interfaces/reading-repository.interface';
 import { ReadingValidatorService } from '../services/reading-validator.service';
@@ -10,6 +10,7 @@ import { DecksService } from '../../../decks/decks.service';
 import { PredefinedQuestionsService } from '../../../../predefined-questions/predefined-questions.service';
 import { SubscriptionsService } from '../../../../subscriptions/subscriptions.service';
 import { RevenueCalculationService } from '../../../../tarotistas/services/revenue-calculation.service';
+import { CardFreeInterpretationService } from '../../../cards/card-free-interpretation.service';
 import { TarotReading } from '../../entities/tarot-reading.entity';
 import { User, UserPlan } from '../../../../users/entities/user.entity';
 import { CreateReadingDto } from '../../dto/create-reading.dto';
@@ -29,6 +30,7 @@ describe('CreateReadingUseCase', () => {
   let predefinedQuestionsService: jest.Mocked<PredefinedQuestionsService>;
   let subscriptionsService: jest.Mocked<SubscriptionsService>;
   let _revenueCalculationService: jest.Mocked<RevenueCalculationService>;
+  let cardFreeInterpretationService: jest.Mocked<CardFreeInterpretationService>;
 
   const mockUser: User = {
     id: 100,
@@ -79,6 +81,7 @@ describe('CreateReadingUseCase', () => {
       cards: mockCards,
       cardPositions: mockDto.cardPositions,
       interpretation: null,
+      freeInterpretations: null,
       createdAt: new Date(),
       updatedAt: new Date(),
       regenerationCount: 0,
@@ -106,6 +109,7 @@ describe('CreateReadingUseCase', () => {
           useValue: {
             validateUser: jest.fn(),
             validateSpreadAccess: jest.fn(),
+            validateCategoryAccess: jest.fn(),
           },
         },
         {
@@ -161,6 +165,12 @@ describe('CreateReadingUseCase', () => {
             recordRevenue: jest.fn().mockResolvedValue(undefined),
           },
         },
+        {
+          provide: CardFreeInterpretationService,
+          useValue: {
+            findByCardsAndCategory: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -173,6 +183,7 @@ describe('CreateReadingUseCase', () => {
     decksService = module.get(DecksService);
     predefinedQuestionsService = module.get(PredefinedQuestionsService);
     subscriptionsService = module.get(SubscriptionsService);
+    cardFreeInterpretationService = module.get(CardFreeInterpretationService);
   });
 
   afterEach(() => {
@@ -892,6 +903,192 @@ describe('CreateReadingUseCase', () => {
         mockReading.id,
         1,
       );
+    });
+  });
+
+  describe('FREE flow with categoryId (T-FR-B02)', () => {
+    const mockFreeUser: User = {
+      id: 200,
+      email: 'free@example.com',
+      plan: UserPlan.FREE,
+    } as User;
+
+    const mockFreeDto: CreateReadingDto = {
+      deckId: 1,
+      spreadId: 1,
+      cardIds: [1, 2, 3],
+      cardPositions: [
+        { cardId: 1, position: 'past', isReversed: false },
+        { cardId: 2, position: 'present', isReversed: false },
+        { cardId: 3, position: 'future', isReversed: true },
+      ],
+      customQuestion: '¿Cómo va mi relación?',
+      useAI: false,
+      categoryId: 1,
+    };
+
+    const mockFreeInterpretationsMap = {
+      0: { content: 'Interpretación para carta 1 upright en amor' },
+      1: { content: 'Interpretación para carta 2 upright en amor' },
+      2: { content: 'Interpretación para carta 3 reversed en amor' },
+    };
+
+    it('should call validateCategoryAccess when categoryId is provided', async () => {
+      const mockReading = createMockReading({ user: mockFreeUser });
+      const mockUpdatedReading = createMockReading({
+        user: mockFreeUser,
+        freeInterpretations: mockFreeInterpretationsMap,
+      });
+
+      validator.validateUser.mockResolvedValue(mockFreeUser);
+      validator.validateCategoryAccess.mockResolvedValue(undefined);
+      decksService.findDeckById.mockResolvedValue(mockDeck);
+      spreadsService.findById.mockResolvedValue(mockSpread);
+      cardsService.findByIds.mockResolvedValue(mockCards);
+      readingRepo.create.mockResolvedValue(mockReading);
+      cardFreeInterpretationService.findByCardsAndCategory.mockResolvedValue(
+        mockFreeInterpretationsMap,
+      );
+      readingRepo.update.mockResolvedValue(mockUpdatedReading);
+
+      await useCase.execute(mockFreeUser, mockFreeDto);
+
+      expect(validator.validateCategoryAccess).toHaveBeenCalledWith(
+        UserPlan.FREE,
+        1,
+      );
+    });
+
+    it('should call cardFreeInterpretationService and persist freeInterpretations', async () => {
+      const mockReading = createMockReading({ user: mockFreeUser });
+      const mockUpdatedReading = createMockReading({
+        user: mockFreeUser,
+        freeInterpretations: mockFreeInterpretationsMap,
+      });
+
+      validator.validateUser.mockResolvedValue(mockFreeUser);
+      validator.validateCategoryAccess.mockResolvedValue(undefined);
+      decksService.findDeckById.mockResolvedValue(mockDeck);
+      spreadsService.findById.mockResolvedValue(mockSpread);
+      cardsService.findByIds.mockResolvedValue(mockCards);
+      readingRepo.create.mockResolvedValue(mockReading);
+      cardFreeInterpretationService.findByCardsAndCategory.mockResolvedValue(
+        mockFreeInterpretationsMap,
+      );
+      readingRepo.update.mockResolvedValue(mockUpdatedReading);
+
+      const result = await useCase.execute(mockFreeUser, mockFreeDto);
+
+      expect(
+        cardFreeInterpretationService.findByCardsAndCategory,
+      ).toHaveBeenCalledWith(mockCards, mockFreeDto.cardPositions, 1);
+      expect(readingRepo.update).toHaveBeenCalledWith(mockReading.id, {
+        freeInterpretations: mockFreeInterpretationsMap,
+      });
+      expect(result).toEqual(mockUpdatedReading);
+    });
+
+    it('should NOT call cardFreeInterpretationService when categoryId is absent', async () => {
+      const dtoCategoryAbsent: CreateReadingDto = {
+        ...mockFreeDto,
+        categoryId: undefined,
+      };
+      const mockReading = createMockReading({ user: mockFreeUser });
+
+      validator.validateUser.mockResolvedValue(mockFreeUser);
+      decksService.findDeckById.mockResolvedValue(mockDeck);
+      spreadsService.findById.mockResolvedValue(mockSpread);
+      cardsService.findByIds.mockResolvedValue(mockCards);
+      readingRepo.create.mockResolvedValue(mockReading);
+
+      await useCase.execute(mockFreeUser, dtoCategoryAbsent);
+
+      expect(
+        cardFreeInterpretationService.findByCardsAndCategory,
+      ).not.toHaveBeenCalled();
+      expect(validator.validateCategoryAccess).not.toHaveBeenCalled();
+      expect(readingRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call cardFreeInterpretationService when useAI is true (PREMIUM flow takes precedence)', async () => {
+      const dtoPremiumAI: CreateReadingDto = {
+        ...mockFreeDto,
+        useAI: true,
+        categoryId: 1,
+      };
+      const mockReading = createMockReading();
+      const mockUpdatedReading = createMockReading({
+        interpretation: 'AI interpretation',
+      });
+
+      validator.validateUser.mockResolvedValue(mockUser);
+      validator.validateCategoryAccess.mockResolvedValue(undefined);
+      decksService.findDeckById.mockResolvedValue(mockDeck);
+      spreadsService.findById.mockResolvedValue(mockSpread);
+      cardsService.findByIds.mockResolvedValue(mockCards);
+      readingRepo.create.mockResolvedValue(mockReading);
+      interpretationsService.generateInterpretation.mockResolvedValue({
+        interpretation: 'AI interpretation',
+        fromCache: false,
+      });
+      readingRepo.update.mockResolvedValue(mockUpdatedReading);
+
+      await useCase.execute(mockUser, dtoPremiumAI);
+
+      expect(
+        cardFreeInterpretationService.findByCardsAndCategory,
+      ).not.toHaveBeenCalled();
+      expect(interpretationsService.generateInterpretation).toHaveBeenCalled();
+    });
+
+    it('should propagate ForbiddenException from validateCategoryAccess', async () => {
+      validator.validateUser.mockResolvedValue(mockFreeUser);
+      validator.validateCategoryAccess.mockRejectedValue(
+        new ForbiddenException(
+          'Los usuarios free solo pueden acceder a las categorías: amor, salud, dinero',
+        ),
+      );
+      decksService.findDeckById.mockResolvedValue(mockDeck);
+      spreadsService.findById.mockResolvedValue(mockSpread);
+      cardsService.findByIds.mockResolvedValue(mockCards);
+
+      await expect(useCase.execute(mockFreeUser, mockFreeDto)).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      expect(readingRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('should NOT touch the interpretation field in the FREE flow', async () => {
+      const mockReading = createMockReading({
+        user: mockFreeUser,
+        interpretation: null,
+      });
+      const mockUpdatedReading = createMockReading({
+        user: mockFreeUser,
+        interpretation: null,
+        freeInterpretations: mockFreeInterpretationsMap,
+      });
+
+      validator.validateUser.mockResolvedValue(mockFreeUser);
+      validator.validateCategoryAccess.mockResolvedValue(undefined);
+      decksService.findDeckById.mockResolvedValue(mockDeck);
+      spreadsService.findById.mockResolvedValue(mockSpread);
+      cardsService.findByIds.mockResolvedValue(mockCards);
+      readingRepo.create.mockResolvedValue(mockReading);
+      cardFreeInterpretationService.findByCardsAndCategory.mockResolvedValue(
+        mockFreeInterpretationsMap,
+      );
+      readingRepo.update.mockResolvedValue(mockUpdatedReading);
+
+      const result = await useCase.execute(mockFreeUser, mockFreeDto);
+
+      // Only freeInterpretations should be updated — not interpretation
+      expect(readingRepo.update).toHaveBeenCalledWith(
+        mockReading.id,
+        expect.not.objectContaining({ interpretation: expect.anything() }),
+      );
+      expect(result.interpretation).toBeNull();
     });
   });
 });

--- a/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.ts
@@ -9,7 +9,7 @@ import { IReadingRepository } from '../../domain/interfaces/reading-repository.i
 import { ReadingValidatorService } from '../services/reading-validator.service';
 import { CreateReadingDto } from '../../dto/create-reading.dto';
 import { TarotReading } from '../../entities/tarot-reading.entity';
-import { User } from '../../../../users/entities/user.entity';
+import { User, UserPlan } from '../../../../users/entities/user.entity';
 import { InterpretationsService } from '../../../interpretations/interpretations.service';
 import { CardsService } from '../../../cards/cards.service';
 import { SpreadsService } from '../../../spreads/spreads.service';
@@ -185,7 +185,8 @@ export class CreateReadingUseCase {
     }
 
     // T-FR-B02: Flujo FREE — buscar interpretaciones pre-escritas si se proporcionó categoryId
-    if (createReadingDto.categoryId) {
+    // Solo aplica a usuarios FREE/ANONYMOUS; PREMIUM nunca recibe freeInterpretations
+    if (createReadingDto.categoryId && user.plan !== UserPlan.PREMIUM) {
       const freeInterpretations =
         await this.cardFreeInterpretationService.findByCardsAndCategory(
           cards,

--- a/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.ts
@@ -18,6 +18,7 @@ import { PredefinedQuestionsService } from '../../../../predefined-questions/pre
 import { SubscriptionsService } from '../../../../subscriptions/subscriptions.service';
 import { RevenueCalculationService } from '../../../../tarotistas/services/revenue-calculation.service';
 import { SubscriptionType } from '../../../../tarotistas/entities/user-tarotista-subscription.entity';
+import { CardFreeInterpretationService } from '../../../cards/card-free-interpretation.service';
 
 @Injectable()
 export class CreateReadingUseCase {
@@ -34,6 +35,7 @@ export class CreateReadingUseCase {
     private readonly predefinedQuestionsService: PredefinedQuestionsService,
     private readonly subscriptionsService: SubscriptionsService,
     private readonly revenueCalculationService: RevenueCalculationService,
+    private readonly cardFreeInterpretationService: CardFreeInterpretationService,
   ) {}
 
   async execute(
@@ -70,6 +72,14 @@ export class CreateReadingUseCase {
 
     // Validar que el usuario tiene acceso al spread según su plan
     this.validator.validateSpreadAccess(user.plan, spread.requiredPlan);
+
+    // Validar acceso a la categoría si se proporciona (solo relevante para usuarios FREE)
+    if (createReadingDto.categoryId) {
+      await this.validator.validateCategoryAccess(
+        user.plan,
+        createReadingDto.categoryId,
+      );
+    }
 
     // Determinar tipo de pregunta
     const questionType = createReadingDto.predefinedQuestionId
@@ -172,6 +182,29 @@ export class CreateReadingUseCase {
             'No se pudo generar la interpretación automáticamente. El error ha sido registrado. Por favor, intenta regenerar más tarde.',
         });
       }
+    }
+
+    // T-FR-B02: Flujo FREE — buscar interpretaciones pre-escritas si se proporcionó categoryId
+    if (createReadingDto.categoryId) {
+      const freeInterpretations =
+        await this.cardFreeInterpretationService.findByCardsAndCategory(
+          cards,
+          createReadingDto.cardPositions,
+          createReadingDto.categoryId,
+        );
+
+      const updatedReading = await this.readingRepo.update(reading.id, {
+        freeInterpretations,
+      });
+
+      // Calcular y registrar revenue para lecturas FREE con categoría
+      await this.calculateRevenueForReading(
+        updatedReading,
+        tarotistaId,
+        user.id,
+      );
+
+      return updatedReading;
     }
 
     // Calcular y registrar revenue para lecturas sin interpretación también

--- a/backend/tarot-app/src/modules/tarot/readings/dto/create-reading.dto.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/dto/create-reading.dto.ts
@@ -13,6 +13,7 @@ import {
   ValidationArguments,
   ValidateIf,
   MinLength,
+  IsPositive,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -174,4 +175,15 @@ export class CreateReadingDto {
   @IsOptional()
   @Validate(HasQuestionConstraint)
   useAI?: boolean;
+
+  @ApiProperty({
+    example: 1,
+    description:
+      'ID de la categoría elegida (requerido para usuarios FREE con interpretación pre-escrita)',
+    required: false,
+  })
+  @IsInt()
+  @IsPositive()
+  @IsOptional()
+  categoryId?: number;
 }

--- a/backend/tarot-app/src/modules/tarot/readings/readings.module.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/readings.module.ts
@@ -23,6 +23,7 @@ import { SubscriptionsModule } from '../../subscriptions/subscriptions.module';
 import { TarotistasModule } from '../../tarotistas/tarotistas.module';
 import { PlanConfigModule } from '../../plan-config/plan-config.module';
 import { UsersModule } from '../../users/users.module';
+import { CategoriesModule } from '../../categories/categories.module';
 
 // ==================== Clean Architecture ====================
 // Repositories
@@ -64,6 +65,7 @@ import { RestoreReadingUseCase } from './application/use-cases/restore-reading.u
     TarotistasModule,
     PlanConfigModule,
     UsersModule,
+    CategoriesModule,
   ],
   controllers: [
     ReadingsController,

--- a/docs/BACKLOG_FREE_READING_EXPERIENCE.md
+++ b/docs/BACKLOG_FREE_READING_EXPERIENCE.md
@@ -374,7 +374,7 @@ CARTA DEL DÍA:
 | -------- | ------------------------------------------------------------------ | -------- | ----------- | ---------- |
 | T-FR-P01 | Rename de rutas `/ritual` → `/tarot` + redirects                   | Frontend | ✅ COMPLETADA | 0.5 días   |
 | T-FR-B01 | Capa de dominio: Migración, entidad y campos nuevos                | Backend  | ✅ COMPLETADA | 2 días     |
-| T-FR-B02 | Capa de aplicación: Service, Repository y modificación de use case | Backend  | 🔴 CRÍTICA | 3 días     |
+| T-FR-B02 | Capa de aplicación: Service, Repository y modificación de use case | Backend  | ✅ COMPLETADA | 3 días     |
 | T-FR-B03 | Validación de mazo FREE + modificación de daily-reading            | Backend  | 🔴 CRÍTICA | 2 días     |
 | T-FR-B04 | Capability `canUseFullDeck` + endpoint `GET /cards?category=`      | Backend  | 🟡 ALTA    | 1 día      |
 | T-FR-S01 | Seed de tiradas — 132 prompts para Claude/Gemini                   | Content  | 🔴 CRÍTICA | 3 días     |
@@ -493,7 +493,7 @@ Crear la estructura de datos para las interpretaciones pre-escritas de usuarios 
 **Prioridad:** 🔴 CRÍTICA
 **Estimación:** 3 días
 **Dependencias:** T-FR-B01
-**Estado:** ⏳ PENDIENTE
+**Estado:** ✅ COMPLETADA
 **Cubre HUS:** HUS-003
 
 #### 📋 Descripción
@@ -504,51 +504,52 @@ Crear el servicio que consulta las interpretaciones pre-escritas y modificar el 
 
 **Service:**
 
-- [ ] Crear `CardFreeInterpretationService` con método `findByCardsAndCategory(cardPositions, categoryId)` que retorna un mapa `{ cardId: { upright?: string; reversed?: string } }` o similar estructura indexable por posición
-- [ ] Tests unitarios con happy path + casos de combinaciones faltantes (fallback)
+- [x] Crear `CardFreeInterpretationService` con método `findByCardsAndCategory(cards, cardPositions, categoryId)` que retorna un mapa `{ [positionIndex]: { content: string } }` indexado por posición (0..N-1)
+- [x] Tests unitarios con happy path + casos de combinaciones faltantes (fallback a `meaningUpright/Reversed`)
 
 **Modificación de Use Case:**
 
-- [ ] Modificar [create-reading.use-case.ts](backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.ts):
+- [x] Modificar [create-reading.use-case.ts](backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.ts):
   ```typescript
   if (createReadingDto.useAI === true) {
-    // PREMIUM — SIN CAMBIOS (L141-143: setea reading.interpretation)
+    // PREMIUM — SIN CAMBIOS (setea reading.interpretation)
   } else if (createReadingDto.categoryId) {
     // FREE: buscar interpretaciones pre-escritas por categoría
     const freeInterpretations = await this.cardFreeInterpretationService
-      .findByCardsAndCategory(cards, positions, createReadingDto.categoryId);
+      .findByCardsAndCategory(cards, cardPositions, createReadingDto.categoryId);
     await this.readingRepo.update(reading.id, { freeInterpretations });
   }
   ```
-- [ ] Persistir en el campo `freeInterpretations: jsonb` creado en T-FR-B01 (NO usar el campo `interpretation` — está reservado para la interpretación personalizada de PREMIUM)
-- [ ] Mantener fallback: si no se encuentra combinación para una carta, usar `meaningUpright/Reversed` existente
+- [x] Persistir en el campo `freeInterpretations: jsonb` creado en T-FR-B01 (NO usar el campo `interpretation` — está reservado para la interpretación personalizada de PREMIUM)
+- [x] Mantener fallback: si no se encuentra combinación para una carta, usar `meaningUpright/Reversed` existente
 
 **DTO:**
 
-- [ ] Agregar `categoryId?: number` al [CreateReadingDto](backend/tarot-app/src/modules/tarot/readings/dto/create-reading.dto.ts) (hoy NO existe — verificado). Validaciones: `@IsInt() @IsOptional() @IsPositive()`
-- [ ] El response sigue siendo la entidad `TarotReading` (no hay response DTO separado — verificado). `freeInterpretations` queda visible gracias al nuevo campo de entidad
+- [x] Agregar `categoryId?: number` al [CreateReadingDto](backend/tarot-app/src/modules/tarot/readings/dto/create-reading.dto.ts). Validaciones: `@IsInt() @IsOptional() @IsPositive()`
+- [x] El response sigue siendo la entidad `TarotReading`. `freeInterpretations` queda visible gracias al nuevo campo de entidad
 
 **Validación de categoryId por plan:**
 
-- [ ] Modificar [ReadingValidatorService](backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.ts): agregar método `validateCategoryAccess(userPlan, categorySlug)` que verifique que FREE solo use slugs `['amor', 'salud', 'dinero']`
-- [ ] Llamar el validador desde `create-reading.use-case.ts` antes de construir la lectura. Lanzar `ForbiddenException` si la categoría no está permitida para el plan
-- [ ] Tests unitarios del validador cubriendo los 3 slugs permitidos para FREE, rechazo de `trabajo`/`espiritual`/`general`, y acceso total para PREMIUM
+- [x] Agregar método `validateCategoryAccess(userPlan, categoryId)` en [ReadingValidatorService](backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.ts) que verifica que FREE/ANONYMOUS solo use slugs `['amor', 'salud', 'dinero']` consultando `CategoriesService.findOne(categoryId)`. PREMIUM tiene acceso total sin consulta.
+- [x] Llamar el validador desde `create-reading.use-case.ts` antes de crear la lectura. Lanza `ForbiddenException` si la categoría no está permitida para el plan
+- [x] Tests unitarios del validador cubriendo los 3 slugs permitidos para FREE, rechazo de `trabajo`/`espiritual`/`general`, ANONYMOUS rechazado, y acceso total para PREMIUM
 
 **Tests:**
 
-- [ ] Tests unitarios del use case cubriendo:
-  - PREMIUM con `useAI: true` → genera interpretación personalizada (sin cambios)
-  - FREE con `categoryId` → carga interpretaciones pre-escritas
-  - FREE sin `categoryId` → fallback o error
-  - Combinación carta+categoría+orientación sin seed → fallback
+- [x] Tests unitarios del use case cubriendo:
+  - PREMIUM con `useAI: true` → genera interpretación personalizada (sin cambios, zero regresión)
+  - FREE con `categoryId` → carga interpretaciones pre-escritas y persiste en `freeInterpretations`
+  - FREE sin `categoryId` → no llama a `cardFreeInterpretationService`
+  - `useAI: true` con `categoryId` → flujo PREMIUM toma precedencia
+  - `validateCategoryAccess` lanza `ForbiddenException` → `readingRepo.create` no se llama
 
 #### 🎯 Criterios de aceptación
 
-- [ ] El flujo PREMIUM sigue funcionando exactamente igual (zero regresión)
-- [ ] El flujo FREE con `categoryId` retorna interpretaciones pre-escritas
-- [ ] El historial de lecturas muestra las interpretaciones persistidas
-- [ ] Coverage ≥ 80%
-- [ ] No se usa `any` ni `eslint-disable`
+- [x] El flujo PREMIUM sigue funcionando exactamente igual (zero regresión)
+- [x] El flujo FREE con `categoryId` retorna interpretaciones pre-escritas
+- [x] El historial de lecturas muestra las interpretaciones persistidas
+- [x] Coverage ≥ 80%
+- [x] No se usa `any` ni `eslint-disable`
 
 ---
 


### PR DESCRIPTION
## Resumen

- Crea CardFreeInterpretationService.findByCardsAndCategory() con fallback a meaningUpright/Reversed
- Agrega validateCategoryAccess en ReadingValidatorService: FREE/ANONYMOUS limitados a amor/salud/dinero
- Modifica CreateReadingUseCase: bloque FREE persiste en freeInterpretations (NO toca interpretation de PREMIUM)
- Agrega categoryId a CreateReadingDto
- Zero regresion en flujo PREMIUM

## Tests

123 tests pasando, build y lint OK, arquitectura validada

## Dependencia

Requiere T-FR-B01 (merged)