### PR TITLE
feat(frontend): unify Premium CTA copy via CTA_PREMIUM constant (T-UI-05)

### DIFF
--- a/docs/BACKLOG_CONSISTENCIA_UI.md
+++ b/docs/BACKLOG_CONSISTENCIA_UI.md
@@ -296,7 +296,7 @@ Nota: en `SacredEventsWidget`, "Próximamente" se usa como **etiqueta de secció
 | T-UI-02 | Migrar empty states a `<EmptyState>` | 🔴 Crítica | 1.5 días | — | ✅ COMPLETADA |
 | T-UI-03 | Migrar error states a `<ErrorDisplay>` y unificar copy "Intentar de nuevo" | 🔴 Crítica | 1 día | — | ✅ COMPLETADA |
 | T-UI-04 | Refactor banners/alerts a `<Alert>` con variantes | 🔴 Crítica | 2 días | — | ⏳ PENDIENTE |
-| T-UI-05 | Unificar copy de CTAs Premium (constante única) | 🟡 Alta | 0.5 día | T-UI-04 (idealmente) | ⏳ PENDIENTE |
+| T-UI-05 | Unificar copy de CTAs Premium (constante única) | 🟡 Alta | 0.5 día | T-UI-04 (idealmente) | ✅ COMPLETADA |
 | T-UI-06 | Migrar skeletons inline a `<Skeleton>` | 🟡 Alta | 1 día | — | ⏳ PENDIENTE |
 | T-UI-07 | Unificar copy de CTAs de auth | 🟡 Alta | 0.5 día | — | ⏳ PENDIENTE |
 | T-UI-08 | Crear `<DisclaimerBanner>` y migrar páginas legales | 🟢 Media | 0.5 día | T-UI-04 | ⏳ PENDIENTE |
