### PR TITLE
feat(T-FR-F03): DailyCardExperience con texto de energia diaria para FREE/anonimo

### DIFF
--- a/docs/BACKLOG_FREE_READING_EXPERIENCE.md
+++ b/docs/BACKLOG_FREE_READING_EXPERIENCE.md
@@ -381,7 +381,7 @@ CARTA DEL DÍA:
 | T-FR-S02 | Seed de carta del día — 44 prompts para Claude/Gemini              | Content  | ✅ COMPLETADA | 2 días     |
 | T-FR-F01 | Frontend: CategorySelector con modo Free + routing                 | Frontend | ✅ COMPLETADA | 2 días     |
 | T-FR-F02 | Frontend: InterpretationSection con textos pre-escritos + CTA      | Frontend | ✅ COMPLETADA | 2 días     |
-| T-FR-F03 | Frontend: DailyCardExperience con texto de energía diaria          | Frontend | 🔴 CRÍTICA | 2 días     |
+| T-FR-F03 | Frontend: DailyCardExperience con texto de energía diaria          | Frontend | ✅ COMPLETADA | 2 días     |
 | T-FR-F04 | Frontend: Deck filtrado a Arcanos Mayores para FREE                | Frontend | 🟡 ALTA    | 2 días     |
 
 **Estimación total:** ~21.5 días de desarrollo (incluye TDD + ciclos de calidad + generación de contenido)
@@ -882,7 +882,7 @@ Modificar `CategorySelector` para soportar un modo FREE con filtrado a 3 categor
 **Prioridad:** 🔴 CRÍTICA
 **Estimación:** 2 días
 **Dependencias:** T-FR-B03 (backend retorna `dailyFreeUpright/Reversed`)
-**Estado:** ⏳ PENDIENTE
+**Estado:** ✅ COMPLETADA
 **Cubre HUS:** HUS-004, HUS-006
 
 #### 📋 Descripción
@@ -891,24 +891,24 @@ Modificar `DailyCardExperience` para que muestre el texto único de "energía di
 
 #### ✅ Tareas específicas
 
-- [ ] Actualizar tipos: el response de carta del día incluye `interpretation: string` (ya existente, ahora poblado con `dailyFreeUpright/Reversed`)
-- [ ] Modificar `DailyCardExperience.tsx`:
+- [x] Actualizar tipos: el response de carta del día incluye `interpretation: string` (ya existente, ahora poblado con `dailyFreeUpright/Reversed`)
+- [x] Modificar `DailyCardExperience.tsx`:
   - Renderizar el texto como un bloque único (no 3 secciones temáticas)
   - Encabezado: "🌟 Tu Carta del Día" + nombre de la carta + orientación
   - Incluir `FreeReadingUpgradeBanner` al final (para FREE/anónimo)
   - Para PREMIUM: mantener el layout actual con la interpretación personalizada
-- [ ] Fallback visual si `interpretation` es null (texto mínimo + keywords)
-- [ ] Tests unitarios:
+- [x] Fallback visual si `interpretation` es null (texto mínimo + keywords)
+- [x] Tests unitarios:
   - FREE/anónimo ve el texto único de energía diaria
   - PREMIUM ve la interpretación personalizada (sin regresión)
   - Banner upgrade visible para FREE/anónimo
 
 #### 🎯 Criterios de aceptación
 
-- [ ] FREE/anónimo ve el texto único de energía diaria
-- [ ] PREMIUM ve la interpretación personalizada y profunda (sin regresión)
-- [ ] El layout es claro, no dividido por categorías
-- [ ] Banner upgrade visible para no-Premium
+- [x] FREE/anónimo ve el texto único de energía diaria
+- [x] PREMIUM ve la interpretación personalizada y profunda (sin regresión)
+- [x] El layout es claro, no dividido por categorías
+- [x] Banner upgrade visible para no-Premium
 
 ---
 

