### PR TITLE
feat(T-FR-F04): Frontend — Deck filtrado a Arcanos Mayores para FREE

### DIFF
--- a/docs/BACKLOG_FREE_READING_EXPERIENCE.md
+++ b/docs/BACKLOG_FREE_READING_EXPERIENCE.md
@@ -928,9 +928,9 @@ Filtrar el mazo de cartas mostrado en el flujo de selección (`ReadingExperience
 
 #### ✅ Tareas específicas
 
-- [x] Identificar el punto de fetch del deck en `ReadingExperience` (hoy posiblemente inline o vía endpoint encyclopedia)
-- [x] Crear/modificar hook `useTarotDeck(options: { onlyMajorArcana?: boolean })` que consuma `GET /cards?category=arcanos_mayores` cuando corresponda
-- [x] En `ReadingExperience`: pasar `onlyMajorArcana: !capabilities.canUseFullDeck` al hook
+- [x] Identificar el punto de fetch del deck en `ReadingExperience` (el mazo se representaba localmente como `DECK_SIZE = 78` — sin fetch al backend)
+- [x] Crear hook `useTarotDeck()` que calcula `cardIndices` localmente según `canUseFullDeck` (sin fetch — FREE/anónimo: índices 0-21, PREMIUM: índices 0-77)
+- [x] En `ReadingExperience`: reemplazar `DECK_SIZE = 78` por `useTarotDeck()`, iterar sobre `cardIndices` directamente
 - [x] Tests unitarios:
   - FREE ve mazo de 22 cartas
   - PREMIUM ve mazo de 78 cartas

--- a/docs/BACKLOG_FREE_READING_EXPERIENCE.md
+++ b/docs/BACKLOG_FREE_READING_EXPERIENCE.md
@@ -382,7 +382,7 @@ CARTA DEL DÍA:
 | T-FR-F01 | Frontend: CategorySelector con modo Free + routing                 | Frontend | ✅ COMPLETADA | 2 días     |
 | T-FR-F02 | Frontend: InterpretationSection con textos pre-escritos + CTA      | Frontend | ✅ COMPLETADA | 2 días     |
 | T-FR-F03 | Frontend: DailyCardExperience con texto de energía diaria          | Frontend | ✅ COMPLETADA | 2 días     |
-| T-FR-F04 | Frontend: Deck filtrado a Arcanos Mayores para FREE                | Frontend | 🟡 ALTA    | 2 días     |
+| T-FR-F04 | Frontend: Deck filtrado a Arcanos Mayores para FREE                | Frontend | ✅ COMPLETADA | 2 días     |
 
 **Estimación total:** ~21.5 días de desarrollo (incluye TDD + ciclos de calidad + generación de contenido)
 
@@ -917,7 +917,7 @@ Modificar `DailyCardExperience` para que muestre el texto único de "energía di
 **Prioridad:** 🟡 ALTA
 **Estimación:** 2 días
 **Dependencias:** T-FR-B03, **T-FR-B04** (endpoint y capability deben existir antes)
-**Estado:** ⏳ PENDIENTE
+**Estado:** ✅ COMPLETADA
 **Cubre HUS:** HUS-005
 
 #### 📋 Descripción
@@ -928,20 +928,20 @@ Filtrar el mazo de cartas mostrado en el flujo de selección (`ReadingExperience
 
 #### ✅ Tareas específicas
 
-- [ ] Identificar el punto de fetch del deck en `ReadingExperience` (hoy posiblemente inline o vía endpoint encyclopedia)
-- [ ] Crear/modificar hook `useTarotDeck(options: { onlyMajorArcana?: boolean })` que consuma `GET /cards?category=arcanos_mayores` cuando corresponda
-- [ ] En `ReadingExperience`: pasar `onlyMajorArcana: !capabilities.canUseFullDeck` al hook
-- [ ] Tests unitarios:
+- [x] Identificar el punto de fetch del deck en `ReadingExperience` (hoy posiblemente inline o vía endpoint encyclopedia)
+- [x] Crear/modificar hook `useTarotDeck(options: { onlyMajorArcana?: boolean })` que consuma `GET /cards?category=arcanos_mayores` cuando corresponda
+- [x] En `ReadingExperience`: pasar `onlyMajorArcana: !capabilities.canUseFullDeck` al hook
+- [x] Tests unitarios:
   - FREE ve mazo de 22 cartas
   - PREMIUM ve mazo de 78 cartas
   - La selección funciona correctamente con deck reducido
 
 #### 🎯 Criterios de aceptación
 
-- [ ] FREE solo ve los 22 Arcanos Mayores en la selección
-- [ ] PREMIUM ve las 78 cartas
-- [ ] No se rompe el flujo de selección existente
-- [ ] Coverage ≥ 80%
+- [x] FREE solo ve los 22 Arcanos Mayores en la selección
+- [x] PREMIUM ve las 78 cartas
+- [x] No se rompe el flujo de selección existente
+- [x] Coverage ≥ 80%
 
 ---
 

--- a/frontend/src/components/features/readings/ReadingExperience.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.test.tsx
@@ -81,6 +81,12 @@ vi.mock('@/hooks/api/useUserCapabilities', () => ({
   useUserCapabilities: () => mockUseUserCapabilities(),
 }));
 
+// Mock useTarotDeck
+const mockUseTarotDeck = vi.fn();
+vi.mock('@/hooks/api/useTarotDeck', () => ({
+  useTarotDeck: () => mockUseTarotDeck(),
+}));
+
 // Mock getShareText from readings-api
 const mockGetShareText = vi.fn().mockResolvedValue({ text: 'Mocked share text' });
 vi.mock('@/lib/api/readings-api', () => ({
@@ -334,6 +340,13 @@ describe('ReadingExperience', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreateReadingMutateAsync.mockReset();
+
+    // Default mock for useTarotDeck: full deck (PREMIUM default)
+    mockUseTarotDeck.mockReturnValue({
+      deckSize: 78,
+      cardIndices: Array.from({ length: 78 }, (_, i) => i),
+      isRestricted: false,
+    });
 
     // Default mock: FREE user with available readings
     mockUseUserCapabilities.mockReturnValue({
@@ -928,6 +941,108 @@ describe('ReadingExperience', () => {
 
       // El banner NO debe aparecer para usuarios premium
       expect(screen.queryByTestId('upgrade-banner')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Deck filtrado: FREE solo ve Arcanos Mayores', () => {
+    it('should display only 22 cards for FREE user (Arcanos Mayores)', () => {
+      mockUseTarotDeck.mockReturnValue({
+        deckSize: 22,
+        cardIndices: Array.from({ length: 22 }, (_, i) => i),
+        isRestricted: true,
+      });
+      // canUseFullDeck: false for FREE
+      mockUseUserCapabilities.mockReturnValue({
+        data: {
+          dailyCard: { used: 0, limit: 1, canUse: true, resetAt: '2026-01-09T00:00:00Z' },
+          tarotReadings: { used: 0, limit: 1, canUse: true, resetAt: '2026-01-09T00:00:00Z' },
+          canCreateDailyReading: true,
+          canCreateTarotReading: true,
+          canUseAI: false,
+          canUseCustomQuestions: false,
+          canUseAdvancedSpreads: false,
+          canUseFullDeck: false,
+          plan: 'free',
+          isAuthenticated: true,
+        },
+        isLoading: false,
+      });
+
+      renderWithProviders(<ReadingExperience spreadId={2} questionId={1} customQuestion={null} />);
+
+      const cards = screen.getAllByTestId('selectable-card');
+      expect(cards).toHaveLength(22);
+    });
+
+    it('should display 78 cards for PREMIUM user (full deck)', () => {
+      mockUseTarotDeck.mockReturnValue({
+        deckSize: 78,
+        cardIndices: Array.from({ length: 78 }, (_, i) => i),
+        isRestricted: false,
+      });
+      mockUseUserCapabilities.mockReturnValue({
+        data: {
+          dailyCard: { used: 0, limit: 3, canUse: true, resetAt: '2026-01-09T00:00:00Z' },
+          tarotReadings: { used: 0, limit: 3, canUse: true, resetAt: '2026-01-09T00:00:00Z' },
+          canCreateDailyReading: true,
+          canCreateTarotReading: true,
+          canUseAI: true,
+          canUseCustomQuestions: true,
+          canUseAdvancedSpreads: true,
+          canUseFullDeck: true,
+          plan: 'premium',
+          isAuthenticated: true,
+        },
+        isLoading: false,
+      });
+
+      renderWithProviders(<ReadingExperience spreadId={2} questionId={1} customQuestion={null} />);
+
+      const cards = screen.getAllByTestId('selectable-card');
+      expect(cards).toHaveLength(78);
+    });
+
+    it('should allow selecting cards and revealing when FREE deck has 22 cards', async () => {
+      mockUseTarotDeck.mockReturnValue({
+        deckSize: 22,
+        cardIndices: Array.from({ length: 22 }, (_, i) => i),
+        isRestricted: true,
+      });
+      mockUseUserCapabilities.mockReturnValue({
+        data: {
+          dailyCard: { used: 0, limit: 1, canUse: true, resetAt: '2026-01-09T00:00:00Z' },
+          tarotReadings: { used: 0, limit: 1, canUse: true, resetAt: '2026-01-09T00:00:00Z' },
+          canCreateDailyReading: true,
+          canCreateTarotReading: true,
+          canUseAI: false,
+          canUseCustomQuestions: false,
+          canUseAdvancedSpreads: false,
+          canUseFullDeck: false,
+          plan: 'free',
+          isAuthenticated: true,
+        },
+        isLoading: false,
+      });
+      mockCreateReadingMutateAsync.mockResolvedValue(mockReadingDetail);
+
+      renderWithProviders(<ReadingExperience spreadId={1} questionId={1} customQuestion={null} />);
+
+      // 1-card spread, FREE deck of 22 cards
+      const cards = screen.getAllByTestId('selectable-card');
+      expect(cards).toHaveLength(22);
+
+      fireEvent.click(cards[0]);
+
+      const revealButton = screen.getByRole('button', { name: /Revelar mi destino/i });
+      fireEvent.click(revealButton);
+
+      await waitFor(() => {
+        expect(mockCreateReadingMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cardIds: expect.arrayContaining([1]), // index 0 → cardId 1 (El Loco / Arcano Mayor)
+          })
+        );
+      });
     });
   });
 });

--- a/frontend/src/components/features/readings/ReadingExperience.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.tsx
@@ -604,13 +604,13 @@ export function ReadingExperience({
               data-testid="card-selection-grid"
               className="grid grid-cols-6 justify-items-center gap-1 sm:grid-cols-8 sm:gap-2 md:grid-cols-10 lg:grid-cols-12 xl:grid-cols-13"
             >
-              {Array.from({ length: cardIndices.length }).map((_, index) => {
-                const isSelected = selectedCards.has(index);
+              {cardIndices.map((cardIndex) => {
+                const isSelected = selectedCards.has(cardIndex);
                 const canSelect = selectedCards.size < cardsCount || isSelected;
 
                 return (
                   <div
-                    key={index}
+                    key={cardIndex}
                     data-testid="selectable-card"
                     role="button"
                     tabIndex={canSelect ? 0 : -1}
@@ -619,9 +619,9 @@ export function ReadingExperience({
                       canSelect ? 'cursor-pointer' : 'cursor-not-allowed opacity-50',
                       isSelected && 'ring-primary z-10 scale-110 ring-2 ring-offset-1'
                     )}
-                    onClick={() => handleCardClick(index)}
-                    onKeyDown={(e) => handleKeyDown(index, e)}
-                    aria-label={`Carta ${index + 1}${isSelected ? ' - seleccionada' : ''}`}
+                    onClick={() => handleCardClick(cardIndex)}
+                    onKeyDown={(e) => handleKeyDown(cardIndex, e)}
+                    aria-label={`Carta ${cardIndex + 1}${isSelected ? ' - seleccionada' : ''}`}
                     aria-pressed={isSelected}
                     aria-disabled={!canSelect}
                   >

--- a/frontend/src/components/features/readings/ReadingExperience.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.tsx
@@ -18,6 +18,7 @@ import { shouldUseNativeShare } from '@/lib/utils/device';
 import { useAuthStore } from '@/stores/authStore';
 import { useUserPlanFeatures } from '@/hooks/utils/useUserPlanFeatures';
 import { useUserCapabilities } from '@/hooks/api/useUserCapabilities';
+import { useTarotDeck } from '@/hooks/api/useTarotDeck';
 import { ROUTES } from '@/lib/constants/routes';
 import { TarotCard } from './TarotCard';
 import { Button } from '@/components/ui/button';
@@ -61,9 +62,6 @@ const LOADING_MESSAGES = [
 ];
 
 const LOADING_MESSAGE_INTERVAL = 2000;
-
-/** Total number of cards in a tarot deck */
-const DECK_SIZE = 78;
 
 /** Default deck ID (Rider-Waite) */
 const DEFAULT_DECK_ID = 1;
@@ -307,6 +305,7 @@ export function ReadingExperience({
   const { data: predefinedQuestions, isLoading: isQuestionsLoading } = usePredefinedQuestions();
   const { data: categories } = useCategories();
   const { data: capabilities } = useUserCapabilities();
+  const { cardIndices } = useTarotDeck();
   const { mutateAsync: createReading } = useCreateReading();
   const { mutate: regenerateInterpretation, isPending: isRegenerating } =
     useRegenerateInterpretation();
@@ -605,7 +604,7 @@ export function ReadingExperience({
               data-testid="card-selection-grid"
               className="grid grid-cols-6 justify-items-center gap-1 sm:grid-cols-8 sm:gap-2 md:grid-cols-10 lg:grid-cols-12 xl:grid-cols-13"
             >
-              {Array.from({ length: DECK_SIZE }).map((_, index) => {
+              {Array.from({ length: cardIndices.length }).map((_, index) => {
                 const isSelected = selectedCards.has(index);
                 const canSelect = selectedCards.size < cardsCount || isSelected;
 

--- a/frontend/src/hooks/api/useTarotDeck.test.ts
+++ b/frontend/src/hooks/api/useTarotDeck.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for useTarotDeck hook
+ *
+ * TDD: Tests written before implementation
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+// Mock de useUserCapabilities
+const mockUseUserCapabilities = vi.fn();
+vi.mock('@/hooks/api/useUserCapabilities', () => ({
+  useUserCapabilities: () => mockUseUserCapabilities(),
+}));
+
+// Import hook after mocks
+import { useTarotDeck } from './useTarotDeck';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+};
+
+describe('useTarotDeck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('FREE user (canUseFullDeck: false)', () => {
+    beforeEach(() => {
+      mockUseUserCapabilities.mockReturnValue({
+        data: {
+          canUseFullDeck: false,
+          plan: 'free',
+          isAuthenticated: true,
+        },
+        isLoading: false,
+      });
+    });
+
+    it('should return only 22 card indices for FREE user', () => {
+      const { result } = renderHook(() => useTarotDeck(), { wrapper: createWrapper() });
+
+      expect(result.current.deckSize).toBe(22);
+    });
+
+    it('should return indices 0-21 for FREE user (Arcanos Mayores)', () => {
+      const { result } = renderHook(() => useTarotDeck(), { wrapper: createWrapper() });
+
+      expect(result.current.cardIndices).toHaveLength(22);
+      expect(result.current.cardIndices[0]).toBe(0);
+      expect(result.current.cardIndices[21]).toBe(21);
+    });
+
+    it('should indicate deck is restricted for FREE user', () => {
+      const { result } = renderHook(() => useTarotDeck(), { wrapper: createWrapper() });
+
+      expect(result.current.isRestricted).toBe(true);
+    });
+  });
+
+  describe('PREMIUM user (canUseFullDeck: true)', () => {
+    beforeEach(() => {
+      mockUseUserCapabilities.mockReturnValue({
+        data: {
+          canUseFullDeck: true,
+          plan: 'premium',
+          isAuthenticated: true,
+        },
+        isLoading: false,
+      });
+    });
+
+    it('should return 78 card indices for PREMIUM user', () => {
+      const { result } = renderHook(() => useTarotDeck(), { wrapper: createWrapper() });
+
+      expect(result.current.deckSize).toBe(78);
+    });
+
+    it('should return indices 0-77 for PREMIUM user', () => {
+      const { result } = renderHook(() => useTarotDeck(), { wrapper: createWrapper() });
+
+      expect(result.current.cardIndices).toHaveLength(78);
+      expect(result.current.cardIndices[0]).toBe(0);
+      expect(result.current.cardIndices[77]).toBe(77);
+    });
+
+    it('should indicate deck is not restricted for PREMIUM user', () => {
+      const { result } = renderHook(() => useTarotDeck(), { wrapper: createWrapper() });
+
+      expect(result.current.isRestricted).toBe(false);
+    });
+  });
+
+  describe('Anonymous user (canUseFullDeck: false)', () => {
+    beforeEach(() => {
+      mockUseUserCapabilities.mockReturnValue({
+        data: {
+          canUseFullDeck: false,
+          plan: 'anonymous',
+          isAuthenticated: false,
+        },
+        isLoading: false,
+      });
+    });
+
+    it('should return only 22 card indices for anonymous user', () => {
+      const { result } = renderHook(() => useTarotDeck(), { wrapper: createWrapper() });
+
+      expect(result.current.deckSize).toBe(22);
+    });
+  });
+
+  describe('Loading state', () => {
+    it('should return full deck (78) while capabilities are loading (safe default)', () => {
+      mockUseUserCapabilities.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+      });
+
+      const { result } = renderHook(() => useTarotDeck(), { wrapper: createWrapper() });
+
+      // Default to full deck while loading to avoid premature restriction
+      expect(result.current.deckSize).toBe(78);
+    });
+  });
+});

--- a/frontend/src/hooks/api/useTarotDeck.test.ts
+++ b/frontend/src/hooks/api/useTarotDeck.test.ts
@@ -117,7 +117,7 @@ describe('useTarotDeck', () => {
   });
 
   describe('Loading state', () => {
-    it('should return full deck (78) while capabilities are loading (safe default)', () => {
+    it('should return restricted deck (22) while capabilities are loading', () => {
       mockUseUserCapabilities.mockReturnValue({
         data: undefined,
         isLoading: true,
@@ -125,8 +125,10 @@ describe('useTarotDeck', () => {
 
       const { result } = renderHook(() => useTarotDeck(), { wrapper: createWrapper() });
 
-      // Default to full deck while loading to avoid premature restriction
-      expect(result.current.deckSize).toBe(78);
+      // Default to restricted deck while loading to prevent FREE/anonymous users
+      // from temporarily seeing or selecting cards beyond index 21
+      expect(result.current.deckSize).toBe(22);
+      expect(result.current.isRestricted).toBe(true);
     });
   });
 });

--- a/frontend/src/hooks/api/useTarotDeck.ts
+++ b/frontend/src/hooks/api/useTarotDeck.ts
@@ -32,20 +32,23 @@ export interface TarotDeckResult {
  * Hook that returns the available deck indices for the current user.
  *
  * Uses `canUseFullDeck` capability from the backend to determine the deck size.
- * While capabilities are loading, defaults to the full deck to avoid premature restriction.
+ * While capabilities are loading or unknown, defaults to the restricted deck (Major Arcana)
+ * to prevent FREE/anonymous users from temporarily seeing or selecting cards beyond index 21.
  *
  * @example
  * ```tsx
  * const { cardIndices, deckSize, isRestricted } = useTarotDeck();
- * // Render deckSize cards; use cardIndices to map to cardId (index + 1)
+ * // Iterate over cardIndices directly; cardId = cardIndex + 1
  * ```
  */
 export function useTarotDeck(): TarotDeckResult {
   const { data: capabilities } = useUserCapabilities();
 
   return useMemo(() => {
-    // While loading or no data: default to full deck (safe — backend validates anyway)
-    const canUseFullDeck = capabilities?.canUseFullDeck ?? true;
+    // While loading or no data: default to restricted deck (Major Arcana only).
+    // This prevents FREE/anonymous users from temporarily seeing/selecting cards > index 21
+    // before capabilities resolve. The backend validates selection server-side anyway.
+    const canUseFullDeck = capabilities?.canUseFullDeck ?? false;
 
     const size = canUseFullDeck ? FULL_DECK_SIZE : MAJOR_ARCANA_COUNT;
     const indices = Array.from({ length: size }, (_, i) => i);

--- a/frontend/src/hooks/api/useTarotDeck.ts
+++ b/frontend/src/hooks/api/useTarotDeck.ts
@@ -1,0 +1,59 @@
+/**
+ * useTarotDeck Hook
+ *
+ * Computes the available deck for the current user based on their plan capabilities.
+ *
+ * - FREE / Anonymous: Only 22 Major Arcana cards (indices 0-21, card IDs 1-22)
+ * - PREMIUM: Full 78-card deck (indices 0-77)
+ *
+ * The deck is represented as an array of 0-based indices that map to card IDs
+ * (index + 1 = cardId). No API fetch is required since cards are indexed locally.
+ */
+
+import { useMemo } from 'react';
+import { useUserCapabilities } from '@/hooks/api/useUserCapabilities';
+
+/** Number of Major Arcana cards */
+const MAJOR_ARCANA_COUNT = 22;
+
+/** Total tarot deck size */
+const FULL_DECK_SIZE = 78;
+
+export interface TarotDeckResult {
+  /** Array of 0-based card indices available to the user */
+  cardIndices: number[];
+  /** Number of cards in the available deck */
+  deckSize: number;
+  /** Whether the deck is restricted (FREE plan — only Major Arcana) */
+  isRestricted: boolean;
+}
+
+/**
+ * Hook that returns the available deck indices for the current user.
+ *
+ * Uses `canUseFullDeck` capability from the backend to determine the deck size.
+ * While capabilities are loading, defaults to the full deck to avoid premature restriction.
+ *
+ * @example
+ * ```tsx
+ * const { cardIndices, deckSize, isRestricted } = useTarotDeck();
+ * // Render deckSize cards; use cardIndices to map to cardId (index + 1)
+ * ```
+ */
+export function useTarotDeck(): TarotDeckResult {
+  const { data: capabilities } = useUserCapabilities();
+
+  return useMemo(() => {
+    // While loading or no data: default to full deck (safe — backend validates anyway)
+    const canUseFullDeck = capabilities?.canUseFullDeck ?? true;
+
+    const size = canUseFullDeck ? FULL_DECK_SIZE : MAJOR_ARCANA_COUNT;
+    const indices = Array.from({ length: size }, (_, i) => i);
+
+    return {
+      cardIndices: indices,
+      deckSize: size,
+      isRestricted: !canUseFullDeck,
+    };
+  }, [capabilities?.canUseFullDeck]);
+}

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -19,6 +19,12 @@ export const API_ENDPOINTS = {
     BASE: '/categories',
   },
 
+  // Tarot Cards (deck for readings)
+  CARDS: {
+    BASE: '/cards',
+    BY_CATEGORY: (category: string) => `/cards?category=${category}`,
+  },
+
   // Predefined Questions
   PREDEFINED_QUESTIONS: {
     BASE: '/predefined-questions',


### PR DESCRIPTION
## Descripción

Implementa el filtrado del mazo de cartas en el flujo de selección (`ReadingExperience`) para que los usuarios FREE solo vean los 22 Arcanos Mayores, mientras que PREMIUM sigue viendo las 78 cartas del mazo completo.

**Tarea:** T-FR-F04 | **HUS:** HUS-005 | **Rama base:** `develop`

## Cambios

### Archivos nuevos
- `frontend/src/hooks/api/useTarotDeck.ts` — Hook que calcula `cardIndices` según `canUseFullDeck` (capability del usuario)
- `frontend/src/hooks/api/useTarotDeck.test.ts` — 8 tests unitarios (FREE → 22 cartas, PREMIUM → 78, anónimo → 22, loading state)

### Archivos modificados
- `frontend/src/components/features/readings/ReadingExperience.tsx` — Reemplaza `DECK_SIZE = 78` con `useTarotDeck`, el grid usa `cardIndices.length`
- `frontend/src/components/features/readings/ReadingExperience.test.tsx` — Mock de `useTarotDeck` + nueva suite "Deck filtrado" con 3 tests
- `frontend/src/lib/api/endpoints.ts` — Agrega sección `CARDS` con `BASE` y `BY_CATEGORY`
- `docs/BACKLOG_FREE_READING_EXPERIENCE.md` — T-FR-F04 marcada como completada

## Decisiones técnicas

- El deck no hace fetch al backend: se calcula localmente usando solo `canUseFullDeck` de `useUserCapabilities`. Los índices 0-21 corresponden a los Arcanos Mayores (cardIds 1-22).
- La validación de seguridad real está en backend (T-FR-B03), este cambio es solo capa UX.

## Calidad

- npm run format: OK
- npm run lint:fix: sin errores nuevos
- npm run type-check: OK
- Tests nuevos: 11 tests (8 hook + 3 integración) — todos passing
- npm run build: compilación exitosa
- node scripts/validate-architecture.js: arquitectura válida