@@ -466,7 +466,7 @@ Unificar los 6 patrones de markup de banners (`bg-yellow-50`, `bg-red-50`, `bg-g
 **Prioridad:** 🟡 ALTA
 **Estimación:** 0.5 día
 **Dependencias:** decisión de producto sobre copy canónico
-**Estado:** ⏳ PENDIENTE
+**Estado:** ✅ COMPLETADA
 **Cubre INC:** INC-005
 
 #### 📋 Descripción
@@ -479,26 +479,28 @@ Existen 6 copys distintos para la misma acción ("Comenzar ahora", "Upgrade a Pr
 
 #### ✅ Tareas específicas
 
-- [ ] Reunión/Slack con PO para fijar copy por contexto.
-- [ ] Crear `lib/constants/cta-copy.ts` exportando `CTA_PREMIUM = { PURCHASE: '...', LIMIT_REACHED: '...', UPSELL_SOFT: '...' }`.
-- [ ] Migrar archivos:
-  - [`UpgradeModal.tsx:170`](../frontend/src/components/features/readings/UpgradeModal.tsx#L170)
-  - [`UpgradeBanner.tsx:53`](../frontend/src/components/features/readings/UpgradeBanner.tsx#L53)
-  - [`PremiumUpgradePrompt.tsx:109,274`](../frontend/src/components/features/conversion/PremiumUpgradePrompt.tsx#L109)
-  - [`PremiumPreview.tsx:80`](../frontend/src/components/features/conversion/PremiumPreview.tsx#L80)
-  - [`DailyCardLimitReached.tsx:236`](../frontend/src/components/features/daily-reading/DailyCardLimitReached.tsx#L236)
-  - [`ReadingLimitReached.tsx:136`](../frontend/src/components/features/readings/ReadingLimitReached.tsx#L136)
-  - [`SacredEventsWidget.tsx:205`](../frontend/src/components/features/dashboard/SacredEventsWidget.tsx#L205)
-  - [`PremiumPage.tsx:131`](../frontend/src/components/features/premium/PremiumPage.tsx#L131)
-  - [`PlanComparison.tsx:74`](../frontend/src/components/features/home/PlanComparison.tsx#L74)
-- [ ] Actualizar tests que asuman copy específico.
+- [x] Reunión/Slack con PO para fijar copy por contexto.
+- [x] Crear `lib/constants/cta-copy.ts` exportando `CTA_PREMIUM = { PURCHASE: 'Comenzar Premium', LIMIT_REACHED: 'Mejorar a Premium', UPSELL_SOFT: 'Upgrade a Premium' }`.
+- [x] Migrar archivos:
+  - [`UpgradeModal.tsx`](../frontend/src/components/features/readings/UpgradeModal.tsx)
+  - [`UpgradeBanner.tsx`](../frontend/src/components/features/readings/UpgradeBanner.tsx)
+  - [`PremiumUpgradePrompt.tsx`](../frontend/src/components/features/conversion/PremiumUpgradePrompt.tsx)
+  - [`PremiumPreview.tsx`](../frontend/src/components/features/conversion/PremiumPreview.tsx)
+  - [`DailyCardLimitReached.tsx`](../frontend/src/components/features/daily-reading/DailyCardLimitReached.tsx)
+  - [`ReadingLimitReached.tsx`](../frontend/src/components/features/readings/ReadingLimitReached.tsx)
+  - [`SacredEventsWidget.tsx`](../frontend/src/components/features/dashboard/SacredEventsWidget.tsx)
+  - [`PremiumPage.tsx`](../frontend/src/components/features/premium/PremiumPage.tsx)
+  - [`PlanComparison.tsx`](../frontend/src/components/features/home/PlanComparison.tsx)
+  - [`LimitReachedModal.tsx`](../frontend/src/components/features/conversion/LimitReachedModal.tsx)
+  - [`PremiumBenefitsSection.tsx`](../frontend/src/components/features/home/PremiumBenefitsSection.tsx)
+- [x] Actualizar tests que asuman copy específico (8 archivos de tests).
 
 #### 🎯 Criterios de aceptación
 
-- [ ] Existe `lib/constants/cta-copy.ts` con copys documentados.
-- [ ] No queda ningún CTA Premium con literal hardcoded en componentes de feature.
-- [ ] El producto valida el copy final.
-- [ ] Ciclo de calidad pasa.
+- [x] Existe `lib/constants/cta-copy.ts` con copys documentados.
+- [x] No queda ningún CTA Premium con literal hardcoded en componentes de feature.
+- [x] El producto valida el copy final.
+- [x] Ciclo de calidad pasa.
 
 #### 📁 Archivos involucrados
 

--- a/frontend/src/components/features/conversion/LimitReachedModal.test.tsx
+++ b/frontend/src/components/features/conversion/LimitReachedModal.test.tsx
@@ -72,7 +72,7 @@ describe('LimitReachedModal', () => {
       />
     );
 
-    const upgradeButton = screen.getByRole('button', { name: /actualizar a premium/i });
+    const upgradeButton = screen.getByRole('button', { name: /mejorar a premium/i });
     await user.click(upgradeButton);
 
     expect(mockOnUpgrade).toHaveBeenCalledOnce();

--- a/frontend/src/components/features/conversion/LimitReachedModal.tsx
+++ b/frontend/src/components/features/conversion/LimitReachedModal.tsx
@@ -10,6 +10,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 
 /**
  * Props for LimitReachedModal component
@@ -102,7 +103,7 @@ export default function LimitReachedModal({
             className="w-full bg-gradient-to-r from-purple-600 to-pink-600 text-white hover:from-purple-700 hover:to-pink-700"
             size="lg"
           >
-            Actualizar a Premium
+            {CTA_PREMIUM.LIMIT_REACHED}
           </Button>
           <Button variant="outline" onClick={onClose} className="w-full" size="lg">
             Volver mañana

--- a/frontend/src/components/features/conversion/PremiumPreview.test.tsx
+++ b/frontend/src/components/features/conversion/PremiumPreview.test.tsx
@@ -104,7 +104,7 @@ describe('PremiumPreview', () => {
       </PremiumPreview>
     );
 
-    expect(screen.getByRole('button', { name: /actualizar a premium/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /comenzar premium/i })).toBeInTheDocument();
   });
 
   it('should have proper relative positioning for overlay', () => {
@@ -126,7 +126,7 @@ describe('PremiumPreview', () => {
       </PremiumPreview>
     );
 
-    const button = screen.getByRole('button', { name: /actualizar a premium/i });
+    const button = screen.getByRole('button', { name: /comenzar premium/i });
     await user.click(button);
 
     expect(mockMutate).toHaveBeenCalledOnce();
@@ -142,7 +142,7 @@ describe('PremiumPreview', () => {
       </PremiumPreview>
     );
 
-    const button = screen.getByRole('button', { name: /actualizar a premium/i });
+    const button = screen.getByRole('button', { name: /comenzar premium/i });
     await user.click(button);
 
     expect(mockRouterPush).toHaveBeenCalledWith(
@@ -173,7 +173,7 @@ describe('PremiumPreview', () => {
           <div>Premium Content</div>
         </PremiumPreview>
       );
-      screen.getByRole('button', { name: /actualizar a premium/i }).click();
+      screen.getByRole('button', { name: /comenzar premium/i }).click();
 
       expect(window.location.href).toBe(initPoint);
     } finally {

--- a/frontend/src/components/features/conversion/PremiumPreview.tsx
+++ b/frontend/src/components/features/conversion/PremiumPreview.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/useAuth';
 import { useCreatePreapproval } from '@/hooks/api/useSubscription';
 import { ROUTES } from '@/lib/constants/routes';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 import type { ReactNode } from 'react';
 
 /**
@@ -77,7 +78,7 @@ export default function PremiumPreview({
             className="bg-gradient-to-r from-purple-600 to-pink-600 text-white hover:from-purple-700 hover:to-pink-700"
             size="lg"
           >
-            {isPending ? 'Cargando...' : 'Actualizar a Premium'}
+            {isPending ? 'Cargando...' : CTA_PREMIUM.PURCHASE}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/features/conversion/PremiumUpgradePrompt.tsx
+++ b/frontend/src/components/features/conversion/PremiumUpgradePrompt.tsx
@@ -15,6 +15,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useCreatePreapproval } from '@/hooks/api/useSubscription';
 import type { CreatePreapprovalResponse } from '@/types';
 import { ROUTES } from '@/lib/constants/routes';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 
 // ============================================================================
 // Constants
@@ -106,7 +107,7 @@ function CtaButton({ isPending, onClick }: CtaButtonProps) {
       ) : (
         <>
           <Sparkles className="mr-2 h-4 w-4" aria-hidden="true" />
-          Obtener Premium
+          {CTA_PREMIUM.PURCHASE}
         </>
       )}
     </Button>
@@ -271,7 +272,7 @@ export default function PremiumUpgradePrompt({
           variant="secondary"
           className="flex-shrink-0 bg-white text-purple-600 hover:bg-white/90"
         >
-          {isPending ? 'Cargando...' : 'Obtener Premium'}
+          {isPending ? 'Cargando...' : CTA_PREMIUM.PURCHASE}
         </Button>
       </div>
     </div>

--- a/frontend/src/components/features/daily-reading/DailyCardLimitReached.test.tsx
+++ b/frontend/src/components/features/daily-reading/DailyCardLimitReached.test.tsx
@@ -76,10 +76,10 @@ describe('DailyCardLimitReached', () => {
       expect(screen.getByRole('button', { name: /Nueva lectura/i })).toBeInTheDocument();
     });
 
-    test('should render "Actualizar a Premium" button', () => {
+    test('should render "Mejorar a Premium" button', () => {
       render(<DailyCardLimitReached />);
 
-      expect(screen.getByRole('button', { name: /Actualizar a Premium/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Mejorar a Premium/i })).toBeInTheDocument();
     });
 
     test('should render Premium benefits list', () => {
@@ -125,11 +125,11 @@ describe('DailyCardLimitReached', () => {
       expect(mockPush).toHaveBeenCalledWith('/tarot');
     });
 
-    test('should navigate to /planes when "Actualizar a Premium" button is clicked', async () => {
+    test('should navigate to /planes when "Mejorar a Premium" button is clicked', async () => {
       const user = userEvent.setup();
       render(<DailyCardLimitReached />);
 
-      const upgradeButton = screen.getByRole('button', { name: /Actualizar a Premium/i });
+      const upgradeButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
       await user.click(upgradeButton);
 
       expect(mockPush).toHaveBeenCalledWith('/planes');

--- a/frontend/src/components/features/daily-reading/DailyCardLimitReached.tsx
+++ b/frontend/src/components/features/daily-reading/DailyCardLimitReached.tsx
@@ -6,6 +6,7 @@ import { Calendar, History, Sparkles, Crown, CalendarHeart, Bell, Wand2 } from '
 import { useUserCapabilities } from '@/hooks/api/useUserCapabilities';
 import { Button } from '@/components/ui/button';
 import { PREMIUM_BENEFITS } from '@/lib/constants';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 import { ROUTES } from '@/lib/constants/routes';
 import {
   Card,
@@ -233,7 +234,7 @@ export function DailyCardLimitReached() {
               size="lg"
             >
               <Crown className="h-4 w-4" />
-              Actualizar a Premium
+              {CTA_PREMIUM.LIMIT_REACHED}
             </Button>
             <div className="flex w-full flex-col gap-2 sm:flex-row">
               <Button

--- a/frontend/src/components/features/dashboard/SacredEventsWidget.test.tsx
+++ b/frontend/src/components/features/dashboard/SacredEventsWidget.test.tsx
@@ -316,7 +316,7 @@ describe('SacredEventsWidget', () => {
       renderComponent();
 
       expect(screen.getByText('Desbloquea el calendario completo')).toBeInTheDocument();
-      expect(screen.getByText('Mejorar a Premium')).toBeInTheDocument();
+      expect(screen.getByText('Upgrade a Premium')).toBeInTheDocument();
     });
 
     it('should hide upsell section for premium users', () => {
@@ -328,7 +328,7 @@ describe('SacredEventsWidget', () => {
       renderComponent();
 
       expect(screen.queryByText('Desbloquea el calendario completo')).not.toBeInTheDocument();
-      expect(screen.queryByText('Mejorar a Premium')).not.toBeInTheDocument();
+      expect(screen.queryByText('Upgrade a Premium')).not.toBeInTheDocument();
     });
   });
 
@@ -418,7 +418,7 @@ describe('SacredEventsWidget', () => {
 
       renderComponent();
 
-      const link = screen.getByText('Mejorar a Premium').closest('a');
+      const link = screen.getByText('Upgrade a Premium').closest('a');
       expect(link).toHaveAttribute('href', '/premium');
     });
   });

--- a/frontend/src/components/features/dashboard/SacredEventsWidget.tsx
+++ b/frontend/src/components/features/dashboard/SacredEventsWidget.tsx
@@ -12,6 +12,7 @@ import { useAuthStore } from '@/stores/authStore';
 import Link from 'next/link';
 import { SacredEventType, ImportanceLevel, IMPORTANCE_INFO, type SacredEvent } from '@/types';
 import { parseDateString } from '@/lib/utils/date';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 import { differenceInCalendarDays } from 'date-fns';
 
 const EVENT_ICONS: Record<SacredEventType, React.ComponentType<{ className?: string }>> = {
@@ -202,7 +203,7 @@ export function SacredEventsWidget() {
             title="Desbloquea el calendario completo"
             description="Accede a todos los eventos sagrados del año y planifica tus rituales con anticipación."
             href="/premium"
-            ctaLabel="Mejorar a Premium"
+            ctaLabel={CTA_PREMIUM.UPSELL_SOFT}
           />
         </div>
       )}

--- a/frontend/src/components/features/home/LandingPage.test.tsx
+++ b/frontend/src/components/features/home/LandingPage.test.tsx
@@ -59,8 +59,9 @@ describe('LandingPage', () => {
     // HowItWorks CTA
     expect(screen.getByRole('link', { name: /comienza tu viaje/i })).toBeInTheDocument();
 
-    // Premium CTA
-    expect(screen.getByRole('link', { name: /actualizar a premium/i })).toBeInTheDocument();
+    // Premium CTA (puede aparecer en múltiples secciones: PremiumBenefitsSection, PlanComparison, etc.)
+    const premiumLinks = screen.getAllByRole('link', { name: /comenzar premium/i });
+    expect(premiumLinks.length).toBeGreaterThanOrEqual(1);
   });
 
   it('should render BirthChartPromo section', () => {

--- a/frontend/src/components/features/home/PlanComparison.tsx
+++ b/frontend/src/components/features/home/PlanComparison.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { ROUTES } from '@/lib/constants/routes';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 import { Check, X, Star } from 'lucide-react';
 
 interface PlanFeature {
@@ -71,7 +72,7 @@ const plans: Plan[] = [
       { text: '3 consultas péndulo / día', included: true },
       { text: 'Compartir lecturas e historial completo', included: true },
     ],
-    cta: { text: 'Comenzar Premium', href: ROUTES.PREMIUM },
+    cta: { text: CTA_PREMIUM.PURCHASE, href: ROUTES.PREMIUM },
     recommended: true,
   },
 ];

--- a/frontend/src/components/features/home/PremiumBenefitsSection.test.tsx
+++ b/frontend/src/components/features/home/PremiumBenefitsSection.test.tsx
@@ -65,7 +65,7 @@ describe('PremiumBenefitsSection', () => {
   it('should render upgrade CTA button', () => {
     render(<PremiumBenefitsSection />);
 
-    const ctaButton = screen.getByRole('link', { name: /actualizar a premium/i });
+    const ctaButton = screen.getByRole('link', { name: /comenzar premium/i });
 
     expect(ctaButton).toBeInTheDocument();
     expect(ctaButton).toHaveAttribute('href', '/registro');

--- a/frontend/src/components/features/home/PremiumBenefitsSection.tsx
+++ b/frontend/src/components/features/home/PremiumBenefitsSection.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { ROUTES } from '@/lib/constants/routes';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 import { Sparkles, Layers, MessageSquare, BarChart3, ShieldOff, Crown } from 'lucide-react';
 
 const benefits = [
@@ -133,7 +134,7 @@ export function PremiumBenefitsSection() {
           >
             <Link href={ROUTES.REGISTER}>
               <Crown className="mr-2 h-4 w-4" />
-              Actualizar a Premium
+              {CTA_PREMIUM.PURCHASE}
             </Link>
           </Button>
         </div>

--- a/frontend/src/components/features/premium/PremiumPage.tsx
+++ b/frontend/src/components/features/premium/PremiumPage.tsx
@@ -12,6 +12,7 @@ import { usePublicPlans } from '@/hooks/api/usePublicPlans';
 import { useCreatePreapproval } from '@/hooks/api/useSubscription';
 import { useAuthStore } from '@/stores/authStore';
 import { ROUTES } from '@/lib/constants/routes';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 import type { PlanConfig } from '@/types/admin.types';
 
 // ============================================================================
@@ -128,7 +129,7 @@ function PremiumCtaButton({ premiumPlan, testId }: PremiumCtaButtonProps) {
       data-testid={testId}
       className="w-full bg-purple-600 text-white hover:bg-purple-700"
     >
-      {isPending ? 'Redirigiendo...' : 'Comenzar Premium'}
+      {isPending ? 'Redirigiendo...' : CTA_PREMIUM.PURCHASE}
       {premiumPlan && !isPending && (
         <span className="ml-2 text-sm opacity-80">${premiumPlan.price.toFixed(2)}/mes</span>
       )}

--- a/frontend/src/components/features/readings/ReadingLimitReached.test.tsx
+++ b/frontend/src/components/features/readings/ReadingLimitReached.test.tsx
@@ -68,7 +68,7 @@ describe('ReadingLimitReached', () => {
   it('should render upgrade premium button', () => {
     render(<ReadingLimitReached />);
 
-    const upgradeButton = screen.getByRole('button', { name: /Actualizar a Premium/i });
+    const upgradeButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
     expect(upgradeButton).toBeInTheDocument();
   });
 
@@ -90,7 +90,7 @@ describe('ReadingLimitReached', () => {
     const user = userEvent.setup();
     render(<ReadingLimitReached />);
 
-    const upgradeButton = screen.getByRole('button', { name: /Actualizar a Premium/i });
+    const upgradeButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
     await user.click(upgradeButton);
 
     expect(mockPush).toHaveBeenCalledWith('/planes');
@@ -126,7 +126,7 @@ describe('ReadingLimitReached', () => {
   it('should have primary button styling on upgrade button', () => {
     render(<ReadingLimitReached />);
 
-    const upgradeButton = screen.getByRole('button', { name: /Actualizar a Premium/i });
+    const upgradeButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
     expect(upgradeButton).toHaveClass('bg-gradient-to-r', 'from-purple-600', 'to-amber-600');
   });
 

--- a/frontend/src/components/features/readings/ReadingLimitReached.tsx
+++ b/frontend/src/components/features/readings/ReadingLimitReached.tsx
@@ -5,6 +5,7 @@ import { Calendar, History, Crown, Sparkles } from 'lucide-react';
 
 import { useUserCapabilities } from '@/hooks/api/useUserCapabilities';
 import { Button } from '@/components/ui/button';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 import {
   Card,
   CardContent,
@@ -133,7 +134,7 @@ export function ReadingLimitReached() {
           size="lg"
         >
           <Crown className="h-4 w-4" />
-          Actualizar a Premium
+          {CTA_PREMIUM.LIMIT_REACHED}
         </Button>
         <div className="flex w-full flex-col gap-2 sm:flex-row">
           <Button

--- a/frontend/src/components/features/readings/UpgradeBanner.tsx
+++ b/frontend/src/components/features/readings/UpgradeBanner.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/useAuth';
 import { useCreatePreapproval } from '@/hooks/api/useSubscription';
 import { ROUTES } from '@/lib/constants/routes';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 
 export default function UpgradeBanner() {
   const router = useRouter();
@@ -50,7 +51,7 @@ export default function UpgradeBanner() {
           variant="secondary"
           className="flex-shrink-0 bg-white text-purple-600 hover:bg-white/90"
         >
-          {isPending ? 'Cargando...' : 'Upgrade a Premium'}
+          {isPending ? 'Cargando...' : CTA_PREMIUM.UPSELL_SOFT}
         </Button>
       </div>
     </div>

--- a/frontend/src/components/features/readings/UpgradeModal.test.tsx
+++ b/frontend/src/components/features/readings/UpgradeModal.test.tsx
@@ -69,10 +69,22 @@ describe('UpgradeModal', () => {
       expect(screen.getByText(/mes/i)).toBeInTheDocument();
     });
 
-    it('should render CTA button', () => {
+    it('should render CTA button with PURCHASE copy when no reason', () => {
       render(<UpgradeModal open={true} onClose={mockOnClose} />);
 
+      expect(screen.getByRole('button', { name: /Comenzar Premium/i })).toBeInTheDocument();
+    });
+
+    it('should render CTA button with LIMIT_REACHED copy when reason is limit-reached', () => {
+      render(<UpgradeModal open={true} onClose={mockOnClose} reason="limit-reached" />);
+
       expect(screen.getByRole('button', { name: /Mejorar a Premium/i })).toBeInTheDocument();
+    });
+
+    it('should render CTA button with PURCHASE copy when reason is feature-locked', () => {
+      render(<UpgradeModal open={true} onClose={mockOnClose} reason="feature-locked" />);
+
+      expect(screen.getByRole('button', { name: /Comenzar Premium/i })).toBeInTheDocument();
     });
 
     it('should render "Más información" link', () => {
@@ -105,17 +117,17 @@ describe('UpgradeModal', () => {
       expect(mockOnClose).toHaveBeenCalled();
     });
 
-    it('should enable "Mejorar a Premium" CTA button for free users', () => {
+    it('should enable CTA button for free users', () => {
       render(<UpgradeModal open={true} onClose={mockOnClose} />);
 
-      const ctaButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
+      const ctaButton = screen.getByRole('button', { name: /Comenzar Premium/i });
       expect(ctaButton).not.toBeDisabled();
     });
 
-    it('should call createPreapproval mutate when clicking "Mejorar a Premium" as free user', () => {
+    it('should call createPreapproval mutate when clicking CTA as free user', () => {
       render(<UpgradeModal open={true} onClose={mockOnClose} />);
 
-      const ctaButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
+      const ctaButton = screen.getByRole('button', { name: /Comenzar Premium/i });
       fireEvent.click(ctaButton);
 
       expect(mockMutate).toHaveBeenCalledTimes(1);
@@ -143,7 +155,7 @@ describe('UpgradeModal', () => {
 
         render(<UpgradeModal open={true} onClose={mockOnClose} />);
 
-        const ctaButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
+        const ctaButton = screen.getByRole('button', { name: /Comenzar Premium/i });
         fireEvent.click(ctaButton);
 
         expect(window.location.href).toBe(initPoint);
@@ -160,7 +172,7 @@ describe('UpgradeModal', () => {
 
       render(<UpgradeModal open={true} onClose={mockOnClose} />);
 
-      const ctaButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
+      const ctaButton = screen.getByRole('button', { name: /Comenzar Premium/i });
       fireEvent.click(ctaButton);
 
       expect(mockRouterPush).toHaveBeenCalledWith(

--- a/frontend/src/components/features/readings/UpgradeModal.test.tsx
+++ b/frontend/src/components/features/readings/UpgradeModal.test.tsx
@@ -72,7 +72,7 @@ describe('UpgradeModal', () => {
     it('should render CTA button', () => {
       render(<UpgradeModal open={true} onClose={mockOnClose} />);
 
-      expect(screen.getByRole('button', { name: /Comenzar ahora/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Mejorar a Premium/i })).toBeInTheDocument();
     });
 
     it('should render "Más información" link', () => {
@@ -105,17 +105,17 @@ describe('UpgradeModal', () => {
       expect(mockOnClose).toHaveBeenCalled();
     });
 
-    it('should enable "Comenzar ahora" CTA button for free users', () => {
+    it('should enable "Mejorar a Premium" CTA button for free users', () => {
       render(<UpgradeModal open={true} onClose={mockOnClose} />);
 
-      const ctaButton = screen.getByRole('button', { name: /Comenzar ahora/i });
+      const ctaButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
       expect(ctaButton).not.toBeDisabled();
     });
 
-    it('should call createPreapproval mutate when clicking "Comenzar ahora" as free user', () => {
+    it('should call createPreapproval mutate when clicking "Mejorar a Premium" as free user', () => {
       render(<UpgradeModal open={true} onClose={mockOnClose} />);
 
-      const ctaButton = screen.getByRole('button', { name: /Comenzar ahora/i });
+      const ctaButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
       fireEvent.click(ctaButton);
 
       expect(mockMutate).toHaveBeenCalledTimes(1);
@@ -143,7 +143,7 @@ describe('UpgradeModal', () => {
 
         render(<UpgradeModal open={true} onClose={mockOnClose} />);
 
-        const ctaButton = screen.getByRole('button', { name: /Comenzar ahora/i });
+        const ctaButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
         fireEvent.click(ctaButton);
 
         expect(window.location.href).toBe(initPoint);
@@ -160,7 +160,7 @@ describe('UpgradeModal', () => {
 
       render(<UpgradeModal open={true} onClose={mockOnClose} />);
 
-      const ctaButton = screen.getByRole('button', { name: /Comenzar ahora/i });
+      const ctaButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
       fireEvent.click(ctaButton);
 
       expect(mockRouterPush).toHaveBeenCalledWith(

--- a/frontend/src/components/features/readings/UpgradeModal.tsx
+++ b/frontend/src/components/features/readings/UpgradeModal.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useCreatePreapproval } from '@/hooks/api/useSubscription';
 import { useRouter } from 'next/navigation';
 import { ROUTES } from '@/lib/constants/routes';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 import type { CreatePreapprovalResponse } from '@/types';
 
 /**
@@ -167,7 +168,7 @@ export default function UpgradeModal({ open, onClose, reason }: UpgradeModalProp
             className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
           >
             <Sparkles className="mr-2 h-5 w-5" aria-hidden="true" />
-            {isPending ? 'Cargando...' : 'Comenzar ahora'}
+            {isPending ? 'Cargando...' : CTA_PREMIUM.LIMIT_REACHED}
           </Button>
 
           <button

--- a/frontend/src/components/features/readings/UpgradeModal.tsx
+++ b/frontend/src/components/features/readings/UpgradeModal.tsx
@@ -168,7 +168,11 @@ export default function UpgradeModal({ open, onClose, reason }: UpgradeModalProp
             className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
           >
             <Sparkles className="mr-2 h-5 w-5" aria-hidden="true" />
-            {isPending ? 'Cargando...' : CTA_PREMIUM.LIMIT_REACHED}
+            {isPending
+              ? 'Cargando...'
+              : reason === 'limit-reached'
+                ? CTA_PREMIUM.LIMIT_REACHED
+                : CTA_PREMIUM.PURCHASE}
           </Button>
 
           <button

--- a/frontend/src/lib/constants/cta-copy.ts
+++ b/frontend/src/lib/constants/cta-copy.ts
@@ -1,5 +1,5 @@
 /**
- * Copys canónicos para CTAs de upgrade a Premium.
+ * Textos canónicos para CTAs de upgrade a Premium.
  *
  * Contextos:
  * - PURCHASE: Compra inicial desde la página de planes / comparativa / prompt de conversión.

--- a/frontend/src/lib/constants/cta-copy.ts
+++ b/frontend/src/lib/constants/cta-copy.ts
@@ -1,0 +1,18 @@
+/**
+ * Copys canónicos para CTAs de upgrade a Premium.
+ *
+ * Contextos:
+ * - PURCHASE: Compra inicial desde la página de planes / comparativa / prompt de conversión.
+ * - LIMIT_REACHED: El usuario alcanzó su límite gratuito (lecturas, cartas diarias, etc.).
+ * - UPSELL_SOFT: Upsell suave en banners persistentes o widgets del dashboard.
+ */
+export const CTA_PREMIUM = {
+  /** Página Premium, PlanComparison, PremiumUpgradePrompt, PremiumPreview */
+  PURCHASE: 'Comenzar Premium',
+  /** UpgradeModal, DailyCardLimitReached, ReadingLimitReached */
+  LIMIT_REACHED: 'Mejorar a Premium',
+  /** UpgradeBanner, SacredEventsWidget */
+  UPSELL_SOFT: 'Upgrade a Premium',
+} as const;
+
+export type CtaPremiumKey = keyof typeof CTA_PREMIUM;

--- a/frontend/src/lib/constants/index.ts
+++ b/frontend/src/lib/constants/index.ts
@@ -5,3 +5,5 @@ export { ROUTES } from './routes';
 export { CONFIG } from './config';
 export { PREMIUM_BENEFITS } from './premium-benefits';
 export type { PremiumBenefit, PremiumBenefits } from './premium-benefits';
+export { CTA_PREMIUM } from './cta-copy';
+export type { CtaPremiumKey } from './cta-copy';


### PR DESCRIPTION
## Descripción

Unifica todos los CTAs de upgrade Premium eliminando literales hardcodeados dispersos en 11+ componentes, reemplazándolos por la constante `CTA_PREMIUM`.

## Cambios

### Nueva constante
- `frontend/src/lib/constants/cta-copy.ts` — fuente de verdad con 3 contextos:
  - `PURCHASE = "Comenzar Premium"` → página premium, comparativa de planes, sección de beneficios
  - `LIMIT_REACHED = "Mejorar a Premium"` → modales/pantallas de límite diario/tiradas
  - `UPSELL_SOFT = "Upgrade a Premium"` → banners persistentes y widgets del dashboard

### Componentes migrados (11)
UpgradeModal, UpgradeBanner, PremiumUpgradePrompt, PremiumPreview, DailyCardLimitReached, ReadingLimitReached, SacredEventsWidget, PremiumPage, PlanComparison, LimitReachedModal, PremiumBenefitsSection

### Tests migrados (8)
UpgradeModal, DailyCardLimitReached, ReadingLimitReached, LimitReachedModal, PremiumPreview, SacredEventsWidget, LandingPage, PremiumBenefitsSection

## Calidad

- ✅ `npm run type-check` — sin errores
- ✅ `npm run lint:fix` — sin errores
- ✅ `npm run test:run` — todos los tests pasan
- ✅ `npm run build` — build exitoso
- ✅ `node scripts/validate-architecture.js` — arquitectura válida