### PR TITLE
feat(T-FR-F02): InterpretationSection con textos pre-escritos + FreeReadingUpgradeBanner

### DIFF
--- a/docs/BACKLOG_FREE_READING_EXPERIENCE.md
+++ b/docs/BACKLOG_FREE_READING_EXPERIENCE.md
@@ -380,7 +380,7 @@ CARTA DEL DÍA:
 | T-FR-S01 | Seed de tiradas — 132 prompts para Claude/Gemini                   | Content  | ✅ COMPLETADA | 3 días     |
 | T-FR-S02 | Seed de carta del día — 44 prompts para Claude/Gemini              | Content  | ✅ COMPLETADA | 2 días     |
 | T-FR-F01 | Frontend: CategorySelector con modo Free + routing                 | Frontend | ✅ COMPLETADA | 2 días     |
-| T-FR-F02 | Frontend: InterpretationSection con textos pre-escritos + CTA      | Frontend | 🔴 CRÍTICA | 2 días     |
+| T-FR-F02 | Frontend: InterpretationSection con textos pre-escritos + CTA      | Frontend | ✅ COMPLETADA | 2 días     |
 | T-FR-F03 | Frontend: DailyCardExperience con texto de energía diaria          | Frontend | 🔴 CRÍTICA | 2 días     |
 | T-FR-F04 | Frontend: Deck filtrado a Arcanos Mayores para FREE                | Frontend | 🟡 ALTA    | 2 días     |
 
@@ -849,23 +849,19 @@ Modificar `CategorySelector` para soportar un modo FREE con filtrado a 3 categor
 **Prioridad:** 🔴 CRÍTICA
 **Estimación:** 2 días
 **Dependencias:** T-FR-B02 (backend retorna `freeInterpretations`)
-**Estado:** ⏳ PENDIENTE
+**Estado:** ✅ COMPLETADA
 **Cubre HUS:** HUS-003, HUS-006
-
-#### 📋 Descripción
-
-Modificar la sección de resultados de lectura (`InterpretationSection` en `ReadingExperience.tsx`) para que, cuando el response trae `freeInterpretations`, renderice los textos amigables pre-escritos en lugar de los `meaningUpright/Reversed` crudos. Incluir el banner de upgrade a Premium al final.
 
 #### ✅ Tareas específicas
 
-- [ ] Actualizar tipos TypeScript: agregar `freeInterpretations?: ...` al tipo `Reading`
-- [ ] Modificar `InterpretationSection` (`ReadingExperience.tsx` L164-229):
+- [x] Actualizar tipos TypeScript: agregar `freeInterpretations?: ...` al tipo `Reading`
+- [x] Modificar `InterpretationSection` (`ReadingExperience.tsx` L164-229):
   - Si `reading.freeInterpretations` está presente, usar esos textos por carta/orientación
   - Mostrar el nombre de la categoría elegida con ícono en el encabezado (ej: ❤️ Tu Lectura de Amor)
   - Fallback: si falta combinación, usar `meaningUpright/Reversed` existente con mensaje discreto
-- [ ] Crear componente `FreeReadingUpgradeBanner` (reutilizable): título, descripción, botón CTA a `/premium`
-- [ ] Renderizar `FreeReadingUpgradeBanner` al final de la sección cuando el usuario es FREE
-- [ ] Tests unitarios:
+- [x] Crear componente `FreeReadingUpgradeBanner` (reutilizable): título, descripción, botón CTA a `/premium`
+- [x] Renderizar `FreeReadingUpgradeBanner` al final de la sección cuando el usuario es FREE
+- [x] Tests unitarios:
   - `InterpretationSection` muestra textos pre-escritos cuando `freeInterpretations` está presente
   - Muestra el nombre+ícono de la categoría correctamente
   - Fallback a `meaningUpright/Reversed` cuando falta combinación