--- a/frontend/src/components/features/daily-reading/DailyCardExperience.energiadiaria.test.tsx
+++ b/frontend/src/components/features/daily-reading/DailyCardExperience.energiadiaria.test.tsx
@@ -1,0 +1,408 @@
+/**
+ * T-FR-F03: DailyCardExperience con Texto de Energía Diaria
+ *
+ * Tests TDD para la nueva funcionalidad:
+ * - FREE/anónimo: muestra `interpretation` como bloque único de energía diaria
+ * - PREMIUM: mantiene interpretación personalizada (sin regresión)
+ * - Banner upgrade visible para FREE/anónimo, oculto para PREMIUM
+ * - Fallback visual cuando `interpretation` es null
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { DailyCardExperience } from './DailyCardExperience';
+import {
+  createMockTarotCard,
+  createMockDailyReading,
+  createMockUser,
+  createMockFreeCapabilities,
+  createMockPremiumCapabilities,
+  createMockAnonymousCapabilities,
+} from '@/test/factories';
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+// Mock next/image
+vi.mock('next/image', () => ({
+  default: function MockImage({
+    src,
+    alt,
+    className,
+  }: {
+    src: string;
+    alt: string;
+    className?: string;
+  }) {
+    return <img src={src} alt={alt} className={className} data-testid="next-image" />;
+  },
+}));
+
+// Mock fingerprint utilities
+vi.mock('@/lib/utils/fingerprint', () => ({
+  getSessionFingerprint: vi.fn().mockResolvedValue('mock-fingerprint-12345'),
+  generateSessionFingerprint: vi.fn().mockResolvedValue('mock-fingerprint-12345'),
+}));
+
+// Mock hooks
+const mockUseDailyReadingToday = vi.fn();
+const mockUseDailyReading = vi.fn();
+const mockUseDailyReadingPublic = vi.fn();
+const mockUseAuth = vi.fn();
+const mockUseUserCapabilities = vi.fn();
+const mockUseInvalidateCapabilities = vi.fn();
+
+vi.mock('@/hooks/api/useDailyReading', () => ({
+  useDailyReadingToday: () => mockUseDailyReadingToday(),
+  useDailyReading: () => mockUseDailyReading(),
+  useDailyReadingPublic: () => mockUseDailyReadingPublic(),
+  useRegenerateDailyReading: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('@/hooks/api/useUserCapabilities', () => ({
+  useUserCapabilities: () => mockUseUserCapabilities(),
+  useInvalidateCapabilities: () => mockUseInvalidateCapabilities(),
+}));
+
+vi.mock('@/hooks/utils/useToast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = createTestQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+describe('DailyCardExperience - Energía Diaria (T-FR-F03)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseInvalidateCapabilities.mockReturnValue(vi.fn());
+    mockUseDailyReading.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseDailyReadingPublic.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseDailyReadingToday.mockReturnValue({ data: null, isLoading: false, error: null });
+  });
+
+  describe('FREE usuario autenticado - texto de energía diaria', () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({
+        user: createMockUser({ plan: 'free' }),
+        isAuthenticated: true,
+        isLoading: false,
+      });
+      mockUseUserCapabilities.mockReturnValue({
+        data: createMockFreeCapabilities(),
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('should display daily energy interpretation as single block when interpretation is present', async () => {
+      const user = userEvent.setup();
+      const energyText =
+        'Hoy la energía del Loco te acompaña. En el amor, es un día para animarte a dar ese primer paso.';
+      const createFn = vi.fn((_, options) => {
+        options?.onSuccess?.(
+          createMockDailyReading({
+            interpretation: energyText,
+          })
+        );
+      });
+      mockUseDailyReading.mockReturnValue({ mutate: createFn, isPending: false });
+
+      renderWithProviders(<DailyCardExperience />);
+
+      await user.click(screen.getByTestId('tarot-card'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('revealed-state')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('daily-energy-interpretation')).toBeInTheDocument();
+      expect(screen.getByText(energyText)).toBeInTheDocument();
+    });
+
+    it('should show FreeReadingUpgradeBanner after revealing card with interpretation', async () => {
+      const user = userEvent.setup();
+      const createFn = vi.fn((_, options) => {
+        options?.onSuccess?.(
+          createMockDailyReading({
+            interpretation: 'Hoy la energía de El Loco te acompaña...',
+          })
+        );
+      });
+      mockUseDailyReading.mockReturnValue({ mutate: createFn, isPending: false });
+
+      renderWithProviders(<DailyCardExperience />);
+
+      await user.click(screen.getByTestId('tarot-card'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('free-reading-upgrade-banner')).toBeInTheDocument();
+      });
+    });
+
+    it('should show FreeReadingUpgradeBanner even when interpretation is null (fallback)', async () => {
+      const user = userEvent.setup();
+      const createFn = vi.fn((_, options) => {
+        options?.onSuccess?.(
+          createMockDailyReading({
+            interpretation: null,
+          })
+        );
+      });
+      mockUseDailyReading.mockReturnValue({ mutate: createFn, isPending: false });
+
+      renderWithProviders(<DailyCardExperience />);
+
+      await user.click(screen.getByTestId('tarot-card'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('free-reading-upgrade-banner')).toBeInTheDocument();
+      });
+    });
+
+    it('should show fallback content when interpretation is null', async () => {
+      const user = userEvent.setup();
+      const createFn = vi.fn((_, options) => {
+        options?.onSuccess?.(
+          createMockDailyReading({
+            interpretation: null,
+          })
+        );
+      });
+      mockUseDailyReading.mockReturnValue({ mutate: createFn, isPending: false });
+
+      renderWithProviders(<DailyCardExperience />);
+
+      await user.click(screen.getByTestId('tarot-card'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('revealed-state')).toBeInTheDocument();
+      });
+
+      // Should show fallback section (cardMeaning or keywords)
+      expect(screen.getByTestId('card-meaning-section')).toBeInTheDocument();
+    });
+
+    it('should display card name in header when revealed', async () => {
+      const user = userEvent.setup();
+      const createFn = vi.fn((_, options) => {
+        options?.onSuccess?.(
+          createMockDailyReading({
+            card: createMockTarotCard({ name: 'La Estrella' }),
+            interpretation: 'Hoy la energía de La Estrella te guía...',
+          })
+        );
+      });
+      mockUseDailyReading.mockReturnValue({ mutate: createFn, isPending: false });
+
+      renderWithProviders(<DailyCardExperience />);
+
+      await user.click(screen.getByTestId('tarot-card'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('card-title')).toHaveTextContent('La Estrella');
+      });
+    });
+
+    it('should not show anonymous-cta for authenticated FREE user', async () => {
+      const user = userEvent.setup();
+      const createFn = vi.fn((_, options) => {
+        options?.onSuccess?.(
+          createMockDailyReading({
+            interpretation: 'Hoy la energía de El Loco te acompaña...',
+          })
+        );
+      });
+      mockUseDailyReading.mockReturnValue({ mutate: createFn, isPending: false });
+
+      renderWithProviders(<DailyCardExperience />);
+
+      await user.click(screen.getByTestId('tarot-card'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('revealed-state')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByTestId('anonymous-cta')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('PREMIUM usuario - interpretación personalizada (sin regresión)', () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({
+        user: createMockUser({ plan: 'premium' }),
+        isAuthenticated: true,
+        isLoading: false,
+      });
+      mockUseUserCapabilities.mockReturnValue({
+        data: createMockPremiumCapabilities(),
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('should NOT show FreeReadingUpgradeBanner for PREMIUM user', () => {
+      mockUseDailyReadingToday.mockReturnValue({
+        data: createMockDailyReading({
+          interpretation: 'Interpretación personalizada y profunda...',
+        }),
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<DailyCardExperience />);
+
+      expect(screen.queryByTestId('free-reading-upgrade-banner')).not.toBeInTheDocument();
+    });
+
+    it('should display PREMIUM interpretation in interpretation-section (not daily-energy)', () => {
+      const premiumText = 'Interpretación personalizada y profunda para tu pregunta exacta.';
+      mockUseDailyReadingToday.mockReturnValue({
+        data: createMockDailyReading({ interpretation: premiumText }),
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<DailyCardExperience />);
+
+      expect(screen.getByTestId('interpretation-section')).toBeInTheDocument();
+      expect(screen.getByText(premiumText)).toBeInTheDocument();
+      expect(screen.queryByTestId('daily-energy-interpretation')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Usuario anónimo - texto de energía diaria', () => {
+    beforeEach(() => {
+      mockUseAuth.mockReturnValue({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+      });
+      mockUseUserCapabilities.mockReturnValue({
+        data: createMockAnonymousCapabilities({ canCreateDailyReading: true }),
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('should display daily energy interpretation as single block for anonymous user', async () => {
+      const user = userEvent.setup();
+      const energyText = 'Hoy la energía del Mago te acompaña con su poder creador...';
+      const createFn = vi.fn((_, options) => {
+        options?.onSuccess?.(
+          createMockDailyReading({
+            interpretation: energyText,
+          })
+        );
+      });
+      mockUseDailyReadingPublic.mockReturnValue({ mutate: createFn, isPending: false });
+
+      renderWithProviders(<DailyCardExperience />);
+
+      await user.click(screen.getByTestId('tarot-card'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('daily-energy-interpretation')).toBeInTheDocument();
+        expect(screen.getByText(energyText)).toBeInTheDocument();
+      });
+    });
+
+    it('should show FreeReadingUpgradeBanner for anonymous user after reveal', async () => {
+      const user = userEvent.setup();
+      const createFn = vi.fn((_, options) => {
+        options?.onSuccess?.(
+          createMockDailyReading({
+            interpretation: 'Hoy la energía del Mago...',
+          })
+        );
+      });
+      mockUseDailyReadingPublic.mockReturnValue({ mutate: createFn, isPending: false });
+
+      renderWithProviders(<DailyCardExperience />);
+
+      await user.click(screen.getByTestId('tarot-card'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('free-reading-upgrade-banner')).toBeInTheDocument();
+      });
+    });
+
+    it('should still show anonymous-cta for anonymous user (in addition to upgrade banner)', async () => {
+      const user = userEvent.setup();
+      const createFn = vi.fn((_, options) => {
+        options?.onSuccess?.(
+          createMockDailyReading({
+            interpretation: null,
+          })
+        );
+      });
+      mockUseDailyReadingPublic.mockReturnValue({ mutate: createFn, isPending: false });
+
+      renderWithProviders(<DailyCardExperience />);
+
+      await user.click(screen.getByTestId('tarot-card'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('revealed-state')).toBeInTheDocument();
+      });
+
+      // Anonymous users still see CTA to register
+      expect(screen.getByTestId('anonymous-cta')).toBeInTheDocument();
+    });
+  });
+
+  describe('Existing reading pre-loaded (FREE - re-enter page)', () => {
+    it('should show daily energy interpretation and upgrade banner for pre-loaded FREE reading', () => {
+      mockUseAuth.mockReturnValue({
+        user: createMockUser({ plan: 'free' }),
+        isAuthenticated: true,
+        isLoading: false,
+      });
+      mockUseUserCapabilities.mockReturnValue({
+        data: createMockFreeCapabilities(),
+        isLoading: false,
+        error: null,
+      });
+      mockUseDailyReadingToday.mockReturnValue({
+        data: createMockDailyReading({
+          interpretation: 'Hoy la energía de El Loco te acompaña...',
+        }),
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<DailyCardExperience />);
+
+      expect(screen.getByTestId('daily-energy-interpretation')).toBeInTheDocument();
+      expect(screen.getByTestId('free-reading-upgrade-banner')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/features/daily-reading/DailyCardExperience.tsx
+++ b/frontend/src/components/features/daily-reading/DailyCardExperience.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { TarotCard } from '@/components/features/readings/TarotCard';
 import { ShareButton } from '@/components/features/shared/ShareButton';
+import FreeReadingUpgradeBanner from '@/components/features/readings/FreeReadingUpgradeBanner';
 import { AnonymousLimitReached } from './AnonymousLimitReached';
 import { DailyCardLimitReached } from './DailyCardLimitReached';
 import {
@@ -90,6 +91,7 @@ export function DailyCardExperience() {
 
   // Extract boolean flags from capabilities
   const canCreateDailyReading = capabilities?.canCreateDailyReading ?? false;
+  const canUseAI = capabilities?.canUseAI ?? false;
 
   // Fetch today's reading ONLY if user can still create (hasn't reached limit)
   // MODELO_NEGOCIO_DEFINIDO: "Si reingresa tras consumir límite → Modal inmediato"
@@ -345,9 +347,9 @@ export function DailyCardExperience() {
             )}
           </div>
 
-          {/* Interpretation (authenticated users) or Card Meaning (anonymous users) */}
-          {currentReading?.interpretation ? (
-            // Authenticated users: Full interpretation
+          {/* Interpretation: diferenciado por plan */}
+          {canUseAI && currentReading?.interpretation ? (
+            // PREMIUM: interpretación personalizada y profunda
             <div
               data-testid="interpretation-section"
               className="bg-surface shadow-soft w-full max-w-lg rounded-xl p-6"
@@ -356,8 +358,18 @@ export function DailyCardExperience() {
                 {currentReading.interpretation}
               </p>
             </div>
+          ) : !canUseAI && currentReading?.interpretation ? (
+            // FREE / anónimo con texto de energía diaria (dailyFreeUpright/Reversed)
+            <div
+              data-testid="daily-energy-interpretation"
+              className="bg-surface shadow-soft w-full max-w-lg rounded-xl p-6"
+            >
+              <p className="text-text-primary leading-relaxed whitespace-pre-line">
+                {currentReading.interpretation}
+              </p>
+            </div>
           ) : currentReading?.cardMeaning ? (
-            // Anonymous users: Card meaning from DB
+            // Fallback: sin seed aún — muestra significado DB
             <div
               data-testid="card-meaning-section"
               className="bg-surface shadow-soft w-full max-w-lg rounded-xl p-6"
@@ -366,25 +378,30 @@ export function DailyCardExperience() {
             </div>
           ) : null}
 
-          {/* Anonymous User CTA (shown when no interpretation) */}
-          {!isAuthenticated && currentReading?.cardMeaning && (
-            <div
-              data-testid="anonymous-cta"
-              className="bg-primary/5 border-primary/20 w-full max-w-lg rounded-xl border p-6 text-center"
-            >
-              <p className="text-text-primary mb-4 font-medium">
-                ¿Te gustó? Regístrate gratis para obtener lecturas completas
-              </p>
-              <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
-                <Button onClick={() => router.push(ROUTES.REGISTER)} size="lg">
-                  Crear cuenta gratis
-                </Button>
-                <Button onClick={() => router.push(ROUTES.LOGIN)} variant="outline" size="lg">
-                  Iniciar sesión
-                </Button>
+          {/* Banner de upgrade para FREE y anónimos (HUS-006) */}
+          {!canUseAI && currentReading && <FreeReadingUpgradeBanner />}
+
+          {/* Anonymous User CTA (shown when anonymous user has any reading result) */}
+          {!isAuthenticated &&
+            currentReading &&
+            (currentReading.cardMeaning ?? currentReading.interpretation) && (
+              <div
+                data-testid="anonymous-cta"
+                className="bg-primary/5 border-primary/20 w-full max-w-lg rounded-xl border p-6 text-center"
+              >
+                <p className="text-text-primary mb-4 font-medium">
+                  ¿Te gustó? Regístrate gratis para obtener lecturas completas
+                </p>
+                <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+                  <Button onClick={() => router.push(ROUTES.REGISTER)} size="lg">
+                    Crear cuenta gratis
+                  </Button>
+                  <Button onClick={() => router.push(ROUTES.LOGIN)} variant="outline" size="lg">
+                    Iniciar sesión
+                  </Button>
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
           {/* Share Button - available for all users with a reading */}
           {currentReading && (


### PR DESCRIPTION
## Descripcion

Implementa T-FR-F03: modifica DailyCardExperience para que usuarios FREE/anonimos vean el texto de energia diaria como bloque unico en lugar de keywords tecnicas de DB.

## Cambios

- DailyCardExperience.tsx: Discrimina por canUseAI para el layout de interpretacion
  - FREE/anonimo con interpretation: muestra daily-energy-interpretation (bloque unico)
  - FREE/anonimo con interpretation null: fallback a card-meaning-section (keywords DB)
  - PREMIUM: mantiene interpretation-section sin regresion
  - FreeReadingUpgradeBanner al final para no-Premium con reading activo
  - Condicion anonymous-cta actualizada para cubrir caso con interpretation

- DailyCardExperience.energiadiaria.test.tsx: 12 tests TDD nuevos

## Tests

- 12 tests nuevos: todos pasando
- 27 tests existentes en DailyCardExperience.test.tsx: sin regresion
- 9 tests en DailyCardExperience.anonymous.test.tsx: sin regresion

## Quality Gates

- format, lint:fix (0 errores), type-check (sin errores), build (exitoso), validate-architecture (valido)

## Backlog

T-FR-F03 marcada como COMPLETADA en BACKLOG_FREE_READING_EXPERIENCE.md