### PR TITLE
fix(config): Force UTC timezone on Railway deployment

### DIFF
--- a/backend/tarot-app/Dockerfile
+++ b/backend/tarot-app/Dockerfile
@@ -48,6 +48,7 @@ WORKDIR /app/backend/tarot-app
 
 ENV NODE_ENV=production
 ENV PORT=3000
+ENV TZ=UTC
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \

--- a/backend/tarot-app/src/main.ts
+++ b/backend/tarot-app/src/main.ts
@@ -8,6 +8,9 @@ import * as path from 'path';
 import * as dotenv from 'dotenv';
 import helmet from 'helmet';
 
+// Force UTC timezone for consistent timestamps across all environments
+process.env.TZ = 'UTC';
+
 async function bootstrap() {
   // Explicitly load .env file
   const envPath = path.resolve(process.cwd(), '.env');
@@ -42,6 +45,10 @@ async function bootstrap() {
 
   // Log startup with custom logger
   loggerService.log('Application is starting...', 'Bootstrap');
+  loggerService.log(
+    `Server timezone: TZ=${process.env.TZ}, Date: ${new Date().toISOString()}`,
+    'Bootstrap',
+  );
 
   // Configure security headers with Helmet (TASK-048-a)
   app.use(


### PR DESCRIPTION
## Problema

Los timestamps en la base de datos de producción (Railway) estaban **~2.5 horas adelantados** respecto a la hora UTC real. Esto causaba:
- Lecturas y daily readings con `createdAt` en el futuro
- Posibles inconsistencias en los cálculos de límites diarios (`getStartOfTodayUTC()`)

## Causa Raíz

El container Docker en Railway no tenía `TZ` configurado explícitamente. El runtime de Node.js usaba el timezone del sistema del container, que no era UTC.

TypeORM usa `new Date()` del proceso Node.js para `@CreateDateColumn()`, por lo que los timestamps se almacenaban con el offset incorrecto.

## Solución

1. **Dockerfile**: Agregado `ENV TZ=UTC` en la etapa de producción
2. **main.ts**: Agregado `process.env.TZ = 'UTC'` a nivel de módulo (antes de bootstrap) como defensa adicional
3. **Log de diagnóstico**: Al arrancar el servidor se logea el TZ y la hora actual para verificación

## Verificación Post-Deploy

Llamar a `/api/v1/health/live` y verificar que el timestamp sea UTC correcto.

También se recomienda agregar `TZ=UTC` como variable de entorno en Railway Dashboard.

## Quality Gates

- [x] Format (Prettier)
- [x] Lint (ESLint)
- [x] Tests (4338 passed, 1 failed por ENOMEM preexistente no relacionado)
- [x] Build (nest build OK)