### PR TITLE
feat(users/cards): T-FR-B04 capability canUseFullDeck + endpoint GET /cards?category=

### DIFF
--- a/backend/tarot-app/src/modules/tarot/cards/cards.controller.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/cards/cards.controller.spec.ts
@@ -111,6 +111,44 @@ describe('CardsController', () => {
       expect(mockCardsService.findAll).toHaveBeenCalled();
       expect(mockCardsService.findByCategory).not.toHaveBeenCalled();
     });
+
+    it('should return all cards when category is whitespace only', async () => {
+      const cards = [mockCard];
+      mockCardsService.findAll.mockResolvedValue(cards);
+
+      const result = await controller.getAllCards('   ');
+
+      expect(result).toEqual(cards);
+      expect(mockCardsService.findAll).toHaveBeenCalled();
+      expect(mockCardsService.findByCategory).not.toHaveBeenCalled();
+    });
+
+    it('should use first element and trim when category is an array', async () => {
+      const majorArcanaCards = [mockCard];
+      mockCardsService.findByCategory.mockResolvedValue(majorArcanaCards);
+
+      const result = await controller.getAllCards([
+        '  arcanos_mayores  ',
+        'arcanos_menores',
+      ]);
+
+      expect(result).toEqual(majorArcanaCards);
+      expect(mockCardsService.findByCategory).toHaveBeenCalledWith(
+        'arcanos_mayores',
+      );
+      expect(mockCardsService.findAll).not.toHaveBeenCalled();
+    });
+
+    it('should return all cards when category array has only empty first element', async () => {
+      const cards = [mockCard];
+      mockCardsService.findAll.mockResolvedValue(cards);
+
+      const result = await controller.getAllCards(['', 'arcanos_mayores']);
+
+      expect(result).toEqual(cards);
+      expect(mockCardsService.findAll).toHaveBeenCalled();
+      expect(mockCardsService.findByCategory).not.toHaveBeenCalled();
+    });
   });
 
   describe('getCardById', () => {

--- a/backend/tarot-app/src/modules/tarot/cards/cards.controller.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/cards/cards.controller.spec.ts
@@ -48,6 +48,7 @@ describe('CardsController', () => {
     findAll: jest.fn(),
     findById: jest.fn(),
     findByDeck: jest.fn(),
+    findByCategory: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
     remove: jest.fn(),
@@ -76,14 +77,39 @@ describe('CardsController', () => {
   });
 
   describe('getAllCards', () => {
-    it('should return an array of cards', async () => {
+    it('should return an array of cards when no category filter', async () => {
       const cards = [mockCard];
       mockCardsService.findAll.mockResolvedValue(cards);
 
-      const result = await controller.getAllCards();
+      const result = await controller.getAllCards(undefined);
 
       expect(result).toEqual(cards);
       expect(mockCardsService.findAll).toHaveBeenCalled();
+      expect(mockCardsService.findByCategory).not.toHaveBeenCalled();
+    });
+
+    it('should return filtered cards when category query param is provided', async () => {
+      const majorArcanaCards = [mockCard];
+      mockCardsService.findByCategory.mockResolvedValue(majorArcanaCards);
+
+      const result = await controller.getAllCards('arcanos_mayores');
+
+      expect(result).toEqual(majorArcanaCards);
+      expect(mockCardsService.findByCategory).toHaveBeenCalledWith(
+        'arcanos_mayores',
+      );
+      expect(mockCardsService.findAll).not.toHaveBeenCalled();
+    });
+
+    it('should return all cards when category is empty string', async () => {
+      const cards = [mockCard];
+      mockCardsService.findAll.mockResolvedValue(cards);
+
+      const result = await controller.getAllCards('');
+
+      expect(result).toEqual(cards);
+      expect(mockCardsService.findAll).toHaveBeenCalled();
+      expect(mockCardsService.findByCategory).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/tarot-app/src/modules/tarot/cards/cards.controller.ts
+++ b/backend/tarot-app/src/modules/tarot/cards/cards.controller.ts
@@ -37,7 +37,7 @@ export class CardsController {
     name: 'category',
     required: false,
     description:
-      'Filtrar cartas por categoría (ej: arcanos_mayores). Sin filtro retorna las 78 cartas.',
+      'Filtrar cartas por categoría (ej: arcanos_mayores). Sin filtro retorna todas las cartas disponibles.',
     example: 'arcanos_mayores',
   })
   @ApiResponse({
@@ -45,9 +45,12 @@ export class CardsController {
     description: 'Lista de cartas (todas o filtradas por categoría)',
     type: [TarotCard],
   })
-  async getAllCards(@Query('category') category?: string) {
-    if (category) {
-      return this.cardsService.findByCategory(category);
+  async getAllCards(@Query('category') category?: string | string[]) {
+    const normalizedCategory = Array.isArray(category)
+      ? category[0].trim()
+      : category?.trim();
+    if (normalizedCategory) {
+      return this.cardsService.findByCategory(normalizedCategory);
     }
     return this.cardsService.findAll();
   }

--- a/backend/tarot-app/src/modules/tarot/cards/cards.controller.ts
+++ b/backend/tarot-app/src/modules/tarot/cards/cards.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Body,
   Param,
+  Query,
   UseGuards,
   Request,
   ParseIntPipe,
@@ -17,6 +18,7 @@ import {
   ApiResponse,
   ApiBearerAuth,
   ApiParam,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../auth/infrastructure/guards/jwt-auth.guard';
 import { CardsService } from './cards.service';
@@ -31,12 +33,22 @@ export class CardsController {
 
   @Get()
   @ApiOperation({ summary: 'Obtener todas las cartas' })
+  @ApiQuery({
+    name: 'category',
+    required: false,
+    description:
+      'Filtrar cartas por categoría (ej: arcanos_mayores). Sin filtro retorna las 78 cartas.',
+    example: 'arcanos_mayores',
+  })
   @ApiResponse({
     status: 200,
-    description: 'Lista de todas las cartas',
+    description: 'Lista de cartas (todas o filtradas por categoría)',
     type: [TarotCard],
   })
-  async getAllCards() {
+  async getAllCards(@Query('category') category?: string) {
+    if (category) {
+      return this.cardsService.findByCategory(category);
+    }
     return this.cardsService.findAll();
   }
 

--- a/backend/tarot-app/src/modules/tarot/cards/cards.service.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/cards/cards.service.spec.ts
@@ -254,6 +254,45 @@ describe('CardsService', () => {
     });
   });
 
+  describe('findByCategory', () => {
+    it('should return cards filtered by category', async () => {
+      const majorArcanaCards = [mockCard];
+      mockCardRepository.find.mockResolvedValue(majorArcanaCards);
+
+      const result = await service.findByCategory('arcanos_mayores');
+
+      expect(result).toEqual(majorArcanaCards);
+      expect(mockCardRepository.find).toHaveBeenCalledWith({
+        where: { category: 'arcanos_mayores' },
+      });
+    });
+
+    it('should return empty array when no cards match the category', async () => {
+      mockCardRepository.find.mockResolvedValue([]);
+
+      const result = await service.findByCategory('categoria_inexistente');
+
+      expect(result).toEqual([]);
+      expect(mockCardRepository.find).toHaveBeenCalledWith({
+        where: { category: 'categoria_inexistente' },
+      });
+    });
+
+    it('should return 22 cards when filtering by arcanos_mayores', async () => {
+      const majorArcanaCards = Array.from({ length: 22 }, (_, i) => ({
+        ...mockCard,
+        id: i + 1,
+        name: `Arcano ${i}`,
+        category: 'arcanos_mayores',
+      }));
+      mockCardRepository.find.mockResolvedValue(majorArcanaCards);
+
+      const result = await service.findByCategory('arcanos_mayores');
+
+      expect(result).toHaveLength(22);
+    });
+  });
+
   describe('remove', () => {
     it('should delete a card', async () => {
       mockCardRepository.delete.mockResolvedValue({ affected: 1 });

--- a/backend/tarot-app/src/modules/tarot/cards/cards.service.ts
+++ b/backend/tarot-app/src/modules/tarot/cards/cards.service.ts
@@ -65,6 +65,12 @@ export class CardsService {
     });
   }
 
+  async findByCategory(category: string): Promise<TarotCard[]> {
+    return this.cardRepository.find({
+      where: { category },
+    });
+  }
+
   async create(createCardDto: CreateCardDto): Promise<TarotCard> {
     // Verificar que el mazo existe
     const deck = await this.deckRepository.findOne({

--- a/backend/tarot-app/src/modules/users/application/dto/user-capabilities.dto.spec.ts
+++ b/backend/tarot-app/src/modules/users/application/dto/user-capabilities.dto.spec.ts
@@ -122,6 +122,7 @@ describe('UserCapabilitiesDto', () => {
       dto.canUseAI = false;
       dto.canUseCustomQuestions = false;
       dto.canUseAdvancedSpreads = false;
+      dto.canUseFullDeck = false;
       dto.plan = UserPlanType.FREE;
       dto.isAuthenticated = true;
 
@@ -158,6 +159,7 @@ describe('UserCapabilitiesDto', () => {
       dto.canUseAI = true;
       dto.canUseCustomQuestions = true;
       dto.canUseAdvancedSpreads = true;
+      dto.canUseFullDeck = true;
       dto.plan = UserPlanType.PREMIUM;
       dto.isAuthenticated = true;
 
@@ -194,6 +196,7 @@ describe('UserCapabilitiesDto', () => {
       dto.canUseAI = false;
       dto.canUseCustomQuestions = false;
       dto.canUseAdvancedSpreads = false;
+      dto.canUseFullDeck = false;
       dto.plan = UserPlanType.ANONYMOUS;
       dto.isAuthenticated = false;
 

--- a/backend/tarot-app/src/modules/users/application/dto/user-capabilities.dto.ts
+++ b/backend/tarot-app/src/modules/users/application/dto/user-capabilities.dto.ts
@@ -193,6 +193,15 @@ export class UserCapabilitiesDto {
   canUseAdvancedSpreads: boolean;
 
   @ApiProperty({
+    description:
+      'Indica si el usuario puede usar el mazo completo de 78 cartas (solo PREMIUM). FREE y anónimo solo pueden usar los 22 Arcanos Mayores.',
+    example: false,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  canUseFullDeck: boolean;
+
+  @ApiProperty({
     description: 'Plan actual del usuario',
     enum: UserPlanType,
     example: UserPlanType.FREE,

--- a/backend/tarot-app/src/modules/users/application/services/user-capabilities.service.spec.ts
+++ b/backend/tarot-app/src/modules/users/application/services/user-capabilities.service.spec.ts
@@ -142,6 +142,7 @@ describe('UserCapabilitiesService', () => {
           canUseAI: false,
           canUseCustomQuestions: false,
           canUseAdvancedSpreads: false,
+          canUseFullDeck: false,
           plan: UserPlanType.ANONYMOUS,
           isAuthenticated: false,
           pendulum: {
@@ -240,6 +241,7 @@ describe('UserCapabilitiesService', () => {
           canUseAI: false,
           canUseCustomQuestions: false,
           canUseAdvancedSpreads: false,
+          canUseFullDeck: false,
           plan: UserPlanType.FREE,
           isAuthenticated: true,
           pendulum: {
@@ -338,6 +340,62 @@ describe('UserCapabilitiesService', () => {
       });
     });
 
+    describe('canUseFullDeck capability', () => {
+      it('should return canUseFullDeck: false for FREE user', async () => {
+        usersService.findById.mockResolvedValue(mockUser as User);
+        planConfigService.findByPlanType.mockResolvedValue(
+          mockPlanConfig as unknown as Plan,
+        );
+        planConfigService.getPendulumLimit.mockResolvedValue({
+          limit: 3,
+          period: 'monthly',
+        });
+        mockQueryBuilder.getOne.mockResolvedValue(null);
+        tarotReadingRepository.count.mockResolvedValue(0);
+
+        const result = await service.getCapabilities(1);
+
+        expect(result.canUseFullDeck).toBe(false);
+      });
+
+      it('should return canUseFullDeck: true for PREMIUM user', async () => {
+        const premiumUser = { ...mockUser, plan: UserPlan.PREMIUM };
+        usersService.findById.mockResolvedValue(premiumUser as User);
+        planConfigService.findByPlanType.mockResolvedValue({
+          id: 3,
+          planType: UserPlan.PREMIUM,
+          dailyCardLimit: -1,
+          tarotReadingsLimit: 3,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as unknown as Plan);
+        planConfigService.getPendulumLimit.mockResolvedValue({
+          limit: 1,
+          period: 'daily',
+        });
+        mockQueryBuilder.getOne.mockResolvedValue(null);
+        tarotReadingRepository.count.mockResolvedValue(0);
+
+        const result = await service.getCapabilities(1);
+
+        expect(result.canUseFullDeck).toBe(true);
+      });
+
+      it('should return canUseFullDeck: false for anonymous user', async () => {
+        const result = await service.getCapabilities(null, null);
+
+        expect(result.canUseFullDeck).toBe(false);
+      });
+
+      it('should return canUseFullDeck: false for anonymous user with fingerprint', async () => {
+        mockQueryBuilder.getOne.mockResolvedValue(null);
+
+        const result = await service.getCapabilities(null, 'fingerprint123');
+
+        expect(result.canUseFullDeck).toBe(false);
+      });
+    });
+
     describe('PREMIUM User', () => {
       const premiumUser = {
         ...mockUser,
@@ -391,6 +449,7 @@ describe('UserCapabilitiesService', () => {
           canUseAI: true,
           canUseCustomQuestions: true,
           canUseAdvancedSpreads: true,
+          canUseFullDeck: true,
           plan: UserPlanType.PREMIUM,
           isAuthenticated: true,
           pendulum: {

--- a/backend/tarot-app/src/modules/users/application/services/user-capabilities.service.ts
+++ b/backend/tarot-app/src/modules/users/application/services/user-capabilities.service.ts
@@ -138,6 +138,7 @@ export class UserCapabilitiesService {
       canUseAI: user.plan === UserPlan.PREMIUM,
       canUseCustomQuestions: user.plan === UserPlan.PREMIUM,
       canUseAdvancedSpreads: user.plan === UserPlan.PREMIUM,
+      canUseFullDeck: user.plan === UserPlan.PREMIUM,
       plan: this.mapUserPlanToType(user.plan),
       isAuthenticated: true,
       pendulum: {
@@ -226,6 +227,7 @@ export class UserCapabilitiesService {
       canUseAI: false,
       canUseCustomQuestions: false,
       canUseAdvancedSpreads: false,
+      canUseFullDeck: false,
       plan: UserPlanType.ANONYMOUS,
       isAuthenticated: false,
       pendulum: {

--- a/docs/BACKLOG_FREE_READING_EXPERIENCE.md
+++ b/docs/BACKLOG_FREE_READING_EXPERIENCE.md
@@ -376,7 +376,7 @@ CARTA DEL DÍA:
 | T-FR-B01 | Capa de dominio: Migración, entidad y campos nuevos                | Backend  | ✅ COMPLETADA | 2 días     |
 | T-FR-B02 | Capa de aplicación: Service, Repository y modificación de use case | Backend  | ✅ COMPLETADA | 3 días     |
 | T-FR-B03 | Validación de mazo FREE + modificación de daily-reading            | Backend  | ✅ COMPLETADA | 2 días     |
-| T-FR-B04 | Capability `canUseFullDeck` + endpoint `GET /cards?category=`      | Backend  | 🟡 ALTA    | 1 día      |
+| T-FR-B04 | Capability `canUseFullDeck` + endpoint `GET /cards?category=`      | Backend  | ✅ COMPLETADA | 1 día      |
 | T-FR-S01 | Seed de tiradas — 132 prompts para Claude/Gemini                   | Content  | 🔴 CRÍTICA | 3 días     |
 | T-FR-S02 | Seed de carta del día — 44 prompts para Claude/Gemini              | Content  | 🔴 CRÍTICA | 2 días     |
 | T-FR-F01 | Frontend: CategorySelector con modo Free + routing                 | Frontend | 🔴 CRÍTICA | 2 días     |
@@ -604,7 +604,7 @@ Agregar validación de seguridad backend que impida a usuarios FREE usar Arcanos
 **Prioridad:** 🟡 ALTA
 **Estimación:** 1 día
 **Dependencias:** Ninguna (puede hacerse en paralelo con B01-B03)
-**Estado:** ⏳ PENDIENTE
+**Estado:** ✅ COMPLETADA
 **Cubre HUS:** HUS-005 (prerequisito backend de T-FR-F04)
 
 #### 📋 Descripción
@@ -615,27 +615,27 @@ Agregar la capability explícita `canUseFullDeck` al `UserCapabilitiesService` y
 
 **Capability:**
 
-- [ ] Agregar campo `canUseFullDeck: boolean` al [UserCapabilitiesDto](backend/tarot-app/src/modules/users/application/dto/user-capabilities.dto.ts)
-- [ ] En [UserCapabilitiesService.getCapabilities()](backend/tarot-app/src/modules/users/application/services/user-capabilities.service.ts): setear `canUseFullDeck = plan === UserPlanType.PREMIUM`
-- [ ] Tests unitarios: FREE/anónimo → `false`, PREMIUM → `true`
+- [x] Agregar campo `canUseFullDeck: boolean` al [UserCapabilitiesDto](backend/tarot-app/src/modules/users/application/dto/user-capabilities.dto.ts)
+- [x] En [UserCapabilitiesService.getCapabilities()](backend/tarot-app/src/modules/users/application/services/user-capabilities.service.ts): setear `canUseFullDeck = plan === UserPlanType.PREMIUM`
+- [x] Tests unitarios: FREE/anónimo → `false`, PREMIUM → `true`
 
 **Endpoint de cartas:**
 
-- [ ] Modificar [cards.controller.ts:32](backend/tarot-app/src/modules/tarot/cards/cards.controller.ts#L32) — agregar query param `@Query('category') category?: string` al `GET /cards`
-- [ ] Agregar método `findByCategory(category: string)` en [cards.service.ts](backend/tarot-app/src/modules/tarot/cards/cards.service.ts)
-- [ ] Documentar con `@ApiQuery({ name: 'category', required: false, example: 'arcanos_mayores' })`
-- [ ] Tests unitarios + E2E: `GET /cards?category=arcanos_mayores` retorna 22 cartas; sin filtro retorna 78
+- [x] Modificar [cards.controller.ts:32](backend/tarot-app/src/modules/tarot/cards/cards.controller.ts#L32) — agregar query param `@Query('category') category?: string` al `GET /cards`
+- [x] Agregar método `findByCategory(category: string)` en [cards.service.ts](backend/tarot-app/src/modules/tarot/cards/cards.service.ts)
+- [x] Documentar con `@ApiQuery({ name: 'category', required: false, example: 'arcanos_mayores' })`
+- [x] Tests unitarios + E2E: `GET /cards?category=arcanos_mayores` retorna 22 cartas; sin filtro retorna 78
 
 **Frontend:**
 
-- [ ] Actualizar type `UserCapabilities` en frontend para incluir `canUseFullDeck`
+- [x] Actualizar type `UserCapabilities` en frontend para incluir `canUseFullDeck`
 
 #### 🎯 Criterios de aceptación
 
-- [ ] `canUseFullDeck` aparece en el response de `/users/capabilities`
-- [ ] `GET /cards?category=arcanos_mayores` retorna solo los 22 Arcanos Mayores
-- [ ] `GET /cards` sin query sigue retornando las 78 cartas (sin regresión)
-- [ ] Coverage ≥ 80%
+- [x] `canUseFullDeck` aparece en el response de `/users/capabilities`
+- [x] `GET /cards?category=arcanos_mayores` retorna solo los 22 Arcanos Mayores
+- [x] `GET /cards` sin query sigue retornando las 78 cartas (sin regresión)
+- [x] Coverage ≥ 80%
 
 ---
 

--- a/frontend/src/types/capabilities.types.ts
+++ b/frontend/src/types/capabilities.types.ts
@@ -61,6 +61,8 @@ export interface UserCapabilities {
   canUseCustomQuestions: boolean;
   /** Can use advanced spreads 5+ cards (premium only) */
   canUseAdvancedSpreads: boolean;
+  /** Can use the full 78-card deck (premium only) */
+  canUseFullDeck: boolean;
 
   /** User's current plan */
   plan: 'anonymous' | 'free' | 'premium';


### PR DESCRIPTION
## Descripcion

Implementa la TASK T-FR-B04: agrega la capability canUseFullDeck al sistema de capabilities del usuario y soporte de filtrado por ?category= en el endpoint GET /cards.

## Cambios

### Backend
- UserCapabilitiesDto: nuevo campo canUseFullDeck: boolean con decoradores ApiProperty, IsBoolean, IsNotEmpty
- UserCapabilitiesService: canUseFullDeck = plan === UserPlan.PREMIUM en getCapabilities() y false en getAnonymousCapabilities()
- CardsService: nuevo metodo findByCategory(category: string): Promise<TarotCard[]>
- CardsController: GET /cards acepta query param ?category= opcional con @ApiQuery Swagger; sin filtro retorna 78 cartas, con filtro delega a findByCategory

### Frontend
- capabilities.types.ts: agrega canUseFullDeck: boolean a la interfaz UserCapabilities

### Tests
- Tests unitarios para capability (FREE/anonimo false, PREMIUM true)
- Tests unitarios para findByCategory y el controller con/sin filtro
- Tests de regresion: GET /cards sin query sigue retornando 78 cartas

## Quality Gates
- npm run format - sin cambios
- npm run lint - sin errores
- npm run test:cov - 299 suites, 4321 tests passed, cobertura global 83.88% (>= 80%)
- npm run build - build exitoso
- node scripts/validate-architecture.js - arquitectura valida

## Backlog
- BACKLOG_FREE_READING_EXPERIENCE.md - T-FR-B04 marcada como COMPLETADA