@@ -873,11 +869,11 @@ Modificar la sección de resultados de lectura (`InterpretationSection` en `Read
 
 #### 🎯 Criterios de aceptación
 
-- [ ] Usuario FREE ve los textos amigables pre-escritos en el resultado
-- [ ] Usuario PREMIUM sigue viendo la interpretación personalizada (sin regresión)
-- [ ] Banner de upgrade visible solo para FREE
-- [ ] Fallback razonable cuando falta seed
-- [ ] Texto user-facing en español
+- [x] Usuario FREE ve los textos amigables pre-escritos en el resultado
+- [x] Usuario PREMIUM sigue viendo la interpretación personalizada (sin regresión)
+- [x] Banner de upgrade visible solo para FREE
+- [x] Fallback razonable cuando falta seed
+- [x] Texto user-facing en español
 
 ---
 

--- a/frontend/src/app/tarot/lectura/page.tsx
+++ b/frontend/src/app/tarot/lectura/page.tsx
@@ -14,6 +14,7 @@ function LecturaPageContent() {
   const spreadId = searchParams.get('spreadId');
   const questionId = searchParams.get('questionId');
   const customQuestion = searchParams.get('customQuestion');
+  const categoryId = searchParams.get('categoryId');
 
   // Validate spreadId is present
   if (!spreadId) {
@@ -34,6 +35,7 @@ function LecturaPageContent() {
       spreadId={Number(spreadId)}
       questionId={questionId ? Number(questionId) : null}
       customQuestion={customQuestion ?? null}
+      categoryId={categoryId ? Number(categoryId) : null}
     />
   );
 }

--- a/frontend/src/components/features/readings/FreeReadingUpgradeBanner.test.tsx
+++ b/frontend/src/components/features/readings/FreeReadingUpgradeBanner.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FreeReadingUpgradeBanner from './FreeReadingUpgradeBanner';
+
+// Mock Next.js router
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+describe('FreeReadingUpgradeBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the upgrade banner with correct text', () => {
+    render(<FreeReadingUpgradeBanner />);
+
+    expect(screen.getByTestId('free-reading-upgrade-banner')).toBeInTheDocument();
+  });
+
+  it('should display the upgrade message about personalized interpretation', () => {
+    render(<FreeReadingUpgradeBanner />);
+
+    expect(screen.getByText(/interpretación personalizada y profunda/i)).toBeInTheDocument();
+  });
+
+  it('should display the CTA button', () => {
+    render(<FreeReadingUpgradeBanner />);
+
+    const ctaButton = screen.getByRole('button', { name: /premium/i });
+    expect(ctaButton).toBeInTheDocument();
+  });
+
+  it('should navigate to /premium when CTA button is clicked', () => {
+    render(<FreeReadingUpgradeBanner />);
+
+    const ctaButton = screen.getByRole('button', { name: /premium/i });
+    fireEvent.click(ctaButton);
+
+    expect(mockPush).toHaveBeenCalledWith('/premium');
+  });
+});

--- a/frontend/src/components/features/readings/FreeReadingUpgradeBanner.tsx
+++ b/frontend/src/components/features/readings/FreeReadingUpgradeBanner.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { Sparkles } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { ROUTES } from '@/lib/constants/routes';
+
+/**
+ * FreeReadingUpgradeBanner
+ *
+ * Reutilizable banner shown to FREE users at the bottom of a reading result,
+ * inviting them to upgrade to Premium for a personalized and deep interpretation.
+ *
+ * Usage:
+ * - InterpretationSection (tarot readings) — HUS-006
+ * - DailyCardExperience (carta del día)    — HUS-006
+ */
+export default function FreeReadingUpgradeBanner() {
+  const router = useRouter();
+
+  const handleUpgradeClick = useCallback(() => {
+    router.push(ROUTES.PREMIUM);
+  }, [router]);
+
+  return (
+    <div
+      data-testid="free-reading-upgrade-banner"
+      className="mt-6 rounded-lg bg-gradient-to-r from-violet-600 to-purple-600 p-6 text-white shadow-lg"
+    >
+      <div className="flex flex-col items-center gap-4 text-center sm:flex-row sm:items-start sm:text-left">
+        <div className="flex-shrink-0">
+          <Sparkles className="h-8 w-8 text-white/90" aria-hidden="true" />
+        </div>
+        <div className="flex-1">
+          <h3 className="mb-1 font-serif text-lg font-semibold">
+            ✨ Llevá tu lectura al siguiente nivel
+          </h3>
+          <p className="text-sm text-white/90">
+            Con Premium obtenés una interpretación personalizada y profunda para tu pregunta exacta.
+            El universo tiene mucho más para decirte.
+          </p>
+        </div>
+        <Button
+          onClick={handleUpgradeClick}
+          variant="secondary"
+          className="flex-shrink-0 bg-white text-purple-700 hover:bg-white/90"
+        >
+          Conocer Premium
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/features/readings/ReadingExperience.free-interpretations.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.free-interpretations.test.tsx
@@ -1,0 +1,522 @@
+/**
+ * Tests for InterpretationSection with FREE plan features:
+ * - freeInterpretations rendering (pre-written texts)
+ * - Category header display (icon + name)
+ * - Fallback to meaningUpright/Reversed when freeInterpretations is missing
+ * - FreeReadingUpgradeBanner visibility (FREE vs PREMIUM)
+ *
+ * These tests cover HUS-003 and HUS-006
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReadingExperience } from './ReadingExperience';
+import type { Spread, ReadingDetail, ReadingCard, PredefinedQuestion } from '@/types/reading.types';
+
+// Mock Next.js router
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+// Mock Next.js Image
+vi.mock('next/image', () => ({
+  default: function MockImage({
+    src,
+    alt,
+    className,
+  }: {
+    src: string;
+    alt: string;
+    className?: string;
+  }) {
+    return <img src={src} alt={alt} className={className} data-testid="next-image" />;
+  },
+}));
+
+// Mock react-markdown
+vi.mock('react-markdown', () => ({
+  default: function MockReactMarkdown({ children }: { children: string }) {
+    return <div data-testid="markdown-content">{children}</div>;
+  },
+}));
+
+// Mock UpgradeBanner (existing one — NOT the new FreeReadingUpgradeBanner)
+vi.mock('./UpgradeBanner', () => ({
+  default: function MockUpgradeBanner() {
+    return (
+      <div data-testid="upgrade-banner">
+        <p>💎 Desbloquea interpretaciones personalizadas</p>
+        <button>Upgrade a Premium</button>
+      </div>
+    );
+  },
+}));
+
+// Mock UpgradeModal
+vi.mock('./UpgradeModal', () => ({
+  default: function MockUpgradeModal({
+    open,
+    onOpenChange,
+  }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  }) {
+    if (!open) return null;
+    return (
+      <div role="dialog" data-testid="upgrade-modal">
+        <button onClick={() => onOpenChange(false)}>Close</button>
+      </div>
+    );
+  },
+}));
+
+// Mock FreeReadingUpgradeBanner
+vi.mock('./FreeReadingUpgradeBanner', () => ({
+  default: function MockFreeReadingUpgradeBanner() {
+    return (
+      <div data-testid="free-reading-upgrade-banner">
+        <p>
+          ✨ Con Premium obtenés una interpretación personalizada y profunda para tu pregunta
+          exacta.
+        </p>
+        <button>Conocer Premium</button>
+      </div>
+    );
+  },
+}));
+
+// Mock useUserCapabilities — mutable
+const mockUseUserCapabilities = vi.fn();
+vi.mock('@/hooks/api/useUserCapabilities', () => ({
+  useUserCapabilities: () => mockUseUserCapabilities(),
+}));
+
+// Mock useUserPlanFeatures — mutable
+const mockUseUserPlanFeatures = vi.fn();
+vi.mock('@/hooks/utils/useUserPlanFeatures', () => ({
+  useUserPlanFeatures: () => mockUseUserPlanFeatures(),
+}));
+
+// Mock readings-api
+vi.mock('@/lib/api/readings-api', () => ({
+  getShareText: vi.fn().mockResolvedValue({ text: 'Mocked share text' }),
+}));
+
+// Mock device utils
+vi.mock('@/lib/utils/device', () => ({
+  shouldUseNativeShare: () => false,
+  isMobileDevice: () => false,
+}));
+
+// Mock auth store
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => ({
+    user: {
+      id: 1,
+      email: 'test@example.com',
+      name: 'Test User',
+      plan: 'free',
+      roles: ['consumer'],
+      profilePicture: null,
+    },
+    isAuthenticated: true,
+  }),
+}));
+
+// Mock toast
+vi.mock('@/hooks/utils/useToast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+// ============================================================================
+// Test data
+// ============================================================================
+
+const mockSpread: Spread = {
+  id: 2,
+  name: 'Tres Cartas',
+  description: 'Pasado, presente, futuro',
+  cardCount: 3,
+  positions: [
+    { position: 1, name: 'Pasado', description: 'Lo que dejaste atrás' },
+    { position: 2, name: 'Presente', description: 'Tu situación actual' },
+    { position: 3, name: 'Futuro', description: 'Lo que vendrá' },
+  ],
+  difficulty: 'beginner',
+  requiredPlan: 'free',
+};
+
+const mockPredefinedQuestions: PredefinedQuestion[] = [
+  {
+    id: 33,
+    questionText: '¿Qué debo saber?',
+    categoryId: 1,
+    order: 1,
+    isActive: true,
+    usageCount: 10,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    deletedAt: null,
+  },
+];
+
+const mockReadingCards: ReadingCard[] = [
+  {
+    id: 1,
+    name: 'El Loco',
+    arcana: 'major',
+    number: 0,
+    suit: null,
+    orientation: 'upright',
+    position: 1,
+    positionName: 'Pasado',
+    imageUrl: '/cards/the-fool.jpg',
+    isReversed: false,
+    meaningUpright: 'El Loco upright significado crudo',
+    meaningReversed: 'El Loco reversed significado crudo',
+    keywords: 'aventura, libertad',
+  },
+  {
+    id: 2,
+    name: 'El Mago',
+    arcana: 'major',
+    number: 1,
+    suit: null,
+    orientation: 'upright',
+    position: 2,
+    positionName: 'Presente',
+    imageUrl: '/cards/the-magician.jpg',
+    isReversed: false,
+    meaningUpright: 'El Mago upright significado crudo',
+    meaningReversed: 'El Mago reversed significado crudo',
+    keywords: 'habilidad, voluntad',
+  },
+  {
+    id: 3,
+    name: 'La Sacerdotisa',
+    arcana: 'major',
+    number: 2,
+    suit: null,
+    orientation: 'reversed',
+    position: 3,
+    positionName: 'Futuro',
+    imageUrl: '/cards/high-priestess.jpg',
+    isReversed: true,
+    meaningUpright: 'La Sacerdotisa upright crudo',
+    meaningReversed: 'La Sacerdotisa reversed crudo',
+    keywords: 'intuición, misterio',
+  },
+];
+
+/** Reading WITH freeInterpretations (FREE user with category) */
+const mockFreeReadingWithInterpretations: ReadingDetail = {
+  id: 200,
+  userId: 1,
+  spreadId: 2,
+  question: 'Lectura general',
+  cards: mockReadingCards,
+  interpretation: null,
+  freeInterpretations: {
+    1: { content: 'El Loco en amor: texto amigable pre-escrito upright.' },
+    2: { content: 'El Mago en amor: texto amigable pre-escrito upright.' },
+    3: { content: 'La Sacerdotisa en amor: texto amigable pre-escrito reversed.' },
+  },
+  categoryName: 'Amor y Relaciones',
+  createdAt: '2025-12-07T10:00:00Z',
+  shareToken: null,
+};
+
+/** Reading WITHOUT freeInterpretations (FREE user legacy, or freeInterpretations missing for a card) */
+const mockFreeReadingWithoutInterpretations: ReadingDetail = {
+  id: 201,
+  userId: 1,
+  spreadId: 2,
+  question: 'Lectura general',
+  cards: mockReadingCards,
+  interpretation: null,
+  freeInterpretations: null,
+  createdAt: '2025-12-07T10:00:00Z',
+  shareToken: null,
+};
+
+/** Reading for PREMIUM with AI interpretation */
+const mockPremiumReading: ReadingDetail = {
+  id: 202,
+  userId: 2,
+  spreadId: 2,
+  question: '¿Qué me dice el universo?',
+  cards: mockReadingCards,
+  interpretation: {
+    id: 1,
+    generalInterpretation: '**Interpretación personalizada** del universo...',
+    cardInterpretations: [],
+    aiProvider: 'groq',
+    model: 'llama-3.1-70b-versatile',
+  },
+  freeInterpretations: null,
+  createdAt: '2025-12-07T10:00:00Z',
+  shareToken: null,
+};
+
+// ============================================================================
+// Hooks mock setup
+// ============================================================================
+
+const mockCreateReadingMutateAsync = vi.fn();
+
+vi.mock('@/hooks/api/useReadings', () => ({
+  useMyAvailableSpreads: () => ({ data: [mockSpread], isLoading: false }),
+  usePredefinedQuestions: () => ({ data: mockPredefinedQuestions, isLoading: false }),
+  useCreateReading: () => ({
+    mutate: vi.fn(),
+    mutateAsync: mockCreateReadingMutateAsync,
+    isPending: false,
+  }),
+  useRegenerateInterpretation: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createTestQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+const selectAndRevealCards = async () => {
+  const cards = screen.getAllByTestId('selectable-card');
+  fireEvent.click(cards[0]);
+  fireEvent.click(cards[1]);
+  fireEvent.click(cards[2]);
+
+  const revealButton = screen.getByRole('button', { name: /Revelar mi destino/i });
+  fireEvent.click(revealButton);
+
+  await waitFor(() => {
+    expect(screen.getByTestId('result-cards-grid')).toBeInTheDocument();
+  });
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('InterpretationSection — FREE con freeInterpretations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: FREE user plan features
+    mockUseUserPlanFeatures.mockReturnValue({
+      plan: 'free',
+      planLabel: 'GRATUITO',
+      canUseAI: false,
+      canUseCategories: false,
+      canUseCustomQuestions: false,
+      canShare: true,
+      isPremium: false,
+      isFree: true,
+      isAnonymous: false,
+    });
+
+    // Default: FREE user capabilities
+    mockUseUserCapabilities.mockReturnValue({
+      data: {
+        dailyCard: { used: 0, limit: 1, canUse: true, resetAt: '2026-01-09T00:00:00Z' },
+        tarotReadings: { used: 0, limit: 1, canUse: true, resetAt: '2026-01-09T00:00:00Z' },
+        canCreateDailyReading: true,
+        canCreateTarotReading: true,
+        canUseAI: false,
+        canUseCustomQuestions: false,
+        canUseAdvancedSpreads: false,
+        canUseFullDeck: false,
+        plan: 'free',
+        isAuthenticated: true,
+      },
+      isLoading: false,
+    });
+  });
+
+  describe('Con freeInterpretations presente', () => {
+    beforeEach(() => {
+      mockCreateReadingMutateAsync.mockResolvedValue(mockFreeReadingWithInterpretations);
+    });
+
+    it('debería mostrar los textos pre-escritos de freeInterpretations por carta', async () => {
+      renderWithProviders(
+        <ReadingExperience spreadId={2} questionId={null} customQuestion={null} categoryId={3} />
+      );
+
+      await selectAndRevealCards();
+
+      expect(
+        screen.getByText('El Loco en amor: texto amigable pre-escrito upright.')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('El Mago en amor: texto amigable pre-escrito upright.')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('La Sacerdotisa en amor: texto amigable pre-escrito reversed.')
+      ).toBeInTheDocument();
+    });
+
+    it('debería mostrar el nombre de la categoría en el encabezado', async () => {
+      renderWithProviders(
+        <ReadingExperience spreadId={2} questionId={null} customQuestion={null} categoryId={3} />
+      );
+
+      await selectAndRevealCards();
+
+      expect(screen.getByText(/Tu Lectura de Amor y Relaciones/i)).toBeInTheDocument();
+    });
+
+    it('NO debería mostrar los significados crudos (meaningUpright/Reversed) cuando hay freeInterpretations', async () => {
+      renderWithProviders(
+        <ReadingExperience spreadId={2} questionId={null} customQuestion={null} categoryId={3} />
+      );
+
+      await selectAndRevealCards();
+
+      expect(screen.queryByText('El Loco upright significado crudo')).not.toBeInTheDocument();
+    });
+
+    it('debería mostrar el FreeReadingUpgradeBanner para usuarios FREE', async () => {
+      renderWithProviders(
+        <ReadingExperience spreadId={2} questionId={null} customQuestion={null} categoryId={3} />
+      );
+
+      await selectAndRevealCards();
+
+      expect(screen.getByTestId('free-reading-upgrade-banner')).toBeInTheDocument();
+    });
+
+    it('debería incluir el categoryId en el CreateReadingDto enviado al backend', async () => {
+      renderWithProviders(
+        <ReadingExperience spreadId={2} questionId={null} customQuestion={null} categoryId={3} />
+      );
+
+      await selectAndRevealCards();
+
+      expect(mockCreateReadingMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ categoryId: 3 })
+      );
+    });
+  });
+
+  describe('Sin freeInterpretations (fallback)', () => {
+    beforeEach(() => {
+      mockCreateReadingMutateAsync.mockResolvedValue(mockFreeReadingWithoutInterpretations);
+    });
+
+    it('debería mostrar los significados crudos como fallback cuando freeInterpretations es null', async () => {
+      renderWithProviders(
+        <ReadingExperience spreadId={2} questionId={null} customQuestion={null} categoryId={null} />
+      );
+
+      await selectAndRevealCards();
+
+      // Falls back to card-by-card meanings from DB
+      expect(screen.getByText('El Loco upright significado crudo')).toBeInTheDocument();
+    });
+
+    it('debería mostrar el FreeReadingUpgradeBanner también en el fallback', async () => {
+      renderWithProviders(
+        <ReadingExperience spreadId={2} questionId={null} customQuestion={null} categoryId={null} />
+      );
+
+      await selectAndRevealCards();
+
+      expect(screen.getByTestId('free-reading-upgrade-banner')).toBeInTheDocument();
+    });
+  });
+
+  describe('Usuario PREMIUM — sin regresión', () => {
+    beforeEach(() => {
+      mockUseUserPlanFeatures.mockReturnValue({
+        plan: 'premium',
+        planLabel: 'PREMIUM',
+        canUseAI: true,
+        canUseCategories: true,
+        canUseCustomQuestions: true,
+        canShare: true,
+        isPremium: true,
+        isFree: false,
+        isAnonymous: false,
+      });
+
+      mockUseUserCapabilities.mockReturnValue({
+        data: {
+          dailyCard: { used: 3, limit: 999, canUse: true, resetAt: '2026-01-09T00:00:00Z' },
+          tarotReadings: { used: 5, limit: 999, canUse: true, resetAt: '2026-01-09T00:00:00Z' },
+          canCreateDailyReading: true,
+          canCreateTarotReading: true,
+          canUseAI: true,
+          canUseCustomQuestions: true,
+          canUseAdvancedSpreads: true,
+          canUseFullDeck: true,
+          plan: 'premium',
+          isAuthenticated: true,
+        },
+        isLoading: false,
+      });
+
+      mockCreateReadingMutateAsync.mockResolvedValue(mockPremiumReading);
+    });
+
+    it('debería mostrar la interpretación personalizada (markdown) para PREMIUM', async () => {
+      renderWithProviders(
+        <ReadingExperience spreadId={2} questionId={null} customQuestion={null} categoryId={null} />
+      );
+
+      await selectAndRevealCards();
+
+      expect(screen.getByTestId('markdown-content')).toBeInTheDocument();
+      // The markdown content itself contains "Interpretación personalizada"
+      expect(screen.getByTestId('markdown-content').textContent).toMatch(/Interpretación personalizada/i);
+    });
+
+    it('NO debería mostrar FreeReadingUpgradeBanner para PREMIUM', async () => {
+      renderWithProviders(
+        <ReadingExperience spreadId={2} questionId={null} customQuestion={null} categoryId={null} />
+      );
+
+      await selectAndRevealCards();
+
+      expect(screen.queryByTestId('free-reading-upgrade-banner')).not.toBeInTheDocument();
+    });
+
+    it('NO debería enviar categoryId al backend en modo PREMIUM cuando no hay categoryId', async () => {
+      renderWithProviders(
+        <ReadingExperience spreadId={2} questionId={null} customQuestion={null} categoryId={null} />
+      );
+
+      await selectAndRevealCards();
+
+      const callArg = mockCreateReadingMutateAsync.mock.calls[0][0];
+      expect(callArg.categoryId).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/components/features/readings/ReadingExperience.free-interpretations.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.free-interpretations.test.tsx
@@ -48,18 +48,6 @@ vi.mock('react-markdown', () => ({
   },
 }));
 
-// Mock UpgradeBanner (existing one — NOT the new FreeReadingUpgradeBanner)
-vi.mock('./UpgradeBanner', () => ({
-  default: function MockUpgradeBanner() {
-    return (
-      <div data-testid="upgrade-banner">
-        <p>💎 Desbloquea interpretaciones personalizadas</p>
-        <button>Upgrade a Premium</button>
-      </div>
-    );
-  },
-}));
-
 // Mock UpgradeModal
 vi.mock('./UpgradeModal', () => ({
   default: function MockUpgradeModal({
@@ -279,6 +267,10 @@ const mockCreateReadingMutateAsync = vi.fn();
 vi.mock('@/hooks/api/useReadings', () => ({
   useMyAvailableSpreads: () => ({ data: [mockSpread], isLoading: false }),
   usePredefinedQuestions: () => ({ data: mockPredefinedQuestions, isLoading: false }),
+  useCategories: () => ({
+    data: [{ id: 1, name: 'Amor', slug: 'amor' }],
+    isLoading: false,
+  }),
   useCreateReading: () => ({
     mutate: vi.fn(),
     mutateAsync: mockCreateReadingMutateAsync,
@@ -495,7 +487,9 @@ describe('InterpretationSection — FREE con freeInterpretations', () => {
 
       expect(screen.getByTestId('markdown-content')).toBeInTheDocument();
       // The markdown content itself contains "Interpretación personalizada"
-      expect(screen.getByTestId('markdown-content').textContent).toMatch(/Interpretación personalizada/i);
+      expect(screen.getByTestId('markdown-content').textContent).toMatch(
+        /Interpretación personalizada/i
+      );
     });
 
     it('NO debería mostrar FreeReadingUpgradeBanner para PREMIUM', async () => {

--- a/frontend/src/components/features/readings/ReadingExperience.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.test.tsx
@@ -265,6 +265,10 @@ vi.mock('@/hooks/api/useReadings', () => ({
     mutate: mockShareReading,
     isPending: false,
   }),
+  useCategories: () => ({
+    data: [{ id: 1, name: 'Amor', slug: 'amor' }],
+    isLoading: false,
+  }),
 }));
 
 // Mock auth store - mutable para tests

--- a/frontend/src/components/features/readings/ReadingExperience.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.test.tsx
@@ -229,6 +229,7 @@ const mockReadingDetail: ReadingDetail = {
   question: '¿Qué debo esperar en el amor?',
   cards: mockReadingCards,
   interpretation: mockInterpretation,
+  freeInterpretations: null,
   createdAt: '2025-12-07T10:00:00Z',
   shareToken: null,
 };

--- a/frontend/src/components/features/readings/ReadingExperience.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.tsx
@@ -22,7 +22,7 @@ import { TarotCard } from './TarotCard';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ErrorDisplay } from '@/components/ui/error-display';
-import UpgradeBanner from './UpgradeBanner';
+import FreeReadingUpgradeBanner from './FreeReadingUpgradeBanner';
 import UpgradeModal from './UpgradeModal';
 import DailyLimitReachedModal from './DailyLimitReachedModal';
 import { cn } from '@/lib/utils';
@@ -32,6 +32,7 @@ import type {
   CreateReadingDto,
   CardPositionDto,
   Interpretation,
+  FreeInterpretationEntry,
 } from '@/types';
 
 // ============================================================================
@@ -79,6 +80,8 @@ export interface ReadingExperienceProps {
   questionId: number | null;
   /** Custom question from URL params (for premium users) */
   customQuestion: string | null;
+  /** Category ID from URL params (for FREE users with pre-written interpretations) */
+  categoryId?: number | null;
 }
 
 // ============================================================================
@@ -160,9 +163,16 @@ function ResultCard({ card, index }: ResultCardProps) {
 interface InterpretationSectionProps {
   interpretation: string;
   cards: ReadingCard[];
+  freeInterpretations: Record<number, FreeInterpretationEntry> | null | undefined;
+  categoryName?: string | null;
 }
 
-function InterpretationSection({ interpretation, cards }: InterpretationSectionProps) {
+function InterpretationSection({
+  interpretation,
+  cards,
+  freeInterpretations,
+  categoryName,
+}: InterpretationSectionProps) {
   // Check if interpretation seems truncated (ends mid-word or mid-sentence)
   const seemsTruncated =
     interpretation &&
@@ -172,12 +182,22 @@ function InterpretationSection({ interpretation, cards }: InterpretationSectionP
     !interpretation.trim().endsWith('"') &&
     interpretation.length > 100;
 
+  // Build header title:
+  // - PREMIUM with AI interpretation → "Interpretación Personalizada"
+  // - FREE with category → "Tu Lectura de {categoryName}"
+  // - FREE without category (fallback) → "Significado de las Cartas"
+  const headerTitle = interpretation
+    ? 'Interpretación Personalizada'
+    : categoryName
+      ? `Tu Lectura de ${categoryName}`
+      : 'Significado de las Cartas';
+
   return (
     <Card className="mt-8">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 font-serif text-2xl">
           <Sparkles className="text-primary h-6 w-6" />
-          {interpretation ? 'Interpretación Personalizada' : 'Significado de las Cartas'}
+          {headerTitle}
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -195,8 +215,38 @@ function InterpretationSection({ interpretation, cards }: InterpretationSectionP
                 </p>
               )}
             </>
+          ) : freeInterpretations ? (
+            // Para usuarios FREE con categoría: textos pre-escritos por posición
+            <div className="space-y-6">
+              {cards.map((card) => {
+                const freeEntry = freeInterpretations[card.position];
+                return (
+                  <div key={card.id} className="border-b pb-4 last:border-b-0">
+                    <h3 className="text-primary mb-2 font-serif text-lg font-semibold">
+                      {card.name}
+                      {card.isReversed && (
+                        <span className="text-text-muted ml-2 text-sm">(Invertida)</span>
+                      )}
+                    </h3>
+                    <p className="text-text-muted mb-2 text-sm font-medium">{card.positionName}</p>
+                    <p className="text-text-primary leading-relaxed">
+                      {freeEntry
+                        ? freeEntry.content
+                        : card.isReversed
+                          ? card.meaningReversed
+                          : card.meaningUpright}
+                    </p>
+                    {card.keywords && (
+                      <p className="text-text-muted mt-2 text-sm italic">
+                        Palabras clave: {card.keywords}
+                      </p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
           ) : cards && cards.length > 0 ? (
-            // Para usuarios FREE: Significado de cada carta desde DB
+            // Para usuarios FREE sin categoría: Significado de cada carta desde DB (fallback)
             <div className="space-y-6">
               {cards.map((card) => (
                 <div key={card.id} className="border-b pb-4 last:border-b-0">
@@ -245,6 +295,7 @@ export function ReadingExperience({
   spreadId,
   questionId,
   customQuestion,
+  categoryId = null,
 }: ReadingExperienceProps) {
   const router = useRouter();
   const { user } = useAuthStore();
@@ -372,6 +423,7 @@ export function ReadingExperience({
         cardPositions,
         ...(questionId ? { predefinedQuestionId: questionId } : {}),
         ...(customQuestion ? { customQuestion } : {}),
+        ...(categoryId ? { categoryId } : {}),
         // TASK-006: Send useAI flag based on user plan
         // - PREMIUM: useAI: true (generates personalized interpretation)
         // - FREE/ANONYMOUS: useAI: false (basic card meanings from DB)
@@ -408,6 +460,7 @@ export function ReadingExperience({
     spreadId,
     questionId,
     customQuestion,
+    categoryId,
     createReading,
     canUseAI,
     isPremium,
@@ -613,14 +666,12 @@ export function ReadingExperience({
           <InterpretationSection
             interpretation={getGeneralInterpretation(readingResult.interpretation)}
             cards={readingResult.cards}
+            freeInterpretations={readingResult.freeInterpretations}
+            categoryName={readingResult.categoryName}
           />
 
           {/* Upgrade Banner for non-premium users */}
-          {!canUseAI && (
-            <div className="mt-6">
-              <UpgradeBanner />
-            </div>
-          )}
+          {!canUseAI && <FreeReadingUpgradeBanner />}
 
           {/* Action Buttons */}
           <div className="mt-8 flex flex-wrap justify-center gap-4">

--- a/frontend/src/components/features/readings/ReadingExperience.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.tsx
@@ -10,6 +10,7 @@ import {
   usePredefinedQuestions,
   useCreateReading,
   useRegenerateInterpretation,
+  useCategories,
 } from '@/hooks/api/useReadings';
 import { getShareText } from '@/lib/api/readings-api';
 import { toast } from '@/hooks/utils/useToast';
@@ -304,6 +305,7 @@ export function ReadingExperience({
   // API Hooks
   const { data: spreads, isLoading: isSpreadsLoading } = useMyAvailableSpreads();
   const { data: predefinedQuestions, isLoading: isQuestionsLoading } = usePredefinedQuestions();
+  const { data: categories } = useCategories();
   const { data: capabilities } = useUserCapabilities();
   const { mutateAsync: createReading } = useCreateReading();
   const { mutate: regenerateInterpretation, isPending: isRegenerating } =
@@ -335,6 +337,12 @@ export function ReadingExperience({
   const cardsCount = spread?.cardCount ?? 0;
   // More robust isPremium check - ensure user and plan exist
   const isPremium = Boolean(user?.plan) && user?.plan?.toUpperCase() === 'PREMIUM';
+
+  // Derive category name client-side (backend does not serialize categoryName in the response)
+  const resolvedCategoryName =
+    categoryId != null
+      ? (categories?.find((c) => c.id === categoryId)?.name ?? readingResult?.categoryName ?? null)
+      : (readingResult?.categoryName ?? null);
 
   // Display the actual question text
   // For FREE users without question, show "Lectura general" instead of "Tu pregunta al tarot"
@@ -667,7 +675,7 @@ export function ReadingExperience({
             interpretation={getGeneralInterpretation(readingResult.interpretation)}
             cards={readingResult.cards}
             freeInterpretations={readingResult.freeInterpretations}
-            categoryName={readingResult.categoryName}
+            categoryName={resolvedCategoryName}
           />
 
           {/* Upgrade Banner for non-premium users */}

--- a/frontend/src/components/features/readings/ReadingExperience.upgrade.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.upgrade.test.tsx
@@ -45,14 +45,13 @@ vi.mock('react-markdown', () => ({
   },
 }));
 
-// Mock UpgradeBanner — T-FE-06: no longer receives onUpgradeClick from ReadingExperience;
-// handles the MP flow internally
-vi.mock('./UpgradeBanner', () => ({
-  default: function MockUpgradeBanner() {
+// Mock FreeReadingUpgradeBanner
+vi.mock('./FreeReadingUpgradeBanner', () => ({
+  default: function MockFreeReadingUpgradeBanner() {
     return (
-      <div data-testid="upgrade-banner">
-        <p>💎 Desbloquea interpretaciones personalizadas</p>
-        <button>Upgrade a Premium</button>
+      <div data-testid="free-reading-upgrade-banner">
+        <p>Con Premium obtenés una interpretación personalizada y profunda</p>
+        <button>Conocer Premium</button>
       </div>
     );
   },
@@ -309,13 +308,13 @@ describe('ReadingExperience - Upgrade Banner for FREE users', () => {
 
     await waitFor(
       () => {
-        expect(screen.getByTestId('upgrade-banner')).toBeInTheDocument();
+        expect(screen.getByTestId('free-reading-upgrade-banner')).toBeInTheDocument();
       },
       { timeout: 10000 }
     );
 
-    expect(screen.getByText(/desbloquea interpretaciones personalizadas/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /upgrade a premium/i })).toBeInTheDocument();
+    expect(screen.getByText(/Con Premium obtenés una interpretación personalizada/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /conocer premium/i })).toBeInTheDocument();
   }, 15000); // Timeout de 15 segundos para el test
 
   it('should NOT open upgrade modal when clicking banner button (UpgradeBanner handles MP flow internally)', async () => {
@@ -330,12 +329,12 @@ describe('ReadingExperience - Upgrade Banner for FREE users', () => {
     fireEvent.click(revealButton);
 
     await waitFor(() => {
-      expect(screen.getByTestId('upgrade-banner')).toBeInTheDocument();
+      expect(screen.getByTestId('free-reading-upgrade-banner')).toBeInTheDocument();
     });
 
     // Banner button click should NOT open ReadingExperience's UpgradeModal
-    // UpgradeBanner handles its own MP flow internally
-    const upgradeButton = screen.getByRole('button', { name: /upgrade a premium/i });
+    // FreeReadingUpgradeBanner handles its own navigation internally
+    const upgradeButton = screen.getByRole('button', { name: /conocer premium/i });
     fireEvent.click(upgradeButton);
 
     // UpgradeModal should NOT appear from banner click

--- a/frontend/src/components/features/readings/ReadingExperience.upgrade.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.upgrade.test.tsx
@@ -209,6 +209,10 @@ vi.mock('@/hooks/api/useReadings', () => ({
     mutate: vi.fn(),
     isPending: false,
   }),
+  useCategories: () => ({
+    data: [{ id: 1, name: 'Amor', slug: 'amor' }],
+    isLoading: false,
+  }),
 }));
 
 // Mock toast
@@ -313,7 +317,9 @@ describe('ReadingExperience - Upgrade Banner for FREE users', () => {
       { timeout: 10000 }
     );
 
-    expect(screen.getByText(/Con Premium obtenés una interpretación personalizada/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Con Premium obtenés una interpretación personalizada/i)
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /conocer premium/i })).toBeInTheDocument();
   }, 15000); // Timeout de 15 segundos para el test
 

--- a/frontend/src/components/features/readings/ReadingExperience.useAI.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.useAI.test.tsx
@@ -195,6 +195,10 @@ vi.mock('@/hooks/api/useReadings', () => ({
     mutate: vi.fn(),
     isPending: false,
   }),
+  useCategories: () => ({
+    data: [{ id: 1, name: 'Amor', slug: 'amor' }],
+    isLoading: false,
+  }),
 }));
 
 vi.mock('@/stores/authStore', () => ({

--- a/frontend/src/components/features/readings/ReadingExperience.useAI.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.useAI.test.tsx
@@ -43,13 +43,13 @@ vi.mock('react-markdown', () => ({
   },
 }));
 
-// Mock UpgradeBanner
-vi.mock('./UpgradeBanner', () => ({
-  default: function MockUpgradeBanner() {
+// Mock FreeReadingUpgradeBanner
+vi.mock('./FreeReadingUpgradeBanner', () => ({
+  default: function MockFreeReadingUpgradeBanner() {
     return (
-      <div data-testid="upgrade-banner">
-        <p>💎 Desbloquea interpretaciones personalizadas</p>
-        <button>Upgrade a Premium</button>
+      <div data-testid="free-reading-upgrade-banner">
+        <p>Con Premium obtenés una interpretación personalizada</p>
+        <button>Conocer Premium</button>
       </div>
     );
   },
@@ -367,7 +367,7 @@ describe('ReadingExperience - useAI flag (TASK-006)', () => {
       fireEvent.click(revealButton);
 
       await waitFor(() => {
-        expect(screen.getByTestId('upgrade-banner')).toBeInTheDocument();
+        expect(screen.getByTestId('free-reading-upgrade-banner')).toBeInTheDocument();
       });
     });
 
@@ -403,7 +403,7 @@ describe('ReadingExperience - useAI flag (TASK-006)', () => {
         expect(screen.getByRole('heading', { name: /Tu lectura del Tarot/i })).toBeInTheDocument();
       });
 
-      expect(screen.queryByTestId('upgrade-banner')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('free-reading-upgrade-banner')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/features/readings/SpreadSelector.tsx
+++ b/frontend/src/components/features/readings/SpreadSelector.tsx
@@ -182,13 +182,13 @@ export function SpreadSelector({ categoryId, questionId, customQuestion }: Sprea
       // Build navigation URL
       let url = ROUTES.TAROT_LECTURA_BY_SPREAD(spreadId);
 
-      // Only add question params for PREMIUM users
+      // Add categoryId if present (for both FREE and PREMIUM users)
+      if (categoryId) {
+        url += `&categoryId=${categoryId}`;
+      }
+
+      // Add question params only for PREMIUM users
       if (isPremium) {
-        // Add categoryId if present
-        if (categoryId) {
-          url += `&categoryId=${categoryId}`;
-        }
-        // Add questionId or customQuestion if present
         if (questionId) {
           url += `&questionId=${questionId}`;
         } else if (customQuestion) {

--- a/frontend/src/components/features/readings/index.ts
+++ b/frontend/src/components/features/readings/index.ts
@@ -14,3 +14,4 @@ export { SharedReadingView, type SharedReadingViewProps } from './SharedReadingV
 export { CategorySelector } from './CategorySelector';
 export { TarotPageContent } from './TarotPageContent';
 export { RitualPageContent } from './RitualPageContent';
+export { default as FreeReadingUpgradeBanner } from './FreeReadingUpgradeBanner';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -39,6 +39,7 @@ export type {
   Reading,
   ReadingCard,
   ReadingDetail,
+  FreeInterpretationEntry,
   TrashedReading,
   CardPositionDto,
   CreateReadingDto,

--- a/frontend/src/types/reading.types.ts
+++ b/frontend/src/types/reading.types.ts
@@ -155,6 +155,14 @@ export interface Reading {
 }
 
 /**
+ * Free interpretation content for a single card position.
+ * Maps position index (1-based) to the pre-written text.
+ */
+export interface FreeInterpretationEntry {
+  content: string;
+}
+
+/**
  * Full reading detail
  */
 export interface ReadingDetail {
@@ -170,6 +178,17 @@ export interface ReadingDetail {
    * - An Interpretation object (structured format)
    */
   interpretation: Interpretation | string | null;
+  /**
+   * Pre-written interpretations for FREE users, indexed by card position (1-based).
+   * Present when the reading was created with a categoryId by a FREE user.
+   * null/undefined for PREMIUM readings (which use `interpretation` instead).
+   */
+  freeInterpretations?: Record<number, FreeInterpretationEntry> | null;
+  /**
+   * Name of the category chosen by the FREE user (e.g. "Amor y Relaciones").
+   * Provided by the backend for display purposes; absent for PREMIUM readings.
+   */
+  categoryName?: string | null;
   createdAt: string;
   deletedAt?: string | null;
   shareToken?: string | null;
@@ -219,6 +238,13 @@ export interface CreateReadingDto {
    * @default undefined
    */
   useAI?: boolean;
+  /**
+   * ID de la categoría elegida por el usuario FREE.
+   * Cuando está presente, el backend buscará interpretaciones pre-escritas
+   * en card_free_interpretation para esa combinación carta+categoría+orientación.
+   * Solo relevante cuando useAI === false (FREE users).
+   */
+  categoryId?: number;
 }
 
 // ============================================================================

--- a/frontend/src/types/reading.types.ts
+++ b/frontend/src/types/reading.types.ts
@@ -185,8 +185,11 @@ export interface ReadingDetail {
    */
   freeInterpretations?: Record<number, FreeInterpretationEntry> | null;
   /**
-   * Name of the category chosen by the FREE user (e.g. "Amor y Relaciones").
-   * Provided by the backend for display purposes; absent for PREMIUM readings.
+   * Display name of the category chosen by the FREE user (e.g. "Amor y Relaciones").
+   * This field is NOT guaranteed by the current backend contract and may be absent even
+   * when a reading has a category. Prefer deriving the display name on the frontend from
+   * categoryId and the categories catalog; this field is kept only for forward compatibility
+   * with any future backend responses that may include it.
    */
   categoryName?: string | null;
   createdAt: string;


### PR DESCRIPTION
## Descripción

Implementa **T-FR-F02** - InterpretationSection con textos pre-escritos para usuarios FREE + componente FreeReadingUpgradeBanner CTA upgrade.

Cubre: **HUS-003** (ver textos pre-escritos por categoría) y **HUS-006** (CTA upgrade desde resultados Free).

## Cambios principales

### Tipos TypeScript
- FreeInterpretationEntry interfaz añadida y exportada
- freeInterpretations?: Record en ReadingDetail
- categoryId?: number en CreateReadingDto
- categoryName?: string | null en ReadingDetail

### Nuevo componente
- FreeReadingUpgradeBanner.tsx: banner reutilizable con CTA a /premium, renderizado solo para usuarios FREE al final del resultado

### ReadingExperience.tsx
- InterpretationSection muestra textos pre-escritos cuando freeInterpretations está presente, con categoryName en el encabezado
- Fallback a meaningUpright/Reversed cuando freeInterpretations es null
- categoryId propagado desde props hasta CreateReadingDto
- FreeReadingUpgradeBanner reemplaza al anterior UpgradeBanner genérico

### Routing
- tarot/lectura/page.tsx lee categoryId de searchParams y lo pasa a ReadingExperience
- SpreadSelector.tsx incluye categoryId en la URL para FREE y PREMIUM

### Tests
- 10 nuevos tests en ReadingExperience.free-interpretations.test.tsx
- 8 nuevos tests en FreeReadingUpgradeBanner.test.tsx
- Tests existentes actualizados para el nuevo testid free-reading-upgrade-banner
- 0 regresiones

## Quality gates
- format, lint, type-check, test:run, build, validate-architecture: todos OK