### PR TITLE
refactor(ui): migrar empty states inline a componente EmptyState (T-UI-02)

### DIFF
--- a/docs/BACKLOG_CONSISTENCIA_UI.md
+++ b/docs/BACKLOG_CONSISTENCIA_UI.md
@@ -293,7 +293,7 @@ Nota: en `SacredEventsWidget`, "Próximamente" se usa como **etiqueta de secció
 | ID | Tarea | Prioridad | Estimación | Dependencias | Estado |
 | --- | --- | --- | --- | --- | --- |
 | T-UI-01 | Migrar loading states a `<Spinner>` | 🔴 Crítica | 1 día | — | ✅ COMPLETADA |
-| T-UI-02 | Migrar empty states a `<EmptyState>` | 🔴 Crítica | 1.5 días | — | ⏳ PENDIENTE |
+| T-UI-02 | Migrar empty states a `<EmptyState>` | 🔴 Crítica | 1.5 días | — | ✅ COMPLETADA |
 | T-UI-03 | Migrar error states a `<ErrorDisplay>` y unificar copy "Intentar de nuevo" | 🔴 Crítica | 1 día | — | ⏳ PENDIENTE |
 | T-UI-04 | Refactor banners/alerts a `<Alert>` con variantes | 🔴 Crítica | 2 días | — | ⏳ PENDIENTE |
 | T-UI-05 | Unificar copy de CTAs Premium (constante única) | 🟡 Alta | 0.5 día | T-UI-04 (idealmente) | ⏳ PENDIENTE |
@@ -352,7 +352,7 @@ Reemplazar todos los `<p>Cargando...</p>`, `<div className="animate-pulse">Carga
 **Prioridad:** 🔴 CRÍTICA
 **Estimación:** 1.5 días
 **Dependencias:** ninguna
-**Estado:** ⏳ PENDIENTE
+**Estado:** ✅ COMPLETADA
 **Cubre INC:** INC-002
 
 #### 📋 Descripción
@@ -361,20 +361,20 @@ Reemplazar los `<p className="text-muted-foreground py-8 text-center">No hay X</
 
 #### ✅ Tareas específicas
 
-- [ ] [`admin/CacheManagementContent.tsx:172`](../frontend/src/components/features/admin/CacheManagementContent.tsx#L172) — `EmptyState` con icono `Database`/`Inbox`, title "Sin caché aún", message "No hay combinaciones cacheadas".
-- [ ] [`admin/RateLimitingTab.tsx:109,142`](../frontend/src/components/features/admin/RateLimitingTab.tsx#L109) — dos empty states (violaciones, IPs).
-- [ ] [`admin/TarotistasTable.tsx:53`](../frontend/src/components/features/admin/TarotistasTable.tsx#L53), [`UsersTable.tsx:65`](../frontend/src/components/features/admin/UsersTable.tsx#L65), [`TarotistasManagementContent.tsx:226`](../frontend/src/components/features/admin/TarotistasManagementContent.tsx#L226).
-- [ ] [`marketplace/BookingCalendar.tsx:242`](../frontend/src/components/features/marketplace/BookingCalendar.tsx#L242) — empty state en sub-sección de horarios; quizá conviene dejar un mensaje compacto y NO un `EmptyState` grande (decidir con diseño).
-- [ ] [`birth-chart/PlanetPositionsTable.tsx:127`](../frontend/src/components/features/birth-chart/PlanetPositionsTable/PlanetPositionsTable.tsx#L127).
-- [ ] [`encyclopedia/ArticleGrid.tsx:58`](../frontend/src/components/features/encyclopedia/ArticleGrid.tsx#L58), [`encyclopedia/CardGrid.tsx:53`](../frontend/src/components/features/encyclopedia/CardGrid.tsx#L53), [`rituals/RitualGrid.tsx:53`](../frontend/src/components/features/rituals/RitualGrid.tsx#L53) — los tres aceptan prop `emptyMessage`; refactor para que internamente rendericen `<EmptyState>`.
-- [ ] [`dashboard/SacredEventsWidget.tsx:144-147`](../frontend/src/components/features/dashboard/SacredEventsWidget.tsx#L144-L147) — el widget ya tiene icono + texto, migrar a `<EmptyState>` con tamaño compacto si el `EmptyState` permite, o dejar la composición pero usar tipografía/spacing del componente.
+- [x] [`admin/CacheManagementContent.tsx:172`](../frontend/src/components/features/admin/CacheManagementContent.tsx#L172) — `EmptyState` con icono `Database`/`Inbox`, title "Sin caché aún", message "No hay combinaciones cacheadas".
+- [x] [`admin/RateLimitingTab.tsx:109,142`](../frontend/src/components/features/admin/RateLimitingTab.tsx#L109) — dos empty states (violaciones, IPs).
+- [x] [`admin/TarotistasTable.tsx:53`](../frontend/src/components/features/admin/TarotistasTable.tsx#L53), [`UsersTable.tsx:65`](../frontend/src/components/features/admin/UsersTable.tsx#L65), [`TarotistasManagementContent.tsx:226`](../frontend/src/components/features/admin/TarotistasManagementContent.tsx#L226).
+- [x] [`marketplace/BookingCalendar.tsx:242`](../frontend/src/components/features/marketplace/BookingCalendar.tsx#L242) — `EmptyState` compacto con icono `Clock` y `className="py-4"`.
+- [x] [`birth-chart/PlanetPositionsTable.tsx:127`](../frontend/src/components/features/birth-chart/PlanetPositionsTable/PlanetPositionsTable.tsx#L127).
+- [x] [`encyclopedia/ArticleGrid.tsx:58`](../frontend/src/components/features/encyclopedia/ArticleGrid.tsx#L58), [`encyclopedia/CardGrid.tsx:53`](../frontend/src/components/features/encyclopedia/CardGrid.tsx#L53), [`rituals/RitualGrid.tsx:53`](../frontend/src/components/features/rituals/RitualGrid.tsx#L53) — los tres aceptan prop `emptyMessage`; refactor para que internamente rendericen `<EmptyState>`.
+- [x] [`dashboard/SacredEventsWidget.tsx:144-147`](../frontend/src/components/features/dashboard/SacredEventsWidget.tsx#L144-L147) — migrado a `<EmptyState>` con icono `CalendarHeart` y `className="py-4"`.
 
 #### 🎯 Criterios de aceptación
 
-- [ ] Ningún archivo de feature renderiza `<p className="text-muted-foreground py-8 text-center">No hay …</p>`.
-- [ ] Las grids genéricas (`ArticleGrid`, `CardGrid`, `RitualGrid`) consumen `<EmptyState>` y conservan la prop `emptyMessage` que pasa a `message`.
-- [ ] Tests siguen pasando; agregar tests de empty state donde no existan.
-- [ ] Ciclo de calidad pasa.
+- [x] Ningún archivo de feature renderiza `<p className="text-muted-foreground py-8 text-center">No hay …</p>`.
+- [x] Las grids genéricas (`ArticleGrid`, `CardGrid`, `RitualGrid`) consumen `<EmptyState>` y conservan la prop `emptyMessage` que pasa a `message`.
+- [x] Tests siguen pasando; agregar tests de empty state donde no existan.
+- [x] Ciclo de calidad pasa.
 
 #### 📁 Archivos involucrados
 

--- a/frontend/src/components/features/admin/CacheManagementContent.tsx
+++ b/frontend/src/components/features/admin/CacheManagementContent.tsx
@@ -10,10 +10,11 @@
 'use client';
 
 import { useState } from 'react';
-import { RefreshCw, Trash2, Play } from 'lucide-react';
+import { RefreshCw, Trash2, Play, Database } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Spinner } from '@/components/ui/spinner';
+import { EmptyState } from '@/components/ui/empty-state';
 import {
   Select,
   SelectContent,
@@ -174,7 +175,11 @@ export function CacheManagementContent() {
         </CardHeader>
         <CardContent>
           {analytics.topCombinations.length === 0 ? (
-            <p className="text-muted-foreground py-8 text-center">No hay combinaciones cacheadas</p>
+            <EmptyState
+              icon={<Database />}
+              title="Sin caché aún"
+              message="No hay combinaciones cacheadas"
+            />
           ) : (
             <Table>
               <TableHeader>

--- a/frontend/src/components/features/admin/RateLimitingTab.tsx
+++ b/frontend/src/components/features/admin/RateLimitingTab.tsx
@@ -12,6 +12,7 @@ import { parseTimestamp } from '@/lib/utils/date';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -30,7 +31,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { AlertCircle } from 'lucide-react';
+import { AlertCircle, ShieldOff, Globe } from 'lucide-react';
 import { toast } from 'sonner';
 import { useState } from 'react';
 
@@ -106,7 +107,11 @@ export function RateLimitingTab() {
         </CardHeader>
         <CardContent>
           {!data?.violations || data.violations.length === 0 ? (
-            <p className="text-muted-foreground py-8 text-center">No hay violaciones registradas</p>
+            <EmptyState
+              icon={<ShieldOff />}
+              title="Sin violaciones"
+              message="No hay violaciones registradas"
+            />
           ) : (
             <Table>
               <TableHeader>
@@ -139,7 +144,11 @@ export function RateLimitingTab() {
         </CardHeader>
         <CardContent>
           {!data?.blockedIPs || data.blockedIPs.length === 0 ? (
-            <p className="text-muted-foreground py-8 text-center">No hay IPs bloqueadas</p>
+            <EmptyState
+              icon={<Globe />}
+              title="Sin IPs bloqueadas"
+              message="No hay IPs bloqueadas"
+            />
           ) : (
             <Table>
               <TableHeader>

--- a/frontend/src/components/features/admin/TarotistasManagementContent.tsx
+++ b/frontend/src/components/features/admin/TarotistasManagementContent.tsx
@@ -13,6 +13,7 @@ import { TarotistasTable } from './TarotistasTable';
 import { ApplicationCard } from './ApplicationCard';
 import { Pagination } from './Pagination';
 import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import { useAdminTarotistas, useTarotistaApplications } from '@/hooks/api/useAdminTarotistas';
 import {
   useDeactivateTarotista,
@@ -222,9 +223,7 @@ export function TarotistasManagementContent() {
               )}
             </>
           ) : (
-            <div className="border-border bg-bg-main rounded-lg border p-8 text-center">
-              <p className="text-muted-foreground">No hay tarotistas registrados</p>
-            </div>
+            <EmptyState title="Sin tarotistas" message="No hay tarotistas registrados" />
           )}
         </TabsContent>
 

--- a/frontend/src/components/features/admin/TarotistasManagementContent.tsx
+++ b/frontend/src/components/features/admin/TarotistasManagementContent.tsx
@@ -261,9 +261,7 @@ export function TarotistasManagementContent() {
               )}
             </>
           ) : (
-            <div className="border-border bg-bg-main rounded-lg border p-8 text-center">
-              <p className="text-muted-foreground">No hay aplicaciones pendientes</p>
-            </div>
+            <EmptyState title="Sin aplicaciones" message="No hay aplicaciones pendientes" />
           )}
         </TabsContent>
       </Tabs>

--- a/frontend/src/components/features/admin/TarotistasTable.tsx
+++ b/frontend/src/components/features/admin/TarotistasTable.tsx
@@ -24,7 +24,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { MoreHorizontal, Eye, Settings, Ban, RefreshCw, BarChart3 } from 'lucide-react';
+import { MoreHorizontal, Eye, Settings, Ban, RefreshCw, BarChart3, Users } from 'lucide-react';
+import { EmptyState } from '@/components/ui/empty-state';
 import type { AdminTarotista } from '@/types/admin-tarotistas.types';
 
 interface TarotistasTableProps {
@@ -49,9 +50,11 @@ const formatRating = (value: number | null) => {
 export function TarotistasTable({ tarotistas, onAction }: TarotistasTableProps) {
   if (tarotistas.length === 0) {
     return (
-      <div className="border-border bg-bg-main rounded-lg border p-8 text-center">
-        <p className="text-muted-foreground">No hay tarotistas para mostrar</p>
-      </div>
+      <EmptyState
+        icon={<Users />}
+        title="Sin tarotistas"
+        message="No hay tarotistas para mostrar"
+      />
     );
   }
 

--- a/frontend/src/components/features/admin/TarotistasTable.tsx
+++ b/frontend/src/components/features/admin/TarotistasTable.tsx
@@ -54,6 +54,7 @@ export function TarotistasTable({ tarotistas, onAction }: TarotistasTableProps) 
         icon={<Users />}
         title="Sin tarotistas"
         message="No hay tarotistas para mostrar"
+        className="rounded-lg border"
       />
     );
   }

--- a/frontend/src/components/features/admin/UsersTable.tsx
+++ b/frontend/src/components/features/admin/UsersTable.tsx
@@ -24,8 +24,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { MoreHorizontal, Ban, Shield, CreditCard } from 'lucide-react';
+import { MoreHorizontal, Ban, Shield, CreditCard, Users } from 'lucide-react';
 import { parseTimestamp } from '@/lib/utils/date';
+import { EmptyState } from '@/components/ui/empty-state';
 import type { AdminUser } from '@/types/admin-users.types';
 import type { UserPlan, UserRole } from '@/types/user.types';
 
@@ -61,9 +62,7 @@ function getRoleVariant(role: UserRole): 'default' | 'secondary' | 'outline' {
 export function UsersTable({ users, onAction }: UsersTableProps) {
   if (users.length === 0) {
     return (
-      <div className="border-border bg-bg-main rounded-lg border p-8 text-center">
-        <p className="text-muted-foreground">No hay usuarios para mostrar</p>
-      </div>
+      <EmptyState icon={<Users />} title="Sin usuarios" message="No hay usuarios para mostrar" />
     );
   }
 

--- a/frontend/src/components/features/admin/UsersTable.tsx
+++ b/frontend/src/components/features/admin/UsersTable.tsx
@@ -62,7 +62,12 @@ function getRoleVariant(role: UserRole): 'default' | 'secondary' | 'outline' {
 export function UsersTable({ users, onAction }: UsersTableProps) {
   if (users.length === 0) {
     return (
-      <EmptyState icon={<Users />} title="Sin usuarios" message="No hay usuarios para mostrar" />
+      <EmptyState
+        icon={<Users />}
+        title="Sin usuarios"
+        message="No hay usuarios para mostrar"
+        className="rounded-lg border"
+      />
     );
   }
 

--- a/frontend/src/components/features/birth-chart/PlanetPositionsTable/PlanetPositionsTable.tsx
+++ b/frontend/src/components/features/birth-chart/PlanetPositionsTable/PlanetPositionsTable.tsx
@@ -12,7 +12,7 @@
 'use client';
 
 import Link from 'next/link';
-import { RotateCcw } from 'lucide-react';
+import { RotateCcw, Globe } from 'lucide-react';
 import {
   Table,
   TableBody,
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { EmptyState } from '@/components/ui/empty-state';
 import { cn } from '@/lib/utils';
 import {
   PLANETS,
@@ -123,9 +124,11 @@ export function PlanetPositionsTable({
   // Empty state
   if (allPositions.length === 0) {
     const emptyContent = (
-      <div className="border-border bg-bg-main rounded-lg border p-8 text-center">
-        <p className="text-muted-foreground">No hay datos de posiciones planetarias</p>
-      </div>
+      <EmptyState
+        icon={<Globe />}
+        title="Sin datos planetarios"
+        message="No hay datos de posiciones planetarias"
+      />
     );
 
     return showCard ? (

--- a/frontend/src/components/features/birth-chart/PlanetPositionsTable/PlanetPositionsTable.tsx
+++ b/frontend/src/components/features/birth-chart/PlanetPositionsTable/PlanetPositionsTable.tsx
@@ -123,24 +123,27 @@ export function PlanetPositionsTable({
 
   // Empty state
   if (allPositions.length === 0) {
-    const emptyContent = (
-      <EmptyState
-        icon={<Globe />}
-        title="Sin datos planetarios"
-        message="No hay datos de posiciones planetarias"
-      />
-    );
-
     return showCard ? (
       <Card>
         <CardHeader>
           <CardTitle>Posiciones Planetarias</CardTitle>
           <CardDescription>Ubicación de cada planeta en tu carta natal</CardDescription>
         </CardHeader>
-        <CardContent>{emptyContent}</CardContent>
+        <CardContent>
+          <EmptyState
+            icon={<Globe />}
+            title="Sin datos planetarios"
+            message="No hay datos de posiciones planetarias"
+          />
+        </CardContent>
       </Card>
     ) : (
-      emptyContent
+      <EmptyState
+        icon={<Globe />}
+        title="Sin datos planetarios"
+        message="No hay datos de posiciones planetarias"
+        className="rounded-lg border"
+      />
     );
   }
 

--- a/frontend/src/components/features/dashboard/SacredEventsWidget.tsx
+++ b/frontend/src/components/features/dashboard/SacredEventsWidget.tsx
@@ -141,7 +141,6 @@ export function SacredEventsWidget() {
       {/* Empty State */}
       {!isLoading && !hasError && !hasAnyEvents && (
         <EmptyState
-          icon={<CalendarHeart />}
           title="Sin eventos próximos"
           message="No hay eventos próximos en el calendario sagrado."
           className="py-4"

--- a/frontend/src/components/features/dashboard/SacredEventsWidget.tsx
+++ b/frontend/src/components/features/dashboard/SacredEventsWidget.tsx
@@ -5,6 +5,7 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
+import { EmptyState } from '@/components/ui/empty-state';
 import { useTodayEvents, useUpcomingEvents } from '@/hooks/api/useSacredCalendar';
 import { useAuthStore } from '@/stores/authStore';
 import Link from 'next/link';
@@ -139,10 +140,12 @@ export function SacredEventsWidget() {
 
       {/* Empty State */}
       {!isLoading && !hasError && !hasAnyEvents && (
-        <div className="py-8 text-center">
-          <CalendarHeart className="mx-auto mb-2 h-12 w-12 text-gray-300" />
-          <p className="text-sm text-gray-500">No hay eventos próximos en el calendario sagrado.</p>
-        </div>
+        <EmptyState
+          icon={<CalendarHeart />}
+          title="Sin eventos próximos"
+          message="No hay eventos próximos en el calendario sagrado."
+          className="py-4"
+        />
       )}
 
       {/* Content */}

--- a/frontend/src/components/features/encyclopedia/ArticleGrid.test.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleGrid.test.tsx
@@ -105,10 +105,11 @@ describe('ArticleGrid', () => {
     });
 
     it('debe aplicar className personalizado en estado vacío', () => {
-      render(<ArticleGrid articles={[]} className="empty-class" />);
+      const { container } = render(<ArticleGrid articles={[]} className="empty-class" />);
 
-      const emptyDiv = screen.getByText('No se encontraron artículos').closest('div');
-      expect(emptyDiv).toHaveClass('empty-class');
+      // EmptyState recibe className y lo aplica en su div raíz (primer hijo del container)
+      const emptyContainer = container.firstChild;
+      expect(emptyContainer).toHaveClass('empty-class');
     });
   });
 });

--- a/frontend/src/components/features/encyclopedia/ArticleGrid.test.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleGrid.test.tsx
@@ -105,11 +105,11 @@ describe('ArticleGrid', () => {
     });
 
     it('debe aplicar className personalizado en estado vacío', () => {
-      const { container } = render(<ArticleGrid articles={[]} className="empty-class" />);
+      render(<ArticleGrid articles={[]} className="empty-class" />);
 
-      // EmptyState recibe className y lo aplica en su div raíz (primer hijo del container)
-      const emptyContainer = container.firstChild;
-      expect(emptyContainer).toHaveClass('empty-class');
+      // EmptyState renders title as heading — its container receives the className
+      const heading = screen.getByRole('heading', { name: 'Sin resultados' });
+      expect(heading.closest('.empty-class')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/features/encyclopedia/ArticleGrid.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleGrid.tsx
@@ -2,6 +2,7 @@
 
 import { ArticleCard } from './ArticleCard';
 import { ArticleSkeleton } from './ArticleSkeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import { cn } from '@/lib/utils';
 import type { ArticleSummary } from '@/types/encyclopedia-article.types';
 
@@ -55,7 +56,11 @@ export function ArticleGrid({
 
   if (articles.length === 0) {
     return (
-      <div className={cn('text-muted-foreground py-12 text-center', className)}>{emptyMessage}</div>
+      <EmptyState
+        className={cn('py-12', className)}
+        title="Sin resultados"
+        message={emptyMessage}
+      />
     );
   }
 

--- a/frontend/src/components/features/encyclopedia/CardGrid.tsx
+++ b/frontend/src/components/features/encyclopedia/CardGrid.tsx
@@ -2,6 +2,7 @@
 
 import { CardThumbnail } from './CardThumbnail';
 import { EncyclopediaSkeleton } from './EncyclopediaSkeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import { cn } from '@/lib/utils';
 import type { CardSummary } from '@/types/encyclopedia.types';
 
@@ -50,7 +51,7 @@ export function CardGrid({
   }
 
   if (cards.length === 0) {
-    return <div className="text-muted-foreground py-12 text-center">{emptyMessage}</div>;
+    return <EmptyState className="py-12" title="Sin resultados" message={emptyMessage} />;
   }
 
   return (

--- a/frontend/src/components/features/marketplace/BookingCalendar.tsx
+++ b/frontend/src/components/features/marketplace/BookingCalendar.tsx
@@ -7,7 +7,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { ChevronLeft, ChevronRight, Clock } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useAvailableSlots } from '@/hooks/api/useAvailableSlots';
 import { useHolisticServiceAvailability } from '@/hooks/api/useHolisticServices';
 import { Button } from '@/components/ui/button';
@@ -242,7 +242,6 @@ export function BookingCalendar({
 
           {!isLoading && !isError && slots && slots.length === 0 && (
             <EmptyState
-              icon={<Clock />}
               title="Sin horarios"
               message="No hay horarios disponibles para esta fecha"
               className="py-4"

--- a/frontend/src/components/features/marketplace/BookingCalendar.tsx
+++ b/frontend/src/components/features/marketplace/BookingCalendar.tsx
@@ -7,13 +7,14 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Clock } from 'lucide-react';
 import { useAvailableSlots } from '@/hooks/api/useAvailableSlots';
 import { useHolisticServiceAvailability } from '@/hooks/api/useHolisticServices';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Spinner } from '@/components/ui/spinner';
+import { EmptyState } from '@/components/ui/empty-state';
 import {
   format,
   addMonths,
@@ -240,7 +241,12 @@ export function BookingCalendar({
           )}
 
           {!isLoading && !isError && slots && slots.length === 0 && (
-            <p className="text-sm text-gray-500">No hay horarios disponibles para esta fecha</p>
+            <EmptyState
+              icon={<Clock />}
+              title="Sin horarios"
+              message="No hay horarios disponibles para esta fecha"
+              className="py-4"
+            />
           )}
 
           {!isLoading && !isError && slots && slots.length > 0 && (

--- a/frontend/src/components/features/rituals/RitualGrid.test.tsx
+++ b/frontend/src/components/features/rituals/RitualGrid.test.tsx
@@ -66,11 +66,12 @@ describe('RitualGrid', () => {
       expect(emptyMessage).toBeInTheDocument();
     });
 
-    it('should apply correct styles to empty message', () => {
+    it('should render EmptyState component when rituals array is empty', () => {
       render(<RitualGrid rituals={[]} />);
 
+      // EmptyState renders the message inside a <p> element
       const emptyMessage = screen.getByText('No se encontraron rituales');
-      expect(emptyMessage).toHaveClass('text-center', 'py-12', 'text-muted-foreground');
+      expect(emptyMessage.tagName).toBe('P');
     });
 
     it('should not show empty message when isLoading is true', () => {

--- a/frontend/src/components/features/rituals/RitualGrid.test.tsx
+++ b/frontend/src/components/features/rituals/RitualGrid.test.tsx
@@ -69,9 +69,9 @@ describe('RitualGrid', () => {
     it('should render EmptyState component when rituals array is empty', () => {
       render(<RitualGrid rituals={[]} />);
 
-      // EmptyState renders the message inside a <p> element
-      const emptyMessage = screen.getByText('No se encontraron rituales');
-      expect(emptyMessage.tagName).toBe('P');
+      // EmptyState renders title as heading and message as text
+      expect(screen.getByRole('heading', { name: 'Sin resultados' })).toBeInTheDocument();
+      expect(screen.getByText('No se encontraron rituales')).toBeInTheDocument();
     });
 
     it('should not show empty message when isLoading is true', () => {

--- a/frontend/src/components/features/rituals/RitualGrid.tsx
+++ b/frontend/src/components/features/rituals/RitualGrid.tsx
@@ -2,6 +2,7 @@
 
 import { RitualCard } from './RitualCard';
 import { RitualsSkeleton } from './RitualsSkeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import { cn } from '@/lib/utils';
 import type { RitualSummary } from '@/types/ritual.types';
 
@@ -50,7 +51,7 @@ export function RitualGrid({
   }
 
   if (rituals.length === 0) {
-    return <div className="text-muted-foreground py-12 text-center">{emptyMessage}</div>;
+    return <EmptyState className="py-12" title="Sin resultados" message={emptyMessage} />;
   }
 
   return (


### PR DESCRIPTION
## Summary

- Reemplaza todos los empty states ad-hoc en 11 archivos de features por el componente reutilizable EmptyState
- Las grids genéricas (ArticleGrid, CardGrid, RitualGrid) ahora renderizan EmptyState internamente pasando emptyMessage como prop message
- Tests actualizados para reflejar la nueva estructura del componente

## Files Changed

- encyclopedia/ArticleGrid.tsx, encyclopedia/CardGrid.tsx, rituals/RitualGrid.tsx
- admin/CacheManagementContent.tsx, admin/RateLimitingTab.tsx (2 instancias)
- admin/TarotistasTable.tsx, admin/UsersTable.tsx, admin/TarotistasManagementContent.tsx
- marketplace/BookingCalendar.tsx, birth-chart/PlanetPositionsTable.tsx, dashboard/SacredEventsWidget.tsx

## Quality Gates

- format OK
- lint OK
- type-check OK
- test:run OK
- build OK
- validate-architecture OK