### PR TITLE
feat(tarot): T-FR-B03 - Validacion de mazo FREE + modificacion daily reading

### DIFF
--- a/backend/tarot-app/src/modules/tarot/daily-reading/daily-reading.service.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/daily-reading/daily-reading.service.spec.ts
@@ -879,37 +879,85 @@ describe('DailyReadingService', () => {
     });
 
     it('should generate a random daily card for anonymous user', async () => {
+      // T-FR-B03: anonymous users now receive pre-written dailyFreeUpright/Reversed interpretation
+      // (fallback to meaningUpright/Reversed when dailyFreeUpright/Reversed is null)
       mockDailyReadingQueryBuilder.getOne.mockResolvedValue(null);
-      mockCardRepo.count.mockResolvedValue(78);
+      mockCardRepo.count.mockResolvedValue(22); // T-FR-B03: only major arcana (22 cards)
       mockCardQueryBuilder.getOne.mockResolvedValue({
         id: 5,
         name: 'El Hierofante',
         meaningUpright: 'Sabiduría y tradición',
         meaningReversed: 'Rebelión contra normas',
+        dailyFreeUpright: null, // no pre-written text → fallback to meaningUpright/Reversed
+        dailyFreeReversed: null,
       });
 
-      const savedReading = {
-        id: 1,
-        anonymousFingerprint: fingerprint,
-        userId: null,
-        cardId: 5,
-        isReversed: false,
-        interpretation: null,
-        readingDate: new Date().toISOString().split('T')[0],
-        wasRegenerated: false,
-      };
+      // isReversed depends on Math.random; accept either orientation
+      const uprightInterpretation = 'Sabiduría y tradición';
+      const reversedInterpretation = 'Rebelión contra normas';
 
-      mockDailyReadingRepo.create.mockReturnValue(savedReading);
-      mockDailyReadingRepo.save.mockResolvedValue(savedReading);
-      mockDailyReadingRepo.findOne.mockResolvedValue({
-        ...savedReading,
-        card: {
-          id: 5,
-          name: 'El Hierofante',
-          meaningUpright: 'Sabiduría y tradición',
-          meaningReversed: 'Rebelión contra normas',
-        },
-      });
+      mockDailyReadingRepo.create.mockImplementation(
+        (data: {
+          anonymousFingerprint: string;
+          userId: null;
+          cardId: number;
+          isReversed: boolean;
+          interpretation: string;
+          readingDate: string;
+          tarotistaId: number;
+          wasRegenerated: boolean;
+        }) => data,
+      );
+      mockDailyReadingRepo.save.mockImplementation(
+        (data: {
+          anonymousFingerprint: string;
+          userId: null;
+          cardId: number;
+          isReversed: boolean;
+          interpretation: string;
+          readingDate: string;
+          tarotistaId: number;
+          wasRegenerated: boolean;
+        }) => Promise.resolve({ id: 1, ...data }),
+      );
+      mockDailyReadingRepo.findOne.mockImplementation(
+        async () =>
+          ({
+            id: 1,
+            anonymousFingerprint: fingerprint,
+            userId: null,
+            cardId: 5,
+            isReversed: false,
+            interpretation: uprightInterpretation,
+            readingDate: new Date().toISOString().split('T')[0],
+            wasRegenerated: false,
+            card: {
+              id: 5,
+              name: 'El Hierofante',
+              meaningUpright: 'Sabiduría y tradición',
+              meaningReversed: 'Rebelión contra normas',
+              dailyFreeUpright: null,
+              dailyFreeReversed: null,
+            },
+          }) as unknown as Promise<{
+            id: number;
+            anonymousFingerprint: string;
+            userId: null;
+            cardId: number;
+            isReversed: boolean;
+            interpretation: string;
+            readingDate: string;
+            wasRegenerated: boolean;
+            card: {
+              id: number;
+              name: string;
+              meaningUpright: string;
+              meaningReversed: string;
+              dailyFreeUpright: null;
+              dailyFreeReversed: null;
+            };
+          }>,
+      );
 
       const result = await service.generateAnonymousDailyCard(
         fingerprint,
@@ -919,14 +967,22 @@ describe('DailyReadingService', () => {
       expect(result).toBeDefined();
       expect(result.anonymousFingerprint).toBe(fingerprint);
       expect(result.userId).toBeNull();
-      expect(result.interpretation).toBeNull();
-      expect(mockDailyReadingRepo.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          anonymousFingerprint: fingerprint,
-          userId: null,
-          interpretation: null,
-        }),
+      // T-FR-B03: interpretation is now pre-written text (or fallback), NOT null
+      expect(result.interpretation).not.toBeNull();
+
+      // Verify create was called with a non-null interpretation (upright or reversed fallback)
+      const createCall = mockDailyReadingRepo.create.mock
+        .calls[0][0] as unknown as {
+        anonymousFingerprint: string;
+        userId: null;
+        interpretation: string;
+      };
+      expect(createCall.anonymousFingerprint).toBe(fingerprint);
+      expect(createCall.userId).toBeNull();
+      expect([uprightInterpretation, reversedInterpretation]).toContain(
+        createCall.interpretation,
       );
+
       expect(
         mockInterpretationsService.generateDailyCardInterpretation,
       ).not.toHaveBeenCalled();
@@ -1058,6 +1114,426 @@ describe('DailyReadingService', () => {
 
       // Different fingerprints can get different cards
       expect(result1.card.id).not.toBe(result2.card.id);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // T-FR-B03: selectRandomCard con filtro de Arcanos Mayores
+  // -----------------------------------------------------------------------
+  describe('generateDailyCard - T-FR-B03: major arcana filter + dailyFreeUpright/Reversed', () => {
+    const userId = 1;
+    const tarotistaId = 1;
+
+    const majorArcanaCard = {
+      id: 5,
+      name: 'La Justicia',
+      category: 'arcanos_mayores',
+      dailyFreeUpright: 'Hoy la energía de La Justicia te acompaña...',
+      dailyFreeReversed: 'Hoy La Justicia invertida te pide...',
+      meaningUpright: 'Equilibrio y verdad',
+      meaningReversed: 'Injusticia o deshonestidad',
+    };
+
+    beforeEach(() => {
+      mockPlanConfigService.findByPlanType.mockResolvedValue({
+        planType: UserPlan.FREE,
+        dailyCardLimit: 1,
+        tarotReadingsLimit: 3,
+      });
+      mockUsageLimitsService.checkLimit.mockResolvedValue(true);
+    });
+
+    it('should filter cards by arcanos_mayores when FREE user generates daily card', async () => {
+      const mockFreeUser = {
+        id: userId,
+        email: 'free@test.com',
+        plan: UserPlan.FREE,
+      };
+
+      mockDailyReadingQueryBuilder.getOne.mockResolvedValue(null);
+      // FREE: count only returns 22 (arcanos_mayores)
+      mockCardRepo.count.mockResolvedValue(22);
+      mockCardQueryBuilder.getOne.mockResolvedValue(majorArcanaCard);
+
+      const savedReading = {
+        id: 1,
+        userId,
+        tarotistaId,
+        cardId: majorArcanaCard.id,
+        isReversed: false,
+        interpretation: majorArcanaCard.dailyFreeUpright,
+        readingDate: new Date().toISOString().split('T')[0],
+        wasRegenerated: false,
+      };
+
+      mockDailyReadingRepo.create.mockReturnValue(savedReading);
+      mockDailyReadingRepo.save.mockResolvedValue(savedReading);
+      mockDailyReadingRepo.findOne.mockResolvedValue({
+        ...savedReading,
+        card: majorArcanaCard,
+      });
+
+      const result = await service.generateDailyCard(
+        userId,
+        tarotistaId,
+        mockFreeUser,
+      );
+
+      // Verify the query builder was called with arcanos_mayores filter
+      expect(mockCardQueryBuilder.where).toHaveBeenCalledWith(
+        expect.stringContaining('category'),
+        expect.objectContaining({ category: 'arcanos_mayores' }),
+      );
+      // Verify interpretation is from dailyFreeUpright
+      expect(result.interpretation).toBe(majorArcanaCard.dailyFreeUpright);
+    });
+
+    it('should use dailyFreeUpright when FREE user card is not reversed', async () => {
+      const mockFreeUser = {
+        id: userId,
+        email: 'free@test.com',
+        plan: UserPlan.FREE,
+      };
+
+      mockDailyReadingQueryBuilder.getOne.mockResolvedValue(null);
+      mockCardRepo.count.mockResolvedValue(22);
+
+      // Force isReversed = false
+      jest
+        .spyOn(Math, 'random')
+        .mockReturnValueOnce(0.1) // randomIndex → small
+        .mockReturnValueOnce(0.9); // isReversed → false (>= 0.5)
+
+      mockCardQueryBuilder.getOne.mockResolvedValue(majorArcanaCard);
+
+      const savedReading = {
+        id: 1,
+        userId,
+        tarotistaId,
+        cardId: majorArcanaCard.id,
+        isReversed: false,
+        interpretation: majorArcanaCard.dailyFreeUpright,
+        readingDate: new Date().toISOString().split('T')[0],
+        wasRegenerated: false,
+      };
+
+      mockDailyReadingRepo.create.mockReturnValue(savedReading);
+      mockDailyReadingRepo.save.mockResolvedValue(savedReading);
+      mockDailyReadingRepo.findOne.mockResolvedValue({
+        ...savedReading,
+        card: majorArcanaCard,
+      });
+
+      const result = await service.generateDailyCard(
+        userId,
+        tarotistaId,
+        mockFreeUser,
+      );
+
+      expect(result.interpretation).toBe(majorArcanaCard.dailyFreeUpright);
+
+      jest.spyOn(Math, 'random').mockRestore();
+    });
+
+    it('should use dailyFreeReversed when FREE user card is reversed', async () => {
+      const mockFreeUser = {
+        id: userId,
+        email: 'free@test.com',
+        plan: UserPlan.FREE,
+      };
+
+      mockDailyReadingQueryBuilder.getOne.mockResolvedValue(null);
+      mockCardRepo.count.mockResolvedValue(22);
+
+      // Force isReversed = true (random < 0.5)
+      jest
+        .spyOn(Math, 'random')
+        .mockReturnValueOnce(0.1) // randomIndex
+        .mockReturnValueOnce(0.2); // isReversed = true (< 0.5)
+
+      mockCardQueryBuilder.getOne.mockResolvedValue(majorArcanaCard);
+
+      const savedReading = {
+        id: 2,
+        userId,
+        tarotistaId,
+        cardId: majorArcanaCard.id,
+        isReversed: true,
+        interpretation: majorArcanaCard.dailyFreeReversed,
+        readingDate: new Date().toISOString().split('T')[0],
+        wasRegenerated: false,
+      };
+
+      mockDailyReadingRepo.create.mockReturnValue(savedReading);
+      mockDailyReadingRepo.save.mockResolvedValue(savedReading);
+      mockDailyReadingRepo.findOne.mockResolvedValue({
+        ...savedReading,
+        card: majorArcanaCard,
+      });
+
+      const result = await service.generateDailyCard(
+        userId,
+        tarotistaId,
+        mockFreeUser,
+      );
+
+      expect(result.interpretation).toBe(majorArcanaCard.dailyFreeReversed);
+
+      jest.spyOn(Math, 'random').mockRestore();
+    });
+
+    it('should fallback to meaningUpright when dailyFreeUpright is null', async () => {
+      const cardWithNullDaily = {
+        ...majorArcanaCard,
+        dailyFreeUpright: null,
+        dailyFreeReversed: null,
+      };
+
+      const mockFreeUser = {
+        id: userId,
+        email: 'free@test.com',
+        plan: UserPlan.FREE,
+      };
+
+      mockDailyReadingQueryBuilder.getOne.mockResolvedValue(null);
+      mockCardRepo.count.mockResolvedValue(22);
+
+      // Force isReversed = false
+      jest
+        .spyOn(Math, 'random')
+        .mockReturnValueOnce(0.1)
+        .mockReturnValueOnce(0.9);
+
+      mockCardQueryBuilder.getOne.mockResolvedValue(cardWithNullDaily);
+
+      const savedReading = {
+        id: 3,
+        userId,
+        tarotistaId,
+        cardId: cardWithNullDaily.id,
+        isReversed: false,
+        interpretation: cardWithNullDaily.meaningUpright,
+        readingDate: new Date().toISOString().split('T')[0],
+        wasRegenerated: false,
+      };
+
+      mockDailyReadingRepo.create.mockReturnValue(savedReading);
+      mockDailyReadingRepo.save.mockResolvedValue(savedReading);
+      mockDailyReadingRepo.findOne.mockResolvedValue({
+        ...savedReading,
+        card: cardWithNullDaily,
+      });
+
+      const result = await service.generateDailyCard(
+        userId,
+        tarotistaId,
+        mockFreeUser,
+      );
+
+      // Fallback to meaningUpright since dailyFreeUpright is null
+      expect(result.interpretation).toBe(cardWithNullDaily.meaningUpright);
+
+      jest.spyOn(Math, 'random').mockRestore();
+    });
+
+    it('should NOT use dailyFreeUpright for PREMIUM users (uses AI instead)', async () => {
+      const mockPremiumUser = {
+        id: userId,
+        email: 'premium@test.com',
+        plan: UserPlan.PREMIUM,
+      };
+
+      mockPlanConfigService.findByPlanType.mockResolvedValue({
+        planType: UserPlan.PREMIUM,
+        dailyCardLimit: -1,
+        tarotReadingsLimit: -1,
+      });
+
+      mockDailyReadingQueryBuilder.getOne.mockResolvedValue(null);
+      // PREMIUM: count returns all 78 cards
+      mockCardRepo.count.mockResolvedValue(78);
+      mockCardQueryBuilder.getOne.mockResolvedValue(majorArcanaCard);
+
+      const aiInterpretation =
+        '**Energía del Día**: interpretación personalizada';
+      mockInterpretationsService.generateDailyCardInterpretation.mockResolvedValue(
+        aiInterpretation,
+      );
+
+      const savedReading = {
+        id: 4,
+        userId,
+        tarotistaId,
+        cardId: majorArcanaCard.id,
+        isReversed: false,
+        interpretation: aiInterpretation,
+        readingDate: new Date().toISOString().split('T')[0],
+        wasRegenerated: false,
+      };
+
+      mockDailyReadingRepo.create.mockReturnValue(savedReading);
+      mockDailyReadingRepo.save.mockResolvedValue(savedReading);
+      mockDailyReadingRepo.findOne.mockResolvedValue({
+        ...savedReading,
+        card: majorArcanaCard,
+      });
+
+      const result = await service.generateDailyCard(
+        userId,
+        tarotistaId,
+        mockPremiumUser,
+      );
+
+      // PREMIUM should use AI, not dailyFreeUpright
+      expect(
+        mockInterpretationsService.generateDailyCardInterpretation,
+      ).toHaveBeenCalled();
+      expect(result.interpretation).toBe(aiInterpretation);
+      // PREMIUM should NOT filter by arcanos_mayores
+      expect(mockCardQueryBuilder.where).not.toHaveBeenCalledWith(
+        expect.stringContaining('category'),
+        expect.anything(),
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // T-FR-B03: generateAnonymousDailyCard con filtro arcanos mayores
+  // -----------------------------------------------------------------------
+  describe('generateAnonymousDailyCard - T-FR-B03: major arcana filter + dailyFreeUpright/Reversed', () => {
+    const tarotistaId = 1;
+    const fingerprint = 'anon-fp-b03';
+
+    const majorArcanaCard = {
+      id: 3,
+      name: 'La Emperatriz',
+      category: 'arcanos_mayores',
+      dailyFreeUpright: 'Hoy la energía de La Emperatriz te acompaña...',
+      dailyFreeReversed: 'Hoy La Emperatriz invertida te pide...',
+      meaningUpright: 'Abundancia y fertilidad',
+      meaningReversed: 'Bloqueo creativo',
+    };
+
+    it('should filter cards by arcanos_mayores for anonymous users', async () => {
+      mockDailyReadingQueryBuilder.getOne.mockResolvedValue(null);
+      mockCardRepo.count.mockResolvedValue(22);
+      mockCardQueryBuilder.getOne.mockResolvedValue(majorArcanaCard);
+
+      const savedReading = {
+        id: 1,
+        anonymousFingerprint: fingerprint,
+        userId: null,
+        cardId: majorArcanaCard.id,
+        isReversed: false,
+        interpretation: majorArcanaCard.dailyFreeUpright,
+        readingDate: new Date().toISOString().split('T')[0],
+        wasRegenerated: false,
+      };
+
+      mockDailyReadingRepo.create.mockReturnValue(savedReading);
+      mockDailyReadingRepo.save.mockResolvedValue(savedReading);
+      mockDailyReadingRepo.findOne.mockResolvedValue({
+        ...savedReading,
+        card: majorArcanaCard,
+      });
+
+      const result = await service.generateAnonymousDailyCard(
+        fingerprint,
+        tarotistaId,
+      );
+
+      // Should filter by arcanos_mayores
+      expect(mockCardQueryBuilder.where).toHaveBeenCalledWith(
+        expect.stringContaining('category'),
+        expect.objectContaining({ category: 'arcanos_mayores' }),
+      );
+      // Should use dailyFreeUpright (not null)
+      expect(result.interpretation).toBe(majorArcanaCard.dailyFreeUpright);
+    });
+
+    it('should use dailyFreeReversed for anonymous user with reversed card', async () => {
+      mockDailyReadingQueryBuilder.getOne.mockResolvedValue(null);
+      mockCardRepo.count.mockResolvedValue(22);
+
+      // Force isReversed = true
+      jest
+        .spyOn(Math, 'random')
+        .mockReturnValueOnce(0.1)
+        .mockReturnValueOnce(0.2);
+
+      mockCardQueryBuilder.getOne.mockResolvedValue(majorArcanaCard);
+
+      const savedReading = {
+        id: 2,
+        anonymousFingerprint: fingerprint,
+        userId: null,
+        cardId: majorArcanaCard.id,
+        isReversed: true,
+        interpretation: majorArcanaCard.dailyFreeReversed,
+        readingDate: new Date().toISOString().split('T')[0],
+        wasRegenerated: false,
+      };
+
+      mockDailyReadingRepo.create.mockReturnValue(savedReading);
+      mockDailyReadingRepo.save.mockResolvedValue(savedReading);
+      mockDailyReadingRepo.findOne.mockResolvedValue({
+        ...savedReading,
+        card: majorArcanaCard,
+      });
+
+      const result = await service.generateAnonymousDailyCard(
+        fingerprint,
+        tarotistaId,
+      );
+
+      expect(result.interpretation).toBe(majorArcanaCard.dailyFreeReversed);
+
+      jest.spyOn(Math, 'random').mockRestore();
+    });
+
+    it('should fallback to meaningUpright when dailyFreeUpright is null for anonymous user', async () => {
+      const cardWithNullDaily = {
+        ...majorArcanaCard,
+        dailyFreeUpright: null,
+        dailyFreeReversed: null,
+      };
+
+      mockDailyReadingQueryBuilder.getOne.mockResolvedValue(null);
+      mockCardRepo.count.mockResolvedValue(22);
+
+      jest
+        .spyOn(Math, 'random')
+        .mockReturnValueOnce(0.1)
+        .mockReturnValueOnce(0.9); // not reversed
+
+      mockCardQueryBuilder.getOne.mockResolvedValue(cardWithNullDaily);
+
+      const savedReading = {
+        id: 3,
+        anonymousFingerprint: fingerprint,
+        userId: null,
+        cardId: cardWithNullDaily.id,
+        isReversed: false,
+        interpretation: cardWithNullDaily.meaningUpright,
+        readingDate: new Date().toISOString().split('T')[0],
+        wasRegenerated: false,
+      };
+
+      mockDailyReadingRepo.create.mockReturnValue(savedReading);
+      mockDailyReadingRepo.save.mockResolvedValue(savedReading);
+      mockDailyReadingRepo.findOne.mockResolvedValue({
+        ...savedReading,
+        card: cardWithNullDaily,
+      });
+
+      const result = await service.generateAnonymousDailyCard(
+        fingerprint,
+        tarotistaId,
+      );
+
+      expect(result.interpretation).toBe(cardWithNullDaily.meaningUpright);
+
+      jest.spyOn(Math, 'random').mockRestore();
     });
   });
 });

--- a/backend/tarot-app/src/modules/tarot/daily-reading/daily-reading.service.ts
+++ b/backend/tarot-app/src/modules/tarot/daily-reading/daily-reading.service.ts
@@ -4,6 +4,7 @@ import {
   ForbiddenException,
   NotFoundException,
   InternalServerErrorException,
+  Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -22,6 +23,8 @@ import { getTodayUTCDateString } from '../../../common/utils/date.utils';
 
 @Injectable()
 export class DailyReadingService {
+  private readonly logger = new Logger(DailyReadingService.name);
+
   constructor(
     @InjectRepository(DailyReading)
     private readonly dailyReadingRepository: Repository<DailyReading>,
@@ -94,10 +97,15 @@ export class DailyReadingService {
     // TASK-007: Ya determinamos el plan arriba para verificar límites
     // userPlan ya está definido
 
-    // Seleccionar carta aleatoria
-    const { card, isReversed } = await this.selectRandomCard();
+    // T-FR-B03: Seleccionar carta aleatoria
+    // FREE/ANONYMOUS → solo Arcanos Mayores (22 cartas)
+    // PREMIUM → mazo completo (78 cartas)
+    const onlyMajorArcana = userPlan !== UserPlan.PREMIUM;
+    const { card, isReversed } = await this.selectRandomCard(onlyMajorArcana);
 
-    // TASK-007: Generar interpretación solo si el usuario es PREMIUM
+    // T-FR-B03: Generar interpretación según plan del usuario
+    // PREMIUM → interpretación personalizada con IA
+    // FREE/ANONYMOUS → texto pre-escrito dailyFreeUpright/Reversed (con fallback a meaningUpright/Reversed)
     let interpretation: string | null = null;
     if (userPlan === UserPlan.PREMIUM) {
       interpretation =
@@ -106,6 +114,23 @@ export class DailyReadingService {
           isReversed,
           tarotistaId,
         );
+    } else {
+      // FREE/ANONYMOUS: usar campos pre-escritos, con fallback
+      const freeText = isReversed
+        ? card.dailyFreeReversed
+        : card.dailyFreeUpright;
+
+      if (freeText) {
+        interpretation = freeText;
+      } else {
+        // Fallback: sin seed aún, usar keywords técnicos
+        this.logger.warn(
+          `dailyFree${isReversed ? 'Reversed' : 'Upright'} is null for card ${card.id} (${card.name}). Falling back to meaning${isReversed ? 'Reversed' : 'Upright'}.`,
+        );
+        interpretation = isReversed
+          ? card.meaningReversed
+          : card.meaningUpright;
+      }
     }
 
     // Guardar en daily_reading
@@ -213,10 +238,24 @@ export class DailyReadingService {
       );
     }
 
-    // Seleccionar carta aleatoria
-    const { card, isReversed } = await this.selectRandomCard();
+    // T-FR-B03: Seleccionar carta aleatoria — solo Arcanos Mayores para anónimos
+    const { card, isReversed } = await this.selectRandomCard(true);
 
-    // NO generar interpretación IA para usuarios anónimos
+    // T-FR-B03: Usar texto pre-escrito dailyFreeUpright/Reversed, con fallback a meaningUpright/Reversed
+    const freeText = isReversed
+      ? card.dailyFreeReversed
+      : card.dailyFreeUpright;
+    let interpretation: string | null;
+
+    if (freeText) {
+      interpretation = freeText;
+    } else {
+      this.logger.warn(
+        `dailyFree${isReversed ? 'Reversed' : 'Upright'} is null for card ${card.id} (${card.name}). Falling back to meaning${isReversed ? 'Reversed' : 'Upright'}.`,
+      );
+      interpretation = isReversed ? card.meaningReversed : card.meaningUpright;
+    }
+
     // Guardar en daily_reading
     const dailyReading = this.dailyReadingRepository.create({
       userId: null,
@@ -224,7 +263,7 @@ export class DailyReadingService {
       tarotistaId,
       cardId: card.id,
       isReversed,
-      interpretation: null, // Sin IA para anónimos
+      interpretation,
       readingDate: todayStr as unknown as Date,
       wasRegenerated: false,
     });
@@ -365,23 +404,35 @@ export class DailyReadingService {
   }
 
   /**
-   * Selecciona una carta aleatoria del mazo
-   * Incluye probabilidad 50% de que esté invertida
+   * Selecciona una carta aleatoria del mazo.
+   * Incluye probabilidad 50% de que esté invertida.
+   *
+   * @param onlyMajorArcana - Si true, selecciona solo entre los 22 Arcanos Mayores (para FREE/anónimos)
    */
-  private async selectRandomCard(): Promise<{
+  private async selectRandomCard(onlyMajorArcana: boolean = false): Promise<{
     card: TarotCard;
     isReversed: boolean;
   }> {
-    const totalCards = await this.tarotCardRepository.count();
+    const totalCards = await this.tarotCardRepository.count(
+      onlyMajorArcana ? { where: { category: 'arcanos_mayores' } } : undefined,
+    );
+
     const randomIndex = Math.floor(Math.random() * totalCards);
     const isReversed = Math.random() < 0.5;
 
-    const card = await this.tarotCardRepository
+    const cardQueryBuilder = this.tarotCardRepository
       .createQueryBuilder('card')
       .orderBy('card.id', 'ASC')
       .skip(randomIndex)
-      .take(1)
-      .getOne();
+      .take(1);
+
+    if (onlyMajorArcana) {
+      cardQueryBuilder.where('card.category = :category', {
+        category: 'arcanos_mayores',
+      });
+    }
+
+    const card = await cardQueryBuilder.getOne();
 
     if (!card) {
       throw new InternalServerErrorException(

--- a/backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.spec.ts
@@ -13,6 +13,7 @@ import { User, UserPlan } from '../../../../users/entities/user.entity';
 import { PlanConfigService } from '../../../../plan-config/plan-config.service';
 import { CategoriesService } from '../../../../categories/categories.service';
 import { ReadingCategory } from '../../../../categories/entities/reading-category.entity';
+import { TarotCard } from '../../../cards/entities/tarot-card.entity';
 
 // Helper types for test cases
 type PartialUser = Partial<User> & { id: number; plan?: UserPlan | null };
@@ -984,6 +985,119 @@ describe('ReadingValidatorService - BUG HUNTING', () => {
       await expect(
         service.validateCategoryAccess(UserPlan.FREE, 999),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('validateDeckAccess', () => {
+    const mockMajorArcanaCard = (id: number): TarotCard =>
+      ({
+        id,
+        name: `Arcano Mayor ${id}`,
+        category: 'arcanos_mayores',
+      }) as TarotCard;
+
+    const mockMinorArcanaCard = (
+      id: number,
+      category: string = 'bastos',
+    ): TarotCard =>
+      ({
+        id,
+        name: `Arcano Menor ${id}`,
+        category,
+      }) as TarotCard;
+
+    it('should allow PREMIUM user to use any cards (major arcana only)', () => {
+      const cards = [mockMajorArcanaCard(1), mockMajorArcanaCard(2)];
+
+      expect(() =>
+        service.validateDeckAccess(UserPlan.PREMIUM, cards),
+      ).not.toThrow();
+    });
+
+    it('should allow PREMIUM user to use minor arcana cards', () => {
+      const cards = [
+        mockMajorArcanaCard(1),
+        mockMinorArcanaCard(2, 'bastos'),
+        mockMinorArcanaCard(3, 'copas'),
+      ];
+
+      expect(() =>
+        service.validateDeckAccess(UserPlan.PREMIUM, cards),
+      ).not.toThrow();
+    });
+
+    it('should allow FREE user to use only major arcana cards', () => {
+      const cards = [mockMajorArcanaCard(1), mockMajorArcanaCard(2)];
+
+      expect(() =>
+        service.validateDeckAccess(UserPlan.FREE, cards),
+      ).not.toThrow();
+    });
+
+    it('should throw ForbiddenException when FREE user tries to use a minor arcana card (bastos)', () => {
+      const cards = [mockMajorArcanaCard(1), mockMinorArcanaCard(2, 'bastos')];
+
+      expect(() => service.validateDeckAccess(UserPlan.FREE, cards)).toThrow(
+        ForbiddenException,
+      );
+      expect(() => service.validateDeckAccess(UserPlan.FREE, cards)).toThrow(
+        'El plan FREE solo permite cartas de Arcanos Mayores',
+      );
+    });
+
+    it('should throw ForbiddenException when FREE user tries to use a minor arcana card (copas)', () => {
+      const cards = [mockMinorArcanaCard(1, 'copas')];
+
+      expect(() => service.validateDeckAccess(UserPlan.FREE, cards)).toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should throw ForbiddenException when FREE user tries to use a minor arcana card (espadas)', () => {
+      const cards = [mockMajorArcanaCard(1), mockMinorArcanaCard(2, 'espadas')];
+
+      expect(() => service.validateDeckAccess(UserPlan.FREE, cards)).toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should throw ForbiddenException when FREE user tries to use a minor arcana card (oros)', () => {
+      const cards = [mockMinorArcanaCard(1, 'oros'), mockMajorArcanaCard(2)];
+
+      expect(() => service.validateDeckAccess(UserPlan.FREE, cards)).toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should throw ForbiddenException when ANONYMOUS user tries to use minor arcana cards', () => {
+      const cards = [mockMinorArcanaCard(1, 'bastos')];
+
+      expect(() =>
+        service.validateDeckAccess(UserPlan.ANONYMOUS, cards),
+      ).toThrow(ForbiddenException);
+      expect(() =>
+        service.validateDeckAccess(UserPlan.ANONYMOUS, cards),
+      ).toThrow('El plan FREE solo permite cartas de Arcanos Mayores');
+    });
+
+    it('should allow ANONYMOUS user to use only major arcana cards', () => {
+      const cards = [mockMajorArcanaCard(1), mockMajorArcanaCard(2)];
+
+      expect(() =>
+        service.validateDeckAccess(UserPlan.ANONYMOUS, cards),
+      ).not.toThrow();
+    });
+
+    it('should throw ForbiddenException when all cards are minor arcana (malicious FREE user)', () => {
+      const cards = [
+        mockMinorArcanaCard(1, 'bastos'),
+        mockMinorArcanaCard(2, 'copas'),
+        mockMinorArcanaCard(3, 'espadas'),
+      ];
+
+      expect(() => service.validateDeckAccess(UserPlan.FREE, cards)).toThrow(
+        ForbiddenException,
+      );
     });
   });
 });

--- a/backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/services/reading-validator.service.ts
@@ -12,6 +12,7 @@ import { TarotReading } from '../../entities/tarot-reading.entity';
 import { User, UserPlan } from '../../../../users/entities/user.entity';
 import { PlanConfigService } from '../../../../plan-config/plan-config.service';
 import { CategoriesService } from '../../../../categories/categories.service';
+import { TarotCard } from '../../../cards/entities/tarot-card.entity';
 
 @Injectable()
 export class ReadingValidatorService {
@@ -283,6 +284,31 @@ export class ReadingValidatorService {
 
       throw new ForbiddenException(
         `Los usuarios ${planNames[userPlan]} solo pueden acceder a las categorías: ${ReadingValidatorService.FREE_ALLOWED_CATEGORY_SLUGS.join(', ')}`,
+      );
+    }
+  }
+
+  /**
+   * Validate that a user can only use Major Arcana cards if they are on FREE or ANONYMOUS plan.
+   * PREMIUM users can use any cards from the full 78-card deck.
+   *
+   * @param userPlan - The user's subscription plan
+   * @param cards - The cards selected for the reading
+   * @throws ForbiddenException if FREE/ANONYMOUS user tries to use minor arcana cards
+   */
+  validateDeckAccess(userPlan: UserPlan, cards: TarotCard[]): void {
+    // PREMIUM has unrestricted access to all cards
+    if (userPlan === UserPlan.PREMIUM) {
+      return;
+    }
+
+    const hasMinorArcana = cards.some(
+      (card) => card.category !== 'arcanos_mayores',
+    );
+
+    if (hasMinorArcana) {
+      throw new ForbiddenException(
+        'El plan FREE solo permite cartas de Arcanos Mayores',
       );
     }
   }

--- a/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.spec.ts
@@ -110,6 +110,7 @@ describe('CreateReadingUseCase', () => {
             validateUser: jest.fn(),
             validateSpreadAccess: jest.fn(),
             validateCategoryAccess: jest.fn(),
+            validateDeckAccess: jest.fn(),
           },
         },
         {
@@ -1114,6 +1115,109 @@ describe('CreateReadingUseCase', () => {
         expect.not.objectContaining({ interpretation: expect.anything() }),
       );
       expect(result.interpretation).toBeNull();
+    });
+  });
+
+  describe('execute - deck access validation (T-FR-B03)', () => {
+    const mockFreeUser: User = {
+      id: 200,
+      email: 'free@example.com',
+      plan: UserPlan.FREE,
+    } as User;
+
+    const majorArcanaCards = [
+      { id: 1, name: 'El Loco', category: 'arcanos_mayores' },
+      { id: 2, name: 'El Mago', category: 'arcanos_mayores' },
+    ] as unknown as TarotCard[];
+
+    const mixedCards = [
+      { id: 1, name: 'El Loco', category: 'arcanos_mayores' },
+      { id: 22, name: 'As de Bastos', category: 'bastos' },
+    ] as unknown as TarotCard[];
+
+    const mockDtoFree: CreateReadingDto = {
+      deckId: 1,
+      spreadId: 1,
+      cardIds: [1, 2],
+      cardPositions: [
+        { cardId: 1, position: 'past', isReversed: false },
+        { cardId: 2, position: 'present', isReversed: false },
+      ],
+      useAI: false,
+    };
+
+    it('should call validateDeckAccess with user plan and cards', async () => {
+      const mockReading = createMockReading({ user: mockFreeUser });
+      validator.validateUser.mockResolvedValue(mockFreeUser);
+      decksService.findDeckById.mockResolvedValue(mockDeck);
+      spreadsService.findById.mockResolvedValue(mockSpread);
+      cardsService.findByIds.mockResolvedValue(majorArcanaCards);
+      readingRepo.create.mockResolvedValue(mockReading);
+
+      await useCase.execute(mockFreeUser, mockDtoFree);
+
+      expect(validator.validateDeckAccess).toHaveBeenCalledWith(
+        UserPlan.FREE,
+        majorArcanaCards,
+      );
+    });
+
+    it('should throw ForbiddenException when FREE user sends minor arcana cards', async () => {
+      validator.validateUser.mockResolvedValue(mockFreeUser);
+      decksService.findDeckById.mockResolvedValue(mockDeck);
+      spreadsService.findById.mockResolvedValue(mockSpread);
+      cardsService.findByIds.mockResolvedValue(mixedCards);
+      validator.validateDeckAccess.mockImplementation(() => {
+        throw new ForbiddenException(
+          'El plan FREE solo permite cartas de Arcanos Mayores',
+        );
+      });
+
+      await expect(useCase.execute(mockFreeUser, mockDtoFree)).rejects.toThrow(
+        ForbiddenException,
+      );
+      await expect(useCase.execute(mockFreeUser, mockDtoFree)).rejects.toThrow(
+        'El plan FREE solo permite cartas de Arcanos Mayores',
+      );
+    });
+
+    it('should call validateDeckAccess before creating the reading', async () => {
+      const callOrder: string[] = [];
+      validator.validateUser.mockResolvedValue(mockFreeUser);
+      decksService.findDeckById.mockResolvedValue(mockDeck);
+      spreadsService.findById.mockResolvedValue(mockSpread);
+      cardsService.findByIds.mockResolvedValue(majorArcanaCards);
+      validator.validateDeckAccess.mockImplementation(() => {
+        callOrder.push('validateDeckAccess');
+      });
+      readingRepo.create.mockImplementation(() => {
+        callOrder.push('repoCreate');
+        return Promise.resolve(createMockReading({ user: mockFreeUser }));
+      });
+
+      await useCase.execute(mockFreeUser, mockDtoFree);
+
+      const deckIdx = callOrder.indexOf('validateDeckAccess');
+      const createIdx = callOrder.indexOf('repoCreate');
+      expect(deckIdx).toBeGreaterThanOrEqual(0);
+      expect(createIdx).toBeGreaterThan(deckIdx);
+    });
+
+    it('should still call validateDeckAccess for PREMIUM users (no restriction expected)', async () => {
+      const premiumDto: CreateReadingDto = { ...mockDtoFree, useAI: false };
+      const mockReading = createMockReading();
+      validator.validateUser.mockResolvedValue(mockUser); // PREMIUM
+      decksService.findDeckById.mockResolvedValue(mockDeck);
+      spreadsService.findById.mockResolvedValue(mockSpread);
+      cardsService.findByIds.mockResolvedValue(majorArcanaCards);
+      readingRepo.create.mockResolvedValue(mockReading);
+
+      await useCase.execute(mockUser, premiumDto);
+
+      expect(validator.validateDeckAccess).toHaveBeenCalledWith(
+        UserPlan.PREMIUM,
+        majorArcanaCards,
+      );
     });
   });
 });

--- a/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.spec.ts
@@ -1173,10 +1173,9 @@ describe('CreateReadingUseCase', () => {
         );
       });
 
-      await expect(useCase.execute(mockFreeUser, mockDtoFree)).rejects.toThrow(
-        ForbiddenException,
-      );
-      await expect(useCase.execute(mockFreeUser, mockDtoFree)).rejects.toThrow(
+      const executionPromise = useCase.execute(mockFreeUser, mockDtoFree);
+      await expect(executionPromise).rejects.toThrow(ForbiddenException);
+      await expect(executionPromise).rejects.toThrow(
         'El plan FREE solo permite cartas de Arcanos Mayores',
       );
     });

--- a/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.ts
@@ -49,8 +49,8 @@ export class CreateReadingUseCase {
       );
     }
 
-    // Validar usuario
-    await this.validator.validateUser(user.id);
+    // Validar usuario — capturar el User completo desde BD (incluye plan real)
+    const validatedUser = await this.validator.validateUser(user.id);
 
     // Validar que el deck existe
     const deck = await this.decksService.findDeckById(createReadingDto.deckId);
@@ -71,12 +71,15 @@ export class CreateReadingUseCase {
     }
 
     // Validar que el usuario tiene acceso al spread según su plan
-    this.validator.validateSpreadAccess(user.plan, spread.requiredPlan);
+    this.validator.validateSpreadAccess(
+      validatedUser.plan,
+      spread.requiredPlan,
+    );
 
     // Validar acceso a la categoría si se proporciona (solo relevante para usuarios FREE)
     if (createReadingDto.categoryId) {
       await this.validator.validateCategoryAccess(
-        user.plan,
+        validatedUser.plan,
         createReadingDto.categoryId,
       );
     }
@@ -98,7 +101,7 @@ export class CreateReadingUseCase {
     const cards = await this.cardsService.findByIds(createReadingDto.cardIds);
 
     // T-FR-B03: Validar que FREE/ANONYMOUS solo use Arcanos Mayores
-    this.validator.validateDeckAccess(user.plan, cards);
+    this.validator.validateDeckAccess(validatedUser.plan, cards);
 
     // Crear la lectura primero sin interpretación
     const reading = await this.readingRepo.create({
@@ -189,7 +192,10 @@ export class CreateReadingUseCase {
 
     // T-FR-B02: Flujo FREE — buscar interpretaciones pre-escritas si se proporcionó categoryId
     // Solo aplica a usuarios FREE/ANONYMOUS; PREMIUM nunca recibe freeInterpretations
-    if (createReadingDto.categoryId && user.plan !== UserPlan.PREMIUM) {
+    if (
+      createReadingDto.categoryId &&
+      validatedUser.plan !== UserPlan.PREMIUM
+    ) {
       const freeInterpretations =
         await this.cardFreeInterpretationService.findByCardsAndCategory(
           cards,

--- a/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/application/use-cases/create-reading.use-case.ts
@@ -97,6 +97,9 @@ export class CreateReadingUseCase {
     // Obtener las cartas antes de crear la lectura (esto también valida que existan)
     const cards = await this.cardsService.findByIds(createReadingDto.cardIds);
 
+    // T-FR-B03: Validar que FREE/ANONYMOUS solo use Arcanos Mayores
+    this.validator.validateDeckAccess(user.plan, cards);
+
     // Crear la lectura primero sin interpretación
     const reading = await this.readingRepo.create({
       predefinedQuestionId: createReadingDto.predefinedQuestionId || null,

--- a/docs/BACKLOG_FREE_READING_EXPERIENCE.md
+++ b/docs/BACKLOG_FREE_READING_EXPERIENCE.md
@@ -375,7 +375,7 @@ CARTA DEL DÍA:
 | T-FR-P01 | Rename de rutas `/ritual` → `/tarot` + redirects                   | Frontend | ✅ COMPLETADA | 0.5 días   |
 | T-FR-B01 | Capa de dominio: Migración, entidad y campos nuevos                | Backend  | ✅ COMPLETADA | 2 días     |
 | T-FR-B02 | Capa de aplicación: Service, Repository y modificación de use case | Backend  | ✅ COMPLETADA | 3 días     |
-| T-FR-B03 | Validación de mazo FREE + modificación de daily-reading            | Backend  | 🔴 CRÍTICA | 2 días     |
+| T-FR-B03 | Validación de mazo FREE + modificación de daily-reading            | Backend  | ✅ COMPLETADA | 2 días     |
 | T-FR-B04 | Capability `canUseFullDeck` + endpoint `GET /cards?category=`      | Backend  | 🟡 ALTA    | 1 día      |
 | T-FR-S01 | Seed de tiradas — 132 prompts para Claude/Gemini                   | Content  | 🔴 CRÍTICA | 3 días     |
 | T-FR-S02 | Seed de carta del día — 44 prompts para Claude/Gemini              | Content  | 🔴 CRÍTICA | 2 días     |
@@ -558,7 +558,7 @@ Crear el servicio que consulta las interpretaciones pre-escritas y modificar el 
 **Prioridad:** 🔴 CRÍTICA
 **Estimación:** 2 días
 **Dependencias:** T-FR-B01
-**Estado:** ⏳ PENDIENTE
+**Estado:** ✅ COMPLETADA
 **Cubre HUS:** HUS-004, HUS-005
 
 #### 📋 Descripción
@@ -569,31 +569,31 @@ Agregar validación de seguridad backend que impida a usuarios FREE usar Arcanos
 
 **Validación de Mazo (create-reading):**
 
-- [ ] En `create-reading.use-case.ts` (o `ReadingValidatorService`), si `!useAI`, verificar que todas las cartas tengan `category === 'arcanos_mayores'`
-- [ ] Lanzar `ForbiddenException('El plan FREE solo permite cartas de Arcanos Mayores')` si la validación falla
-- [ ] Tests unitarios con intento malicioso (FREE enviando IDs de arcanos menores)
+- [x] En `create-reading.use-case.ts` (o `ReadingValidatorService`), si `!useAI`, verificar que todas las cartas tengan `category === 'arcanos_mayores'`
+- [x] Lanzar `ForbiddenException('El plan FREE solo permite cartas de Arcanos Mayores')` si la validación falla
+- [x] Tests unitarios con intento malicioso (FREE enviando IDs de arcanos menores)
 
 **Modificación de DailyReadingService:**
 
-- [ ] Modificar `selectRandomCard()` en `daily-reading.service.ts`: aceptar parámetro `onlyMajorArcana: boolean`; si `true`, filtrar query por `category: 'arcanos_mayores'`
-- [ ] En el método que orquesta la carta del día: si el usuario es FREE/anónimo → `onlyMajorArcana: true`
-- [ ] Retornar `card.dailyFreeUpright` o `card.dailyFreeReversed` como `interpretation` cuando el usuario no accede a interpretación personalizada (antes retornaba `null` o `meaningUpright`)
-- [ ] Fallback: si `dailyFreeUpright/Reversed` es `null` (aún sin seed), usar `meaningUpright/Reversed` con log warning
+- [x] Modificar `selectRandomCard()` en `daily-reading.service.ts`: aceptar parámetro `onlyMajorArcana: boolean`; si `true`, filtrar query por `category: 'arcanos_mayores'`
+- [x] En el método que orquesta la carta del día: si el usuario es FREE/anónimo → `onlyMajorArcana: true`
+- [x] Retornar `card.dailyFreeUpright` o `card.dailyFreeReversed` como `interpretation` cuando el usuario no accede a interpretación personalizada (antes retornaba `null` o `meaningUpright`)
+- [x] Fallback: si `dailyFreeUpright/Reversed` es `null` (aún sin seed), usar `meaningUpright/Reversed` con log warning
 
 **Tests:**
 
-- [ ] Tests unitarios: usuario anónimo → solo arcanos mayores + texto `dailyFreeUpright`
-- [ ] Tests: usuario FREE → igual que anónimo
-- [ ] Tests: usuario PREMIUM → mazo completo + interpretación personalizada
-- [ ] Tests: fallback cuando `dailyFreeUpright` es `null`
+- [x] Tests unitarios: usuario anónimo → solo arcanos mayores + texto `dailyFreeUpright`
+- [x] Tests: usuario FREE → igual que anónimo
+- [x] Tests: usuario PREMIUM → mazo completo + interpretación personalizada
+- [x] Tests: fallback cuando `dailyFreeUpright` es `null`
 
 #### 🎯 Criterios de aceptación
 
-- [ ] Un cliente malicioso FREE no puede obtener lectura con arcanos menores (403)
-- [ ] Carta del día para FREE/anónimo siempre es un arcano mayor
-- [ ] Carta del día para FREE/anónimo muestra el texto `dailyFreeUpright/Reversed`
-- [ ] El flujo PREMIUM sigue generando interpretación personalizada sin cambios
-- [ ] Coverage ≥ 80%
+- [x] Un cliente malicioso FREE no puede obtener lectura con arcanos menores (403)
+- [x] Carta del día para FREE/anónimo siempre es un arcano mayor
+- [x] Carta del día para FREE/anónimo muestra el texto `dailyFreeUpright/Reversed`
+- [x] El flujo PREMIUM sigue generando interpretación personalizada sin cambios
+- [x] Coverage ≥ 80%
 
 ---
 


### PR DESCRIPTION
## Descripcion

Implementa **T-FR-B03** del backlog BACKLOG_FREE_READING_EXPERIENCE.md, cubriendo HUS-004 y HUS-005.

## Cambios

### Validacion de mazo (create-reading)
- Nuevo metodo validateDeckAccess(plan, cards) en ReadingValidatorService
- Usuarios FREE/ANONYMOUS que intenten crear lecturas con cartas de Arcanos Menores reciben 403 ForbiddenException
- Llamada integrada en CreateReadingUseCase.execute() tras cardsService.findByIds()

### Modificacion de DailyReadingService
- selectRandomCard(onlyMajorArcana: boolean = false): cuando true, filtra a category = 'arcanos_mayores' (22 cartas)
- generateDailyCard: FREE usa selectRandomCard(true) + dailyFreeUpright/Reversed (fallback a meaningUpright/Reversed con Logger.warn)
- generateAnonymousDailyCard: misma logica que FREE

## Tests (TDD)

- ReadingValidatorService: 10 nuevos tests
- CreateReadingUseCase: 4 nuevos tests de integracion validateDeckAccess
- DailyReadingService generateDailyCard T-FR-B03: 5 tests (filtro, dailyFreeUpright/Reversed, fallback, PREMIUM sin cambio)
- DailyReadingService generateAnonymousDailyCard T-FR-B03: 3 tests (filtro, reversed, fallback)
- Test preexistente actualizado para reflejar nuevo comportamiento (interpretacion no null)

## Quality Gates

- npm run format: sin cambios
- npm run lint: sin errores
- npm run test:cov: 299 suites, 4312 tests, 83.88% coverage (mayor 80%)
- npm run build: exitoso
- node scripts/validate-architecture.js: Architecture validation passed