### PR TITLE
refactor(ui): unificar uso de 'Próximamente' (T-UI-10)

### DIFF
--- a/docs/BACKLOG_CONSISTENCIA_UI.md
+++ b/docs/BACKLOG_CONSISTENCIA_UI.md
@@ -301,7 +301,7 @@ Nota: en `SacredEventsWidget`, "Próximamente" se usa como **etiqueta de secció
 | T-UI-07 | Unificar copy de CTAs de auth | 🟡 Alta | 0.5 día | — | ✅ COMPLETADA |
 | T-UI-08 | Crear `<DisclaimerBanner>` y migrar páginas legales | 🟢 Media | 0.5 día | T-UI-04 | ✅ COMPLETADA |
 | T-UI-09 | Migrar feedback de `ContactForm` a toast | 🟢 Media | 0.25 día | — | ✅ COMPLETADA |
-| T-UI-10 | Renombrar/unificar uso de "Próximamente" | 🟢 Baja | 0.25 día | — | ⏳ PENDIENTE |
+| T-UI-10 | Renombrar/unificar uso de "Próximamente" | 🟢 Baja | 0.25 día | — | ✅ COMPLETADA |
 
 **Estimación total:** ~8.5 días.
 
@@ -661,7 +661,7 @@ Las páginas `contacto`, `terminos` y `privacidad` repiten textualmente el mismo
 **Prioridad:** 🟢 BAJA
 **Estimación:** 0.25 día
 **Dependencias:** ninguna
-**Estado:** ⏳ PENDIENTE
+**Estado:** ✅ COMPLETADA
 **Cubre INC:** INC-010
 
 #### 📋 Descripción
@@ -674,17 +674,17 @@ Esto es ambiguo: el usuario puede leer "Próximamente" en el dashboard y pensar 
 
 #### ✅ Tareas específicas
 
-- [ ] Renombrar [`SacredEventsWidget.tsx:174`](../frontend/src/components/features/dashboard/SacredEventsWidget.tsx#L174) de `Próximamente` → `Próximos eventos` (o `Próximos`).
-- [ ] Crear pequeño `<ComingSoonBadge>` o usar `<Badge variant="secondary">Próximamente</Badge>` para los placeholders de features no implementadas:
+- [x] Renombrar [`SacredEventsWidget.tsx:174`](../frontend/src/components/features/dashboard/SacredEventsWidget.tsx#L174) de `Próximamente` → `Próximos eventos` (o `Próximos`).
+- [x] Crear pequeño `<ComingSoonBadge>` o usar `<Badge variant="secondary">Próximamente</Badge>` para los placeholders de features no implementadas:
   - [`profile/SettingsTab.tsx:59,71`](../frontend/src/components/features/profile/SettingsTab.tsx#L59)
   - [`marketplace/TarotistaProfilePage.tsx:346`](../frontend/src/components/features/marketplace/TarotistaProfilePage.tsx#L346)
   - [`admin/PlatformMetricsContent.tsx:123`](../frontend/src/components/features/admin/PlatformMetricsContent.tsx#L123)
 
 #### 🎯 Criterios de aceptación
 
-- [ ] "Próximamente" solo se usa para indicar feature en desarrollo (visualmente como Badge).
-- [ ] Las secciones de eventos usan otro copy ("Próximos eventos" / "Próximos").
-- [ ] Ciclo de calidad pasa.
+- [x] "Próximamente" solo se usa para indicar feature en desarrollo (visualmente como Badge).
+- [x] Las secciones de eventos usan otro copy ("Próximos eventos" / "Próximos").
+- [x] Ciclo de calidad pasa.
 
 #### 📁 Archivos involucrados
 

--- a/docs/BACKLOG_CONSISTENCIA_UI.md
+++ b/docs/BACKLOG_CONSISTENCIA_UI.md
@@ -674,7 +674,7 @@ Esto es ambiguo: el usuario puede leer "Próximamente" en el dashboard y pensar 
 
 #### ✅ Tareas específicas
 
-- [x] Renombrar [`SacredEventsWidget.tsx:174`](../frontend/src/components/features/dashboard/SacredEventsWidget.tsx#L174) de `Próximamente` → `Próximos eventos` (o `Próximos`).
+- [x] Renombrar [`SacredEventsWidget.tsx`](../frontend/src/components/features/dashboard/SacredEventsWidget.tsx) de `Próximamente` → `Próximos eventos` (o `Próximos`).
 - [x] Crear pequeño `<ComingSoonBadge>` o usar `<Badge variant="secondary">Próximamente</Badge>` para los placeholders de features no implementadas:
   - [`profile/SettingsTab.tsx:59,71`](../frontend/src/components/features/profile/SettingsTab.tsx#L59)
   - [`marketplace/TarotistaProfilePage.tsx:346`](../frontend/src/components/features/marketplace/TarotistaProfilePage.tsx#L346)

--- a/frontend/src/components/features/admin/PlatformMetricsContent.tsx
+++ b/frontend/src/components/features/admin/PlatformMetricsContent.tsx
@@ -12,6 +12,7 @@ import { MetricsPeriod } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
 import {
   Select,
   SelectContent,
@@ -123,7 +124,9 @@ export function PlatformMetricsContent() {
               </CardHeader>
               <CardContent>
                 <div className="text-2xl font-bold">0</div>
-                <p className="text-xs text-gray-500">Próximamente</p>
+                <p className="text-xs text-gray-500">
+                  <Badge variant="secondary">Próximamente</Badge>
+                </p>
               </CardContent>
             </Card>
 

--- a/frontend/src/components/features/dashboard/SacredEventsWidget.tsx
+++ b/frontend/src/components/features/dashboard/SacredEventsWidget.tsx
@@ -184,7 +184,7 @@ export function SacredEventsWidget() {
           {hasUpcomingEvents && (
             <div>
               {hasTodayEvents && (
-                <h4 className="mt-4 mb-3 text-sm font-medium text-gray-700">Próximamente</h4>
+                <h4 className="mt-4 mb-3 text-sm font-medium text-gray-700">Próximos eventos</h4>
               )}
               <div className="space-y-2">
                 {upcomingEvents.map((event) => (

--- a/frontend/src/components/features/marketplace/TarotistaProfilePage.tsx
+++ b/frontend/src/components/features/marketplace/TarotistaProfilePage.tsx
@@ -343,7 +343,9 @@ export function TarotistaProfilePage({ id }: TarotistaProfilePageProps) {
             {/* TODO: Implementar lista de reviews cuando el backend esté listo */}
             <div className="py-8 text-center text-gray-500">
               <MessageSquare className="mx-auto mb-4 h-12 w-12 text-gray-300" />
-              <p>Las reseñas estarán disponibles próximamente.</p>
+              <p>
+                Las reseñas están <Badge variant="secondary">Próximamente</Badge>
+              </p>
             </div>
           </CardContent>
         </Card>

--- a/frontend/src/components/features/marketplace/TarotistaProfilePage.tsx
+++ b/frontend/src/components/features/marketplace/TarotistaProfilePage.tsx
@@ -344,7 +344,7 @@ export function TarotistaProfilePage({ id }: TarotistaProfilePageProps) {
             <div className="py-8 text-center text-gray-500">
               <MessageSquare className="mx-auto mb-4 h-12 w-12 text-gray-300" />
               <p>
-                Las reseñas están <Badge variant="secondary">Próximamente</Badge>
+                Las reseñas estarán disponibles <Badge variant="secondary">Próximamente</Badge>
               </p>
             </div>
           </CardContent>

--- a/frontend/src/components/features/profile/SettingsTab.test.tsx
+++ b/frontend/src/components/features/profile/SettingsTab.test.tsx
@@ -57,19 +57,16 @@ describe('SettingsTab', () => {
       render(<SettingsTab />, { wrapper: createWrapper() });
 
       expect(screen.getByText('Notificaciones')).toBeInTheDocument();
-      expect(
-        screen.getByText(/configuración de notificaciones/i)
-      ).toBeInTheDocument();
-      expect(screen.getAllByText('Próximamente').length).toBeGreaterThan(0);
+      expect(screen.getByText(/configuración de notificaciones/i)).toBeInTheDocument();
+      expect(screen.getAllByText('Próximamente')).toHaveLength(2);
     });
 
     it('should render privacy section', () => {
       render(<SettingsTab />, { wrapper: createWrapper() });
 
       expect(screen.getByText('Privacidad')).toBeInTheDocument();
-      expect(
-        screen.getByText(/opciones de privacidad/i)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/opciones de privacidad/i)).toBeInTheDocument();
+      expect(screen.getAllByText('Próximamente')).toHaveLength(2);
     });
 
     it('should render danger zone section', () => {

--- a/frontend/src/components/features/profile/SettingsTab.test.tsx
+++ b/frontend/src/components/features/profile/SettingsTab.test.tsx
@@ -58,8 +58,9 @@ describe('SettingsTab', () => {
 
       expect(screen.getByText('Notificaciones')).toBeInTheDocument();
       expect(
-        screen.getByText(/configuración de notificaciones disponible próximamente/i)
+        screen.getByText(/configuración de notificaciones/i)
       ).toBeInTheDocument();
+      expect(screen.getAllByText('Próximamente').length).toBeGreaterThan(0);
     });
 
     it('should render privacy section', () => {
@@ -67,7 +68,7 @@ describe('SettingsTab', () => {
 
       expect(screen.getByText('Privacidad')).toBeInTheDocument();
       expect(
-        screen.getByText(/opciones de privacidad disponibles próximamente/i)
+        screen.getByText(/opciones de privacidad/i)
       ).toBeInTheDocument();
     });
 

--- a/frontend/src/components/features/profile/SettingsTab.tsx
+++ b/frontend/src/components/features/profile/SettingsTab.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2 } from 'lucide-react';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -56,7 +57,7 @@ export function SettingsTab() {
         </CardHeader>
         <CardContent>
           <p className="text-muted-foreground text-sm">
-            Configuración de notificaciones disponible próximamente
+            Configuración de notificaciones <Badge variant="secondary">Próximamente</Badge>
           </p>
         </CardContent>
       </Card>
@@ -68,7 +69,7 @@ export function SettingsTab() {
         </CardHeader>
         <CardContent>
           <p className="text-muted-foreground text-sm">
-            Opciones de privacidad disponibles próximamente
+            Opciones de privacidad <Badge variant="secondary">Próximamente</Badge>
           </p>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Descripción

Resuelve la inconsistencia semántica de la palabra "Próximamente" que se usaba con dos significados distintos en el frontend (INC-010).

## Cambios

- **`SacredEventsWidget.tsx`**: Renombrado heading `Próximamente` → `Próximos eventos` para la sección de eventos cronológicos (no era "feature no disponible").
- **`SettingsTab.tsx`**: Textos de notificaciones y privacidad ahora usan `<Badge variant="secondary">Próximamente</Badge>` para indicar features en desarrollo.
- **`PlatformMetricsContent.tsx`**: `<p>Próximamente</p>` reemplazado por `<Badge variant="secondary">Próximamente</Badge>`.
- **`TarotistaProfilePage.tsx`**: Texto de reseñas pendientes ahora usa `<Badge variant="secondary">Próximamente</Badge>`.
- **`SettingsTab.test.tsx`**: Tests actualizados al nuevo copy y estructura.

## Criterios de aceptación

- [x] "Próximamente" solo aparece como Badge para features en desarrollo
- [x] Sección de eventos del dashboard usa "Próximos eventos"
- [x] Tests pasan (50/50)
- [x] Ciclo de calidad completo: format ✅ lint ✅ type-check ✅ build ✅ validate-architecture ✅

## Tarea

T-UI-10 del BACKLOG_CONSISTENCIA_UI.md — ahora marcada como ✅ COMPLETADA