### PR TITLE
feat(ui): Crear <DisclaimerBanner> y migrar páginas legales (T-UI-08)

### DIFF
--- a/docs/BACKLOG_CONSISTENCIA_UI.md
+++ b/docs/BACKLOG_CONSISTENCIA_UI.md
@@ -607,16 +607,16 @@ Las páginas `contacto`, `terminos` y `privacidad` repiten textualmente el mismo
 
 - [x] Decidir: ¿componente nuevo `<DisclaimerBanner>` o uso directo de `<Alert variant="info">`?
 - [x] Migrar:
-  - [`app/contacto/page.tsx:42`](../frontend/src/app/contacto/page.tsx#L42)
-  - [`app/terminos/page.tsx:115`](../frontend/src/app/terminos/page.tsx#L115)
-  - [`app/privacidad/page.tsx:152`](../frontend/src/app/privacidad/page.tsx#L152)
+  - `app/contacto/page.tsx`
+  - `app/terminos/page.tsx`
+  - `app/privacidad/page.tsx`
 - [x] Eliminar `bg-yellow-50` hardcoded.
 
 #### 🎯 Criterios de aceptación
 
 - [x] Las tres páginas legales usan el mismo componente.
 - [x] Visualmente idénticas en light mode (único modo soportado).
-- [x] Aprovechar la migración para eliminar las clases `dark:*` legacy presentes en estos `<div>`.
+- [x] Aprovechar la migración para eliminar las clases `dark:*` legacy presentes en estas páginas (`dark:bg-yellow-950/20`, `dark:bg-purple-950/20`, `dark:prose-invert`).
 - [x] Ciclo de calidad pasa.
 
 #### 📁 Archivos involucrados

--- a/docs/BACKLOG_CONSISTENCIA_UI.md
+++ b/docs/BACKLOG_CONSISTENCIA_UI.md
@@ -299,7 +299,7 @@ Nota: en `SacredEventsWidget`, "Próximamente" se usa como **etiqueta de secció
 | T-UI-05 | Unificar copy de CTAs Premium (constante única) | 🟡 Alta | 0.5 día | T-UI-04 (idealmente) | ✅ COMPLETADA |
 | T-UI-06 | Migrar skeletons inline a `<Skeleton>` | 🟡 Alta | 1 día | — | ✅ COMPLETADA |
 | T-UI-07 | Unificar copy de CTAs de auth | 🟡 Alta | 0.5 día | — | ✅ COMPLETADA |
-| T-UI-08 | Crear `<DisclaimerBanner>` y migrar páginas legales | 🟢 Media | 0.5 día | T-UI-04 | ⏳ PENDIENTE |
+| T-UI-08 | Crear `<DisclaimerBanner>` y migrar páginas legales | 🟢 Media | 0.5 día | T-UI-04 | ✅ COMPLETADA |
 | T-UI-09 | Migrar feedback de `ContactForm` a toast | 🟢 Media | 0.25 día | — | ⏳ PENDIENTE |
 | T-UI-10 | Renombrar/unificar uso de "Próximamente" | 🟢 Baja | 0.25 día | — | ⏳ PENDIENTE |
 
@@ -596,7 +596,7 @@ Hoy conviven 4 variantes para la misma acción ("Crear Cuenta", "Crear Cuenta Gr
 **Prioridad:** 🟢 MEDIA
 **Estimación:** 0.5 día
 **Dependencias:** T-UI-04 (variante `info` en `<Alert>`)
-**Estado:** ⏳ PENDIENTE
+**Estado:** ✅ COMPLETADA
 **Cubre INC:** INC-008
 
 #### 📋 Descripción
@@ -605,19 +605,19 @@ Las páginas `contacto`, `terminos` y `privacidad` repiten textualmente el mismo
 
 #### ✅ Tareas específicas
 
-- [ ] Decidir: ¿componente nuevo `<DisclaimerBanner>` o uso directo de `<Alert variant="info">`?
-- [ ] Migrar:
+- [x] Decidir: ¿componente nuevo `<DisclaimerBanner>` o uso directo de `<Alert variant="info">`?
+- [x] Migrar:
   - [`app/contacto/page.tsx:42`](../frontend/src/app/contacto/page.tsx#L42)
   - [`app/terminos/page.tsx:115`](../frontend/src/app/terminos/page.tsx#L115)
   - [`app/privacidad/page.tsx:152`](../frontend/src/app/privacidad/page.tsx#L152)
-- [ ] Eliminar `bg-yellow-50` hardcoded.
+- [x] Eliminar `bg-yellow-50` hardcoded.
 
 #### 🎯 Criterios de aceptación
 
-- [ ] Las tres páginas legales usan el mismo componente.
-- [ ] Visualmente idénticas en light mode (único modo soportado).
-- [ ] Aprovechar la migración para eliminar las clases `dark:*` legacy presentes en estos `<div>`.
-- [ ] Ciclo de calidad pasa.
+- [x] Las tres páginas legales usan el mismo componente.
+- [x] Visualmente idénticas en light mode (único modo soportado).
+- [x] Aprovechar la migración para eliminar las clases `dark:*` legacy presentes en estos `<div>`.
+- [x] Ciclo de calidad pasa.
 
 #### 📁 Archivos involucrados
 

--- a/frontend/src/app/contacto/page.tsx
+++ b/frontend/src/app/contacto/page.tsx
@@ -1,3 +1,4 @@
+import { DisclaimerBanner } from '@/components/ui/disclaimer-banner';
 import { ContactForm } from '@/components/features/contact/ContactForm';
 
 /**
@@ -39,12 +40,7 @@ export default function ContactoPage() {
         </div>
 
         {/* Disclaimer */}
-        <div className="rounded-lg bg-yellow-50 p-4 dark:bg-yellow-950/20">
-          <p className="text-sm text-yellow-800 dark:text-yellow-200">
-            <strong>Nota:</strong> Este formulario es funcional pero el envío de correos aún no está
-            implementado. Los mensajes se muestran en la consola del navegador.
-          </p>
-        </div>
+        <DisclaimerBanner message="Este formulario es funcional pero el envío de correos aún no está implementado. Los mensajes se muestran en la consola del navegador." />
       </div>
     </div>
   );

--- a/frontend/src/app/contacto/page.tsx
+++ b/frontend/src/app/contacto/page.tsx
@@ -27,7 +27,7 @@ export default function ContactoPage() {
         </div>
 
         {/* Alternative Contact Info */}
-        <div className="rounded-lg bg-purple-50 p-6 dark:bg-purple-950/20">
+        <div className="rounded-lg bg-purple-50 p-6">
           <h2 className="text-text-primary mb-3 font-semibold">Otras formas de contacto</h2>
           <div className="text-text-secondary space-y-2 text-sm">
             <p>

--- a/frontend/src/app/privacidad/page.tsx
+++ b/frontend/src/app/privacidad/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { DisclaimerBanner } from '@/components/ui/disclaimer-banner';
+
 /**
  * Página de Política de Privacidad
  *
@@ -149,12 +151,8 @@ export default function PrivacidadPage() {
               </p>
             </section>
 
-            <div className="mt-8 rounded-lg bg-yellow-50 p-4 dark:bg-yellow-950/20">
-              <p className="text-sm text-yellow-800 dark:text-yellow-200">
-                <strong>Nota:</strong> Este es un contenido placeholder. El contenido legal real
-                debe ser revisado y aprobado por profesionales legales antes de su uso en
-                producción.
-              </p>
+            <div className="mt-8">
+              <DisclaimerBanner message="Este es un contenido placeholder. El contenido legal real debe ser revisado y aprobado por profesionales legales antes de su uso en producción." />
             </div>
           </div>
         </div>

--- a/frontend/src/app/privacidad/page.tsx
+++ b/frontend/src/app/privacidad/page.tsx
@@ -24,7 +24,7 @@ export default function PrivacidadPage() {
 
         {/* Content */}
         <div className="rounded-lg border p-6">
-          <div className="prose prose-purple dark:prose-invert max-w-none space-y-6">
+          <div className="prose prose-purple max-w-none space-y-6">
             <section>
               <h2 className="font-serif text-2xl font-semibold">1. Introducción</h2>
               <p className="text-text-secondary">

--- a/frontend/src/app/terminos/page.tsx
+++ b/frontend/src/app/terminos/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { DisclaimerBanner } from '@/components/ui/disclaimer-banner';
+
 /**
  * Página de Términos y Condiciones
  *
@@ -112,12 +114,8 @@ export default function TerminosPage() {
               </p>
             </section>
 
-            <div className="mt-8 rounded-lg bg-yellow-50 p-4 dark:bg-yellow-950/20">
-              <p className="text-sm text-yellow-800 dark:text-yellow-200">
-                <strong>Nota:</strong> Este es un contenido placeholder. El contenido legal real
-                debe ser revisado y aprobado por profesionales legales antes de su uso en
-                producción.
-              </p>
+            <div className="mt-8">
+              <DisclaimerBanner message="Este es un contenido placeholder. El contenido legal real debe ser revisado y aprobado por profesionales legales antes de su uso en producción." />
             </div>
           </div>
         </div>

--- a/frontend/src/app/terminos/page.tsx
+++ b/frontend/src/app/terminos/page.tsx
@@ -24,7 +24,7 @@ export default function TerminosPage() {
 
         {/* Content */}
         <div className="rounded-lg border p-6">
-          <div className="prose prose-purple dark:prose-invert max-w-none space-y-6">
+          <div className="prose prose-purple max-w-none space-y-6">
             <section>
               <h2 className="font-serif text-2xl font-semibold">1. Aceptación de Términos</h2>
               <p className="text-text-secondary">

--- a/frontend/src/components/ui/disclaimer-banner.test.tsx
+++ b/frontend/src/components/ui/disclaimer-banner.test.tsx
@@ -15,9 +15,14 @@ describe('DisclaimerBanner', () => {
     expect(strong.tagName).toBe('STRONG');
   });
 
-  it('should use Alert with info variant (role="alert")', () => {
+  it('should render as an alert (role="alert")', () => {
     render(<DisclaimerBanner message="Mensaje de prueba." />);
     expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('should apply info variant styles (text-blue-800 class)', () => {
+    render(<DisclaimerBanner message="Mensaje de prueba." />);
+    expect(screen.getByRole('alert')).toHaveClass('text-blue-800');
   });
 
   it('should render an Info icon', () => {

--- a/frontend/src/components/ui/disclaimer-banner.test.tsx
+++ b/frontend/src/components/ui/disclaimer-banner.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { DisclaimerBanner } from './disclaimer-banner';
+
+describe('DisclaimerBanner', () => {
+  it('should render the message', () => {
+    render(<DisclaimerBanner message="Este es un contenido placeholder." />);
+    expect(screen.getByText(/Este es un contenido placeholder\./)).toBeInTheDocument();
+  });
+
+  it('should render with "Nota:" prefix bold', () => {
+    render(<DisclaimerBanner message="Mensaje de prueba." />);
+    const strong = screen.getByText('Nota:');
+    expect(strong.tagName).toBe('STRONG');
+  });
+
+  it('should use Alert with info variant (role="alert")', () => {
+    render(<DisclaimerBanner message="Mensaje de prueba." />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('should render an Info icon', () => {
+    render(<DisclaimerBanner message="Mensaje de prueba." />);
+    // El svg del icono Info debe estar presente en el DOM
+    const alert = screen.getByRole('alert');
+    expect(alert.querySelector('svg')).not.toBeNull();
+  });
+
+  it('should accept a custom className', () => {
+    render(<DisclaimerBanner message="Mensaje." className="mt-8" />);
+    expect(screen.getByRole('alert')).toHaveClass('mt-8');
+  });
+
+  it('should have data-testid="disclaimer-banner"', () => {
+    render(<DisclaimerBanner message="Mensaje." />);
+    expect(screen.getByTestId('disclaimer-banner')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/disclaimer-banner.tsx
+++ b/frontend/src/components/ui/disclaimer-banner.tsx
@@ -1,0 +1,21 @@
+import { Info } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+import { Alert, AlertDescription } from './alert';
+
+interface DisclaimerBannerProps {
+  message: string;
+  className?: string;
+}
+
+export function DisclaimerBanner({ message, className }: DisclaimerBannerProps) {
+  return (
+    <Alert variant="info" className={cn(className)} data-testid="disclaimer-banner">
+      <Info />
+      <AlertDescription>
+        <strong>Nota:</strong> {message}
+      </AlertDescription>
+    </Alert>
+  );
+}


### PR DESCRIPTION
## Resumen

Implementa T-UI-08 del backlog de consistencia UI.

- Crea componente reutilizable `<DisclaimerBanner>` en `components/ui/disclaimer-banner.tsx` (wrappea `<Alert variant="info">` con icono `Info` y prefijo "Nota:" en negrita)
- Migra las 3 páginas legales (`/contacto`, `/terminos`, `/privacidad`) que tenían el disclaimer duplicado con `<div bg-yellow-50 dark:bg-yellow-950/20>` hardcoded
- Elimina clases `dark:*` legacy (Auguria solo soporta light mode)
- 6 tests unitarios TDD para el nuevo componente (todos pasan)

## Archivos modificados

- `frontend/src/components/ui/disclaimer-banner.tsx` — nuevo componente
- `frontend/src/components/ui/disclaimer-banner.test.tsx` — tests TDD
- `frontend/src/app/contacto/page.tsx` — migrado a `<DisclaimerBanner>`
- `frontend/src/app/terminos/page.tsx` — migrado a `<DisclaimerBanner>`
- `frontend/src/app/privacidad/page.tsx` — migrado a `<DisclaimerBanner>`
- `docs/BACKLOG_CONSISTENCIA_UI.md` — T-UI-08 marcada como ✅ COMPLETADA

## Checklist

- [x] Tests TDD escritos antes de implementación
- [x] 6/6 tests pasan
- [x] `npm run format` ✅
- [x] `npm run lint:fix` ✅ (0 errores)
- [x] `npm run type-check` ✅
- [x] `npm run build` ✅
- [x] `node scripts/validate-architecture.js` ✅
- [x] Sin `any` ni `eslint-disable`
- [x] Texto user-facing en español
- [x] Backlog actualizado