### PR TITLE
fix(T-UI-12): audit fixes — login copy, /admin/seguridad crash, pricing .000 ARS

### DIFF
--- a/backend/tarot-app/src/database/migrations/1776100000000-UpdatePremiumPlanPriceToArs.ts
+++ b/backend/tarot-app/src/database/migrations/1776100000000-UpdatePremiumPlanPriceToArs.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdatePremiumPlanPriceToArs1776100000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "plans" SET "price" = 7000 WHERE "planType" = 'premium' AND "price" = 9.99`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "plans" SET "price" = 9.99 WHERE "planType" = 'premium' AND "price" = 7000`,
+    );
+  }
+}

--- a/backend/tarot-app/src/database/seeds/plans.seeder.spec.ts
+++ b/backend/tarot-app/src/database/seeds/plans.seeder.spec.ts
@@ -44,7 +44,7 @@ describe('Plans Seeder', () => {
         id: 3,
         planType: UserPlan.PREMIUM,
         name: 'Plan Premium',
-        price: 9.99,
+        price: 7000,
         readingsLimit: 3,
         aiQuotaMonthly: 100,
       },
@@ -98,7 +98,7 @@ describe('Plans Seeder', () => {
       expect.objectContaining({
         planType: UserPlan.PREMIUM,
         name: 'Plan Premium',
-        price: 9.99,
+        price: 7000,
         readingsLimit: 4,
         aiQuotaMonthly: 100,
         allowCustomQuestions: true,

--- a/backend/tarot-app/src/database/seeds/plans.seeder.ts
+++ b/backend/tarot-app/src/database/seeds/plans.seeder.ts
@@ -65,7 +65,7 @@ export async function seedPlans(
       name: 'Plan Premium',
       description:
         'Plan completo con 1 carta del día + 3 tiradas diarias, interpretaciones con IA y preguntas personalizadas',
-      price: 9.99,
+      price: 7000,
       readingsLimit: 4, // DEPRECATED: Use dailyCardLimit + tarotReadingsLimit (1 + 3)
       dailyCardLimit: 1, // 1 daily card per day (same as FREE, but with AI interpretation)
       tarotReadingsLimit: 3,

--- a/frontend/src/app/admin/seguridad/page.test.tsx
+++ b/frontend/src/app/admin/seguridad/page.test.tsx
@@ -29,7 +29,7 @@ describe('AdminSeguridadPage', () => {
     vi.mocked(useAdminSecurity.useRateLimitData).mockReturnValue({
       data: {
         violations: [],
-        blockedIPs: [],
+        blockedIps: [],
         stats: {
           totalViolations: 0,
           totalBlockedIps: 0,

--- a/frontend/src/components/features/admin/RateLimitingTab.test.tsx
+++ b/frontend/src/components/features/admin/RateLimitingTab.test.tsx
@@ -36,7 +36,7 @@ describe('RateLimitingTab', () => {
             lastViolation: '2024-01-01T11:00:00Z',
           },
         ],
-        blockedIPs: [
+        blockedIps: [
           {
             ipAddress: '10.0.0.1',
             reason: 'Excessive violations',

--- a/frontend/src/components/features/admin/RateLimitingTab.test.tsx
+++ b/frontend/src/components/features/admin/RateLimitingTab.test.tsx
@@ -30,7 +30,7 @@ describe('RateLimitingTab', () => {
       data: {
         violations: [
           {
-            ipAddress: '192.168.1.1',
+            ip: '192.168.1.1',
             count: 10,
             firstViolation: '2024-01-01T10:00:00Z',
             lastViolation: '2024-01-01T11:00:00Z',
@@ -38,7 +38,7 @@ describe('RateLimitingTab', () => {
         ],
         blockedIps: [
           {
-            ipAddress: '10.0.0.1',
+            ip: '10.0.0.1',
             reason: 'Excessive violations',
             blockedAt: '2024-01-01T12:00:00Z',
             expiresAt: '2024-01-08T12:00:00Z',

--- a/frontend/src/components/features/admin/RateLimitingTab.tsx
+++ b/frontend/src/components/features/admin/RateLimitingTab.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/ui/empty-state';
+import { ErrorDisplay } from '@/components/ui/error-display';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -36,7 +37,7 @@ import { toast } from 'sonner';
 import { useState } from 'react';
 
 export function RateLimitingTab() {
-  const { data, isLoading } = useRateLimitData();
+  const { data, isLoading, isError, refetch } = useRateLimitData();
   const [unblockIPAddress, setUnblockIPAddress] = useState<string | null>(null);
 
   const handleUnblockClick = (ip: string) => {
@@ -64,9 +65,20 @@ export function RateLimitingTab() {
     );
   }
 
-  const totalViolations = data?.violations.reduce((sum, v) => sum + v.count, 0) || 0;
-  const activeViolatingIps = data?.violations.length || 0;
-  const blockedIpsCount = data?.blockedIPs.length || 0;
+  if (isError) {
+    return (
+      <ErrorDisplay
+        message="Error al cargar datos de rate limiting"
+        onRetry={() => void refetch()}
+      />
+    );
+  }
+
+  const violations = data?.violations ?? [];
+  const blockedIPs = data?.blockedIps ?? [];
+  const totalViolations = violations.reduce((sum, v) => sum + v.count, 0);
+  const activeViolatingIps = violations.length;
+  const blockedIpsCount = blockedIPs.length;
 
   return (
     <div className="space-y-6">
@@ -106,7 +118,7 @@ export function RateLimitingTab() {
           <CardTitle>IPs con Violaciones</CardTitle>
         </CardHeader>
         <CardContent>
-          {!data?.violations || data.violations.length === 0 ? (
+          {violations.length === 0 ? (
             <EmptyState
               icon={<ShieldOff />}
               title="Sin violaciones"
@@ -123,7 +135,7 @@ export function RateLimitingTab() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {data.violations.map((violation) => (
+                {violations.map((violation) => (
                   <TableRow key={violation.ipAddress}>
                     <TableCell className="font-mono">{violation.ipAddress}</TableCell>
                     <TableCell>{violation.count}</TableCell>
@@ -143,7 +155,7 @@ export function RateLimitingTab() {
           <CardTitle>IPs Bloqueadas</CardTitle>
         </CardHeader>
         <CardContent>
-          {!data?.blockedIPs || data.blockedIPs.length === 0 ? (
+          {blockedIPs.length === 0 ? (
             <EmptyState
               icon={<Globe />}
               title="Sin IPs bloqueadas"
@@ -161,7 +173,7 @@ export function RateLimitingTab() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {data.blockedIPs.map((blocked) => (
+                {blockedIPs.map((blocked) => (
                   <TableRow key={blocked.ipAddress}>
                     <TableCell className="font-mono">{blocked.ipAddress}</TableCell>
                     <TableCell>

--- a/frontend/src/components/features/admin/RateLimitingTab.tsx
+++ b/frontend/src/components/features/admin/RateLimitingTab.tsx
@@ -136,8 +136,8 @@ export function RateLimitingTab() {
               </TableHeader>
               <TableBody>
                 {violations.map((violation) => (
-                  <TableRow key={violation.ipAddress}>
-                    <TableCell className="font-mono">{violation.ipAddress}</TableCell>
+                  <TableRow key={violation.ip}>
+                    <TableCell className="font-mono">{violation.ip}</TableCell>
                     <TableCell>{violation.count}</TableCell>
                     <TableCell>{new Date(violation.firstViolation).toLocaleString()}</TableCell>
                     <TableCell>{new Date(violation.lastViolation).toLocaleString()}</TableCell>
@@ -174,8 +174,8 @@ export function RateLimitingTab() {
               </TableHeader>
               <TableBody>
                 {blockedIPs.map((blocked) => (
-                  <TableRow key={blocked.ipAddress}>
-                    <TableCell className="font-mono">{blocked.ipAddress}</TableCell>
+                  <TableRow key={blocked.ip}>
+                    <TableCell className="font-mono">{blocked.ip}</TableCell>
                     <TableCell>
                       <div className="flex items-center gap-2">
                         <AlertCircle className="h-4 w-4 text-red-500" />
@@ -192,7 +192,7 @@ export function RateLimitingTab() {
                       <Button
                         size="sm"
                         variant="outline"
-                        onClick={() => handleUnblockClick(blocked.ipAddress)}
+                        onClick={() => handleUnblockClick(blocked.ip)}
                       >
                         Desbloquear
                       </Button>

--- a/frontend/src/components/features/admin/SecurityEventsTab.tsx
+++ b/frontend/src/components/features/admin/SecurityEventsTab.tsx
@@ -23,6 +23,9 @@ import {
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
+import { EmptyState } from '@/components/ui/empty-state';
+import { ErrorDisplay } from '@/components/ui/error-display';
+import { Search } from 'lucide-react';
 import {
   Table,
   TableBody,
@@ -51,7 +54,7 @@ export function SecurityEventsTab() {
     limit: 10,
   });
 
-  const { data, isLoading } = useSecurityEvents(filters);
+  const { data, isLoading, isError, refetch } = useSecurityEvents(filters);
 
   const handleFilterChange = (key: keyof SecurityEventFilters, value: string | number) => {
     setFilters((prev) => ({
@@ -77,6 +80,18 @@ export function SecurityEventsTab() {
       </div>
     );
   }
+
+  if (isError) {
+    return (
+      <ErrorDisplay
+        message="Error al cargar eventos de seguridad"
+        onRetry={() => void refetch()}
+      />
+    );
+  }
+
+  const events = data?.events ?? [];
+  const meta = data?.meta;
 
   return (
     <div className="space-y-6">
@@ -184,10 +199,12 @@ export function SecurityEventsTab() {
           <CardTitle>Eventos de Seguridad</CardTitle>
         </CardHeader>
         <CardContent>
-          {!data || data.events.length === 0 ? (
-            <p className="text-muted-foreground py-8 text-center">
-              No se encontraron eventos de seguridad
-            </p>
+          {events.length === 0 ? (
+            <EmptyState
+              icon={<Search />}
+              title="Sin eventos"
+              message="No se encontraron eventos de seguridad"
+            />
           ) : (
             <>
               <Table>
@@ -202,7 +219,7 @@ export function SecurityEventsTab() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {data.events.map((event) => (
+                  {events.map((event) => (
                     <TableRow key={event.id}>
                       <TableCell className="whitespace-nowrap">
                         {parseTimestamp(event.createdAt).toLocaleString()}
@@ -222,13 +239,13 @@ export function SecurityEventsTab() {
               </Table>
 
               {/* Paginación */}
-              {data.meta.totalPages > 1 && (
+              {meta && meta.totalPages > 1 && (
                 <div className="mt-6">
                   <Pagination
-                    currentPage={data.meta.currentPage}
-                    totalPages={data.meta.totalPages}
-                    totalItems={data.meta.totalItems}
-                    limit={data.meta.itemsPerPage}
+                    currentPage={meta.currentPage}
+                    totalPages={meta.totalPages}
+                    totalItems={meta.totalItems}
+                    limit={meta.itemsPerPage}
                     onPageChange={handlePageChange}
                   />
                 </div>

--- a/frontend/src/components/features/admin/SecurityManagementContent.test.tsx
+++ b/frontend/src/components/features/admin/SecurityManagementContent.test.tsx
@@ -29,7 +29,7 @@ describe('SecurityManagementContent', () => {
     vi.mocked(useAdminSecurity.useRateLimitData).mockReturnValue({
       data: {
         violations: [],
-        blockedIPs: [],
+        blockedIps: [],
         stats: {
           totalViolations: 0,
           totalBlockedIps: 0,

--- a/frontend/src/components/features/auth/LoginForm.test.tsx
+++ b/frontend/src/components/features/auth/LoginForm.test.tsx
@@ -86,9 +86,9 @@ describe('LoginForm', () => {
     it('should render register link', () => {
       render(<LoginForm />);
 
-      const registerLink = screen.getByText(/crear cuenta nueva/i);
+      const registerLink = screen.getByRole('link', { name: /crear cuenta/i });
       expect(registerLink).toBeInTheDocument();
-      expect(registerLink.closest('a')).toHaveAttribute('href', '/registro');
+      expect(registerLink).toHaveAttribute('href', '/registro');
     });
   });
 

--- a/frontend/src/components/features/auth/LoginForm.tsx
+++ b/frontend/src/components/features/auth/LoginForm.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
 import { useAuth } from '@/hooks/useAuth';
+import { CTA_AUTH } from '@/lib/constants/cta-copy';
 import { loginSchema, type LoginFormData } from '@/lib/validations/auth.schemas';
 
 /**
@@ -146,7 +147,7 @@ export function LoginForm() {
                 Iniciando...
               </>
             ) : (
-              'Iniciar Sesión'
+              CTA_AUTH.LOGIN
             )}
           </Button>
         </form>
@@ -160,7 +161,7 @@ export function LoginForm() {
           ¿Olvidaste tu contraseña?
         </Link>
         <Link href="/registro" className="text-primary text-sm hover:underline">
-          Crear cuenta nueva
+          {CTA_AUTH.REGISTER}
         </Link>
       </CardFooter>
     </Card>

--- a/frontend/src/components/features/premium/PremiumPage.test.tsx
+++ b/frontend/src/components/features/premium/PremiumPage.test.tsx
@@ -38,7 +38,7 @@ const mockPremiumPlan: PlanConfig = {
   planType: 'premium',
   name: 'Plan Premium',
   description: 'Acceso completo a todas las funciones',
-  price: 9.99,
+  price: 7000,
   readingsLimit: -1,
   aiQuotaMonthly: -1,
   allowCustomQuestions: true,
@@ -139,7 +139,7 @@ describe('PremiumPage', () => {
       renderWithProviders(<PremiumPage />);
 
       // Price appears in multiple places (hero text, plan card, button); getAllByText is correct here
-      const priceElements = screen.getAllByText(/9\.99/);
+      const priceElements = screen.getAllByText(/7\.000/);
       expect(priceElements.length).toBeGreaterThan(0);
     });
 

--- a/frontend/src/components/features/premium/PremiumPage.tsx
+++ b/frontend/src/components/features/premium/PremiumPage.tsx
@@ -13,21 +13,12 @@ import { useCreatePreapproval } from '@/hooks/api/useSubscription';
 import { useAuthStore } from '@/stores/authStore';
 import { ROUTES } from '@/lib/constants/routes';
 import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
+import { formatPriceArs } from '@/lib/utils/format';
 import type { PlanConfig } from '@/types/admin.types';
 
 // ============================================================================
 // Constants
 // ============================================================================
-
-const arsPriceFormatter = new Intl.NumberFormat('es-AR', {
-  style: 'currency',
-  currency: 'ARS',
-  maximumFractionDigits: 0,
-});
-
-function formatPriceArs(price: number): string {
-  return arsPriceFormatter.format(price);
-}
 
 interface PlanFeature {
   text: string;

--- a/frontend/src/components/features/premium/PremiumPage.tsx
+++ b/frontend/src/components/features/premium/PremiumPage.tsx
@@ -19,6 +19,16 @@ import type { PlanConfig } from '@/types/admin.types';
 // Constants
 // ============================================================================
 
+const arsPriceFormatter = new Intl.NumberFormat('es-AR', {
+  style: 'currency',
+  currency: 'ARS',
+  maximumFractionDigits: 0,
+});
+
+function formatPriceArs(price: number): string {
+  return arsPriceFormatter.format(price);
+}
+
 interface PlanFeature {
   text: string;
   free: boolean;
@@ -131,7 +141,9 @@ function PremiumCtaButton({ premiumPlan, testId }: PremiumCtaButtonProps) {
     >
       {isPending ? 'Redirigiendo...' : CTA_PREMIUM.PURCHASE}
       {premiumPlan && !isPending && (
-        <span className="ml-2 text-sm opacity-80">${premiumPlan.price.toFixed(2)}/mes</span>
+        <span className="ml-2 text-sm opacity-80">
+          {formatPriceArs(premiumPlan.price)}/mes
+        </span>
       )}
     </Button>
   );
@@ -168,7 +180,7 @@ export function PremiumPage() {
             más por{' '}
             {premiumPlan ? (
               <span className="font-bold text-purple-600 dark:text-purple-400">
-                ${premiumPlan.price.toFixed(2)}/mes
+                {formatPriceArs(premiumPlan.price)}/mes
               </span>
             ) : (
               'un precio accesible'
@@ -214,7 +226,7 @@ export function PremiumPage() {
                 {premiumPlan?.name ?? 'Premium'}
               </h3>
               <p className="mb-4 text-4xl font-bold text-purple-600 dark:text-purple-400">
-                {premiumPlan ? `$${premiumPlan.price.toFixed(2)}` : '---'}
+                {premiumPlan ? formatPriceArs(premiumPlan.price) : '---'}
                 <span className="text-lg font-normal">/mes</span>
               </p>
               <p className="text-sm text-gray-500 dark:text-gray-400">

--- a/frontend/src/components/features/readings/UpgradeModal.test.tsx
+++ b/frontend/src/components/features/readings/UpgradeModal.test.tsx
@@ -65,7 +65,7 @@ describe('UpgradeModal', () => {
     it('should render pricing information', () => {
       render(<UpgradeModal open={true} onClose={mockOnClose} />);
 
-      expect(screen.getByText(/9\.99/)).toBeInTheDocument();
+      expect(screen.getByText(/7\.000/)).toBeInTheDocument();
       expect(screen.getByText(/mes/i)).toBeInTheDocument();
     });
 

--- a/frontend/src/components/features/readings/UpgradeModal.test.tsx
+++ b/frontend/src/components/features/readings/UpgradeModal.test.tsx
@@ -17,12 +17,18 @@ vi.mock('@/hooks/api/useSubscription', () => ({
   useCreatePreapproval: vi.fn(),
 }));
 
+vi.mock('@/hooks/api/usePublicPlans', () => ({
+  usePublicPlans: vi.fn(),
+}));
+
 import UpgradeModal from './UpgradeModal';
 import { useAuth } from '@/hooks/useAuth';
 import { useCreatePreapproval } from '@/hooks/api/useSubscription';
+import { usePublicPlans } from '@/hooks/api/usePublicPlans';
 
 const mockUseAuth = useAuth as ReturnType<typeof vi.fn>;
 const mockUseCreatePreapproval = useCreatePreapproval as ReturnType<typeof vi.fn>;
+const mockUsePublicPlans = usePublicPlans as ReturnType<typeof vi.fn>;
 
 describe('UpgradeModal', () => {
   const mockOnClose = vi.fn();
@@ -37,6 +43,14 @@ describe('UpgradeModal', () => {
     mockUseCreatePreapproval.mockReturnValue({
       mutate: mockMutate,
       isPending: false,
+    });
+    mockUsePublicPlans.mockReturnValue({
+      data: [
+        { id: 1, planType: 'free', name: 'Plan Gratis', price: 0 },
+        { id: 2, planType: 'premium', name: 'Plan Premium', price: 7000 },
+      ],
+      isLoading: false,
+      isError: false,
     });
   });
 

--- a/frontend/src/components/features/readings/UpgradeModal.tsx
+++ b/frontend/src/components/features/readings/UpgradeModal.tsx
@@ -11,9 +11,11 @@ import {
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/useAuth';
 import { useCreatePreapproval } from '@/hooks/api/useSubscription';
+import { usePublicPlans } from '@/hooks/api/usePublicPlans';
 import { useRouter } from 'next/navigation';
 import { ROUTES } from '@/lib/constants/routes';
 import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
+import { formatPriceArs } from '@/lib/utils/format';
 import type { CreatePreapprovalResponse } from '@/types';
 
 /**
@@ -83,6 +85,8 @@ export default function UpgradeModal({ open, onClose, reason }: UpgradeModalProp
   const { user } = useAuth();
   const router = useRouter();
   const { mutate: createPreapproval, isPending } = useCreatePreapproval();
+  const { data: plans } = usePublicPlans();
+  const premiumPrice = plans?.find((p) => p.planType === 'premium')?.price;
 
   // Custom title and description based on reason
   const getContent = () => {
@@ -151,7 +155,9 @@ export default function UpgradeModal({ open, onClose, reason }: UpgradeModalProp
         {/* Pricing */}
         <div className="rounded-lg border border-purple-200 bg-gradient-to-br from-purple-50 to-pink-50 p-6 text-center">
           <div className="flex items-baseline justify-center gap-1">
-            <span className="text-4xl font-bold text-purple-900">$7.000</span>
+            <span className="text-4xl font-bold text-purple-900">
+              {premiumPrice != null ? formatPriceArs(premiumPrice) : '---'}
+            </span>
             <span className="text-muted-foreground">/ mes</span>
           </div>
           <p className="text-muted-foreground mt-2 text-sm">

--- a/frontend/src/components/features/readings/UpgradeModal.tsx
+++ b/frontend/src/components/features/readings/UpgradeModal.tsx
@@ -151,7 +151,7 @@ export default function UpgradeModal({ open, onClose, reason }: UpgradeModalProp
         {/* Pricing */}
         <div className="rounded-lg border border-purple-200 bg-gradient-to-br from-purple-50 to-pink-50 p-6 text-center">
           <div className="flex items-baseline justify-center gap-1">
-            <span className="text-4xl font-bold text-purple-900">$9.99</span>
+            <span className="text-4xl font-bold text-purple-900">$7.000</span>
             <span className="text-muted-foreground">/ mes</span>
           </div>
           <p className="text-muted-foreground mt-2 text-sm">

--- a/frontend/src/hooks/api/useAdminSecurity.test.ts
+++ b/frontend/src/hooks/api/useAdminSecurity.test.ts
@@ -32,7 +32,7 @@ describe('useAdminSecurity hooks', () => {
       const mockData = {
         violations: [
           {
-            ipAddress: '192.168.1.1',
+            ip: '192.168.1.1',
             count: 10,
             firstViolation: '2024-01-01T10:00:00Z',
             lastViolation: '2024-01-01T11:00:00Z',
@@ -40,7 +40,7 @@ describe('useAdminSecurity hooks', () => {
         ],
         blockedIps: [
           {
-            ipAddress: '10.0.0.1',
+            ip: '10.0.0.1',
             reason: 'Excessive violations',
             blockedAt: '2024-01-01T12:00:00Z',
             expiresAt: '2024-01-08T12:00:00Z',

--- a/frontend/src/hooks/api/useAdminSecurity.test.ts
+++ b/frontend/src/hooks/api/useAdminSecurity.test.ts
@@ -38,7 +38,7 @@ describe('useAdminSecurity hooks', () => {
             lastViolation: '2024-01-01T11:00:00Z',
           },
         ],
-        blockedIPs: [
+        blockedIps: [
           {
             ipAddress: '10.0.0.1',
             reason: 'Excessive violations',
@@ -61,7 +61,7 @@ describe('useAdminSecurity hooks', () => {
 
       expect(result.current.data).toEqual(mockData);
       expect(result.current.data?.violations).toHaveLength(1);
-      expect(result.current.data?.blockedIPs).toHaveLength(1);
+      expect(result.current.data?.blockedIps).toHaveLength(1);
       expect(securityApi.fetchRateLimitData).toHaveBeenCalled();
     });
   });

--- a/frontend/src/lib/api/admin-security-api.test.ts
+++ b/frontend/src/lib/api/admin-security-api.test.ts
@@ -19,13 +19,13 @@ describe('admin-security-api', () => {
       const mockData: RateLimitResponse = {
         violations: [
           {
-            ipAddress: '192.168.1.1',
+            ip: '192.168.1.1',
             count: 10,
             firstViolation: '2024-01-01T10:00:00Z',
             lastViolation: '2024-01-01T11:00:00Z',
           },
           {
-            ipAddress: '192.168.1.2',
+            ip: '192.168.1.2',
             count: 5,
             firstViolation: '2024-01-01T09:00:00Z',
             lastViolation: '2024-01-01T09:30:00Z',
@@ -33,7 +33,7 @@ describe('admin-security-api', () => {
         ],
         blockedIps: [
           {
-            ipAddress: '10.0.0.1',
+            ip: '10.0.0.1',
             reason: 'Excessive violations',
             blockedAt: '2024-01-01T12:00:00Z',
             expiresAt: '2024-01-08T12:00:00Z',
@@ -54,7 +54,7 @@ describe('admin-security-api', () => {
       expect(result).toEqual(mockData);
       expect(result.violations).toHaveLength(2);
       expect(result.blockedIps).toHaveLength(1);
-      expect(result.violations[0].ipAddress).toBe('192.168.1.1');
+      expect(result.violations[0].ip).toBe('192.168.1.1');
       expect(result.blockedIps[0].reason).toBe('Excessive violations');
     });
   });

--- a/frontend/src/lib/api/admin-security-api.test.ts
+++ b/frontend/src/lib/api/admin-security-api.test.ts
@@ -31,7 +31,7 @@ describe('admin-security-api', () => {
             lastViolation: '2024-01-01T09:30:00Z',
           },
         ],
-        blockedIPs: [
+        blockedIps: [
           {
             ipAddress: '10.0.0.1',
             reason: 'Excessive violations',
@@ -53,9 +53,9 @@ describe('admin-security-api', () => {
       expect(apiClient.get).toHaveBeenCalledWith('/admin/rate-limits/violations');
       expect(result).toEqual(mockData);
       expect(result.violations).toHaveLength(2);
-      expect(result.blockedIPs).toHaveLength(1);
+      expect(result.blockedIps).toHaveLength(1);
       expect(result.violations[0].ipAddress).toBe('192.168.1.1');
-      expect(result.blockedIPs[0].reason).toBe('Excessive violations');
+      expect(result.blockedIps[0].reason).toBe('Excessive violations');
     });
   });
 

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -245,7 +245,7 @@ export const API_ENDPOINTS = {
     // Public (no authentication required)
     PLAN_CONFIG_PUBLIC: '/plan-config/public',
     // Security & Rate Limiting
-    RATE_LIMIT_DATA: '/admin/rate-limits/violations', // Retorna violations + blockedIPs
+    RATE_LIMIT_DATA: '/admin/rate-limits/violations', // Retorna violations + blockedIps
     SECURITY_EVENTS: '/admin/security/events',
     // TODO: Backend endpoints pendientes
     // BLOCK_IP: '/admin/security/block-ip',

--- a/frontend/src/lib/utils/format.test.ts
+++ b/frontend/src/lib/utils/format.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate, formatRelativeTime, formatPrice, truncateText } from '@/lib/utils/format';
+import {
+  formatDate,
+  formatRelativeTime,
+  formatPrice,
+  formatPriceArs,
+  truncateText,
+} from '@/lib/utils/format';
 
 describe('format utilities', () => {
   describe('formatDate', () => {
@@ -76,6 +82,21 @@ describe('format utilities', () => {
     it('should format price in different currencies', () => {
       const result = formatPrice(100, 'USD');
       expect(result).toContain('$');
+    });
+  });
+
+  describe('formatPriceArs', () => {
+    it('should format ARS price without decimals using thousand separator', () => {
+      const result = formatPriceArs(7000);
+      expect(result).toContain('7.000');
+      expect(result).toContain('$');
+      expect(result).not.toContain(',');
+    });
+
+    it('should round decimal amounts (no fractional pesos)', () => {
+      const result = formatPriceArs(9.99);
+      expect(result).toContain('10');
+      expect(result).not.toContain('9,99');
     });
   });
 

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -46,6 +46,20 @@ export function formatPrice(amount: number, currency = 'EUR'): string {
   }).format(amount);
 }
 
+const arsPriceFormatter = new Intl.NumberFormat('es-AR', {
+  style: 'currency',
+  currency: 'ARS',
+  maximumFractionDigits: 0,
+});
+
+/**
+ * Format a price as Argentine Pesos without decimals (e.g. 7000 → "$ 7.000").
+ * Use as the canonical price formatter for Premium pricing across the app.
+ */
+export function formatPriceArs(amount: number): string {
+  return arsPriceFormatter.format(amount);
+}
+
 /**
  * Truncate text with ellipsis
  */

--- a/frontend/src/types/admin-security.types.ts
+++ b/frontend/src/types/admin-security.types.ts
@@ -7,9 +7,12 @@
 
 /**
  * Violación de rate limiting
+ *
+ * Contrato real backend (RateLimitsAdminController + IPBlockingService):
+ * cada item usa la propiedad `ip` (no `ipAddress`).
  */
 export interface RateLimitViolation {
-  ipAddress: string;
+  ip: string;
   count: number;
   firstViolation: string;
   lastViolation: string;
@@ -17,9 +20,11 @@ export interface RateLimitViolation {
 
 /**
  * IP bloqueada
+ *
+ * Contrato real backend: cada item usa la propiedad `ip` (no `ipAddress`).
  */
 export interface BlockedIP {
-  ipAddress: string;
+  ip: string;
   reason: string;
   blockedAt: string;
   expiresAt: string | null; // Puede ser null si es permanente

--- a/frontend/src/types/admin-security.types.ts
+++ b/frontend/src/types/admin-security.types.ts
@@ -100,11 +100,11 @@ export interface RateLimitStats {
 
 /**
  * Respuesta completa del endpoint de rate limiting
- * Backend retorna violations, blockedIPs y stats en una sola respuesta
+ * Backend retorna violations, blockedIps y stats en una sola respuesta
  */
 export interface RateLimitResponse {
   violations: RateLimitViolation[];
-  blockedIPs: BlockedIP[];
+  blockedIps: BlockedIP[];
   stats: RateLimitStats;
 }
 


### PR DESCRIPTION
## Summary

Tres correcciones detectadas en el audit Playwright post T-UI-11 (validación visual de T-UI-01..11 con 3 usuarios):

- **Fix #1 — Copy /login**: `LoginForm` usa `CTA_AUTH.LOGIN` y `CTA_AUTH.REGISTER` en lugar de hardcodear "Iniciar Sesión" (title-case) y "Crear cuenta nueva". Alinea con el header y la constante canónica.
- **Fix #2 — Crash /admin/seguridad**: bug de contrato: backend devuelve `blockedIps` (lowercase) pero el frontend esperaba `blockedIPs`. Resultado: `data.blockedIPs.length` tiraba `Cannot read properties of undefined`. Tipos y todos los consumers alineados al contrato real. Además se agregó `ErrorDisplay` con retry en ambas tabs y se hicieron defensivos los accesos a `events`/`meta` (el endpoint de events no devuelve `meta`).
- **Fix #3 — Pricing canónico Premium $7.000 ARS**: SEED backend de 9.99 → 7000, migration `UpdatePremiumPlanPriceToArs` actualiza filas existentes, `PremiumPage` formatea con `Intl.NumberFormat('es-AR', { style:'currency', currency:'ARS', maximumFractionDigits:0 })` (sale `$ 7.000`), y `UpgradeModal` deja de hardcodear `$9.99`. Decisión de producto del PO.

## Validación visual (Playwright)

- `/login` → submit "Iniciar sesión", links "Crear cuenta" (1 header + 1 footer del form).
- `/admin/seguridad` (admin@test.com) → 2 tabs renderizan, EmptyState canónico "Sin violaciones / No hay violaciones registradas" y "Sin IPs bloqueadas / No hay IPs bloqueadas".
- `/premium` → "$ 7.000/mes" en hero, plan card y CTA.
- `/api/v1/plan-config/public` → premium.price = "7000.00".

Screenshots en `.tmp/ui-audit-screenshots/` (33-premium, 34-admin-seguridad, 35-login).

## Test plan

- [ ] `npm run lint:fix && npm run type-check && npm run build` (frontend) — OK local
- [ ] `npm run lint && npm run build` (backend) — OK local
- [ ] Suite completa vitest frontend en CI (en este entorno Windows tarda 5+ min, validar en pipeline)
- [ ] `npm run test` backend en CI
- [ ] Validar visualmente en preview:
  - [ ] `/login` muestra "Iniciar sesión" + "Crear cuenta" (no "Iniciar Sesión" ni "Crear cuenta nueva")
  - [ ] `/admin/seguridad` carga las 2 tabs sin crashear (admin@test.com)
  - [ ] `/premium` muestra "$ 7.000/mes" (no "$9.99")
  - [ ] Home (`/`) sigue mostrando "$7.000" (sin cambios)

## Migration

Incluye `1776100000000-UpdatePremiumPlanPriceToArs` (idempotente: solo actualiza filas con `price = 9.99`). Correr `npm run migration:run` después de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)