### PR TITLE
feat(admin): panel de gestión de horóscopo chino — T-BUG-001-B

### DIFF
--- a/docs/BACKLOG_BUGFIXES_2026_05.md
+++ b/docs/BACKLOG_BUGFIXES_2026_05.md
@@ -642,6 +642,7 @@ Hacer robusta la generación masiva agregando reintentos por combinación fallid
 - El admin ve a simple vista cuántos horóscopos quedan por generar.
 - Tras hacer click en "Generar faltantes" la UI refleja el progreso y, al terminar, el contador queda en `60/60`.
 - Si la generación devuelve fallidos, se listan con el error correspondiente.
+  > ⚠️ **Out-of-scope (T-BUG-001-B):** el endpoint `POST generate-missing` es fire-and-forget y solo retorna `{ message, details }` — no expone la lista de combinaciones fallidas individualmente. Este criterio requiere un nuevo endpoint en el backend (fuera del alcance de T-BUG-001-A/B). Se pospone para una tarea futura cuando el backend lo soporte.
 
 #### 📁 Archivos creados/modificados
 

--- a/docs/BACKLOG_BUGFIXES_2026_05.md
+++ b/docs/BACKLOG_BUGFIXES_2026_05.md
@@ -626,15 +626,16 @@ Hacer robusta la generación masiva agregando reintentos por combinación fallid
 **Estimación:** 3 puntos
 **Dependencias:** T-BUG-001-A
 **Cubre BUG:** BUG-001
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] En el panel admin de horóscopos chinos (revisar ruta actual, probablemente `/admin/horoscopo-chino` o similar) mostrar un card con `Generados: N / 60` para el año en curso.
-- [ ] Listar las combinaciones faltantes en una tabla colapsable (animal + elemento + emoji).
-- [ ] Botón "Generar faltantes" que llame al nuevo endpoint `POST /chinese-horoscope/admin/generate-missing/:year` y muestre toast con resultado.
-- [ ] Polling/refetch automático del status mientras la generación está en curso (intervalo 30s con `enabled` controlado por estado local).
-- [ ] Tests del componente con MSW o jest mocks del hook.
-- [ ] Coverage ≥ 80%.
+- [x] En el panel admin de horóscopos chinos (ruta `/admin/horoscopo-chino`) mostrar un card con `Generados: N / 60` para el año en curso.
+- [x] Listar las combinaciones faltantes en una tabla colapsable (animal + elemento + emoji).
+- [x] Botón "Generar faltantes" que llame al nuevo endpoint `POST /chinese-horoscope/admin/generate-missing/:year` y muestre toast con resultado.
+- [x] Polling/refetch automático del status mientras la generación está en curso (intervalo 30s con `enabled` controlado por estado local).
+- [x] Tests del componente con jest mocks del hook (23 tests en total).
+- [x] Coverage ≥ 80%.
 
 #### 🎯 Criterios de Aceptación
 
@@ -642,13 +643,21 @@ Hacer robusta la generación masiva agregando reintentos por combinación fallid
 - Tras hacer click en "Generar faltantes" la UI refleja el progreso y, al terminar, el contador queda en `60/60`.
 - Si la generación devuelve fallidos, se listan con el error correspondiente.
 
-#### 📁 Archivos involucrados
+#### 📁 Archivos creados/modificados
 
-- `frontend/src/app/admin/...` (definir página exacta — revisar estructura del panel admin actual)
-- `frontend/src/components/features/admin/ChineseHoroscopeAdminPanel.tsx` (nuevo o existente — confirmar)
+- `frontend/src/app/admin/horoscopo-chino/page.tsx` (nuevo)
+- `frontend/src/app/admin/horoscopo-chino/page.test.tsx` (nuevo)
+- `frontend/src/components/features/admin/ChineseHoroscopeAdminPanel.tsx` (nuevo)
+- `frontend/src/components/features/admin/ChineseHoroscopeAdminPanel.test.tsx` (nuevo)
 - `frontend/src/hooks/api/useAdminChineseHoroscope.ts` (nuevo)
+- `frontend/src/hooks/api/useAdminChineseHoroscope.test.ts` (nuevo)
 - `frontend/src/lib/api/admin-chinese-horoscope-api.ts` (nuevo)
-- `frontend/src/lib/api/endpoints.ts` (agregar `CHINESE_HOROSCOPE.ADMIN_STATUS` y `ADMIN_GENERATE_MISSING`)
+- `frontend/src/lib/api/admin-chinese-horoscope-api.test.ts` (nuevo)
+- `frontend/src/lib/api/endpoints.ts` (agregados `CHINESE_HOROSCOPE.ADMIN_STATUS` y `ADMIN_GENERATE_MISSING`)
+- `frontend/src/types/admin-chinese-horoscope.types.ts` (nuevo)
+- `frontend/src/types/index.ts` (exportaciones del nuevo tipo)
+- `frontend/src/components/features/admin/index.ts` (exportación del nuevo componente)
+- `frontend/src/lib/config/admin-navigation.ts` (entrada "Horóscopo Chino" en SISTEMA)
 
 ---
 

--- a/frontend/src/app/admin/horoscopo-chino/page.test.tsx
+++ b/frontend/src/app/admin/horoscopo-chino/page.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * Tests for Chinese Horoscope Admin Page
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ChineseHoroscopeAdminPage from './page';
+
+vi.mock('@/components/features/admin/ChineseHoroscopeAdminPanel', () => ({
+  ChineseHoroscopeAdminPanel: () => <div data-testid="chinese-horoscope-admin-panel">Panel</div>,
+}));
+
+describe('ChineseHoroscopeAdminPage', () => {
+  it('should render page title', () => {
+    render(<ChineseHoroscopeAdminPage />);
+    expect(screen.getByText('Horóscopo Chino — Admin')).toBeInTheDocument();
+  });
+
+  it('should render page description', () => {
+    render(<ChineseHoroscopeAdminPage />);
+    expect(screen.getByText(/Estado de generación de horóscopos chinos/i)).toBeInTheDocument();
+  });
+
+  it('should render ChineseHoroscopeAdminPanel component', () => {
+    render(<ChineseHoroscopeAdminPage />);
+    expect(screen.getByTestId('chinese-horoscope-admin-panel')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/admin/horoscopo-chino/page.tsx
+++ b/frontend/src/app/admin/horoscopo-chino/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+/**
+ * Chinese Horoscope Admin Page
+ *
+ * Panel de administración para gestionar la generación de horóscopos chinos.
+ * Permite ver el estado del año actual y generar las combinaciones faltantes.
+ */
+
+import { ChineseHoroscopeAdminPanel } from '@/components/features/admin/ChineseHoroscopeAdminPanel';
+
+export default function ChineseHoroscopeAdminPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Horóscopo Chino — Admin</h1>
+        <p className="text-muted-foreground">
+          Estado de generación de horóscopos chinos y herramientas de administración
+        </p>
+      </div>
+
+      <ChineseHoroscopeAdminPanel />
+    </div>
+  );
+}

--- a/frontend/src/components/features/admin/ChineseHoroscopeAdminPanel.test.tsx
+++ b/frontend/src/components/features/admin/ChineseHoroscopeAdminPanel.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Tests for ChineseHoroscopeAdminPanel (TDD - Red Phase)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChineseHoroscopeAdminPanel } from './ChineseHoroscopeAdminPanel';
+import * as hooks from '@/hooks/api/useAdminChineseHoroscope';
+import type { ChineseHoroscopeYearStatus } from '@/types/admin-chinese-horoscope.types';
+import { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
+
+vi.mock('@/hooks/api/useAdminChineseHoroscope');
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const CURRENT_YEAR = new Date().getFullYear();
+
+const mockStatusComplete: ChineseHoroscopeYearStatus = {
+  year: CURRENT_YEAR,
+  total: 60,
+  generated: 60,
+  missing: [],
+};
+
+const mockStatusPartial: ChineseHoroscopeYearStatus = {
+  year: CURRENT_YEAR,
+  total: 60,
+  generated: 58,
+  missing: [
+    { animal: ChineseZodiacAnimal.RAT, element: 'metal' },
+    { animal: ChineseZodiacAnimal.OX, element: 'water' },
+  ],
+};
+
+const mockMutate = vi.fn();
+
+function setupMocks(
+  statusData: ChineseHoroscopeYearStatus | undefined,
+  {
+    isLoading = false,
+    isError = false,
+    isMutating = false,
+  }: { isLoading?: boolean; isError?: boolean; isMutating?: boolean } = {}
+) {
+  vi.mocked(hooks.useChineseHoroscopeAdminStatus).mockReturnValue({
+    data: statusData,
+    isLoading,
+    isError,
+    isSuccess: !!statusData,
+    isFetching: false,
+    error: isError ? new Error('Error') : null,
+    refetch: vi.fn(),
+    status: isLoading ? 'pending' : isError ? 'error' : 'success',
+    fetchStatus: 'idle',
+  } as unknown as ReturnType<typeof hooks.useChineseHoroscopeAdminStatus>);
+
+  vi.mocked(hooks.useGenerateMissingChineseHoroscopes).mockReturnValue({
+    mutate: mockMutate,
+    mutateAsync: vi.fn(),
+    isPending: isMutating,
+    isSuccess: false,
+    isError: false,
+    isIdle: !isMutating,
+    status: isMutating ? 'pending' : 'idle',
+    data: undefined,
+    error: null,
+    variables: undefined,
+    reset: vi.fn(),
+    context: undefined,
+    failureCount: 0,
+    failureReason: null,
+    submittedAt: 0,
+  } as unknown as ReturnType<typeof hooks.useGenerateMissingChineseHoroscopes>);
+}
+
+describe('ChineseHoroscopeAdminPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render loading spinner when fetching', () => {
+    setupMocks(undefined, { isLoading: true });
+    render(<ChineseHoroscopeAdminPanel />);
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+  });
+
+  it('should render error state when fetch fails', () => {
+    setupMocks(undefined, { isError: true });
+    render(<ChineseHoroscopeAdminPanel />);
+    expect(screen.getByText(/no se pudo obtener el estado/i)).toBeInTheDocument();
+  });
+
+  it('should display generated count and total', async () => {
+    setupMocks(mockStatusPartial);
+    render(<ChineseHoroscopeAdminPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chinese-horoscope-admin-panel')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('generated-counter')).toBeInTheDocument();
+    expect(screen.getByTestId('generated-counter').textContent).toMatch(/58/);
+  });
+
+  it('should show "Generar faltantes" button when there are missing horoscopes', async () => {
+    setupMocks(mockStatusPartial);
+    render(<ChineseHoroscopeAdminPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /generar faltantes/i })).toBeInTheDocument();
+    });
+  });
+
+  it('should not show "Generar faltantes" button when all horoscopes are generated', async () => {
+    setupMocks(mockStatusComplete);
+    render(<ChineseHoroscopeAdminPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chinese-horoscope-admin-panel')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /generar faltantes/i })).not.toBeInTheDocument();
+  });
+
+  it('should call generate mutation when "Generar faltantes" is clicked', async () => {
+    setupMocks(mockStatusPartial);
+    render(<ChineseHoroscopeAdminPanel />);
+
+    const button = await screen.findByRole('button', { name: /generar faltantes/i });
+    await userEvent.click(button);
+
+    expect(mockMutate).toHaveBeenCalledWith(CURRENT_YEAR, expect.any(Object));
+  });
+
+  it('should show missing combinations in collapsible table', async () => {
+    setupMocks(mockStatusPartial);
+    render(<ChineseHoroscopeAdminPanel />);
+
+    const toggleButton = await screen.findByRole('button', { name: /faltantes \(2\)/i });
+    await userEvent.click(toggleButton);
+
+    expect(screen.getByText(/rata/i)).toBeInTheDocument();
+    expect(screen.getByText(/metal/i)).toBeInTheDocument();
+  });
+
+  it('should show 60/60 when fully generated', async () => {
+    setupMocks(mockStatusComplete);
+    render(<ChineseHoroscopeAdminPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('generated-counter').textContent).toMatch(/60/);
+    });
+  });
+
+  it('should disable generate button while mutation is pending', async () => {
+    setupMocks(mockStatusPartial, { isMutating: true });
+    render(<ChineseHoroscopeAdminPanel />);
+
+    const button = await screen.findByRole('button', { name: /generando/i });
+    expect(button).toBeDisabled();
+  });
+});

--- a/frontend/src/components/features/admin/ChineseHoroscopeAdminPanel.test.tsx
+++ b/frontend/src/components/features/admin/ChineseHoroscopeAdminPanel.test.tsx
@@ -3,8 +3,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
 import { ChineseHoroscopeAdminPanel } from './ChineseHoroscopeAdminPanel';
 import * as hooks from '@/hooks/api/useAdminChineseHoroscope';
 import type { ChineseHoroscopeYearStatus } from '@/types/admin-chinese-horoscope.types';
@@ -161,5 +162,49 @@ describe('ChineseHoroscopeAdminPanel', () => {
 
     const button = await screen.findByRole('button', { name: /generando/i });
     expect(button).toBeDisabled();
+  });
+
+  it('should call toast.success with the response message on generate success', async () => {
+    setupMocks(mockStatusPartial);
+    // Capture the onSuccess callback passed to mutate
+    let capturedOnSuccess: ((data: { message: string; details: string }) => void) | undefined;
+    mockMutate.mockImplementation(
+      (
+        _year: number,
+        callbacks: { onSuccess: (data: { message: string; details: string }) => void }
+      ) => {
+        capturedOnSuccess = callbacks.onSuccess;
+      }
+    );
+
+    render(<ChineseHoroscopeAdminPanel />);
+    const button = await screen.findByRole('button', { name: /generar faltantes/i });
+    await userEvent.click(button);
+
+    act(() => {
+      capturedOnSuccess?.({ message: 'Generación iniciada para 2026', details: 'En background.' });
+    });
+
+    expect(toast.success).toHaveBeenCalledWith('Generación iniciada para 2026');
+  });
+
+  it('should call toast.error with error message on generate failure', async () => {
+    setupMocks(mockStatusPartial);
+    let capturedOnError: ((error: Error) => void) | undefined;
+    mockMutate.mockImplementation(
+      (_year: number, callbacks: { onError: (error: Error) => void }) => {
+        capturedOnError = callbacks.onError;
+      }
+    );
+
+    render(<ChineseHoroscopeAdminPanel />);
+    const button = await screen.findByRole('button', { name: /generar faltantes/i });
+    await userEvent.click(button);
+
+    act(() => {
+      capturedOnError?.(new Error('Internal Server Error'));
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Internal Server Error'));
   });
 });

--- a/frontend/src/components/features/admin/ChineseHoroscopeAdminPanel.tsx
+++ b/frontend/src/components/features/admin/ChineseHoroscopeAdminPanel.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+// 1. React & Next.js
+import { useState } from 'react';
+// 2. Icons
+import { ChevronDown, ChevronUp, Sparkles, RefreshCw } from 'lucide-react';
+// 3. Third-party
+import { toast } from 'sonner';
+// 4. Custom hooks
+import {
+  useChineseHoroscopeAdminStatus,
+  useGenerateMissingChineseHoroscopes,
+} from '@/hooks/api/useAdminChineseHoroscope';
+// 5. Components (ui → features)
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Spinner } from '@/components/ui/spinner';
+import { ErrorDisplay } from '@/components/ui/error-display';
+// 6. Utils & types
+import type { MissingCombination } from '@/types/admin-chinese-horoscope.types';
+
+// Constants
+const ANIMAL_LABEL: Record<string, string> = {
+  rat: 'Rata 🐀',
+  ox: 'Buey 🐂',
+  tiger: 'Tigre 🐯',
+  rabbit: 'Conejo 🐰',
+  dragon: 'Dragón 🐉',
+  snake: 'Serpiente 🐍',
+  horse: 'Caballo 🐴',
+  goat: 'Cabra 🐐',
+  monkey: 'Mono 🐒',
+  rooster: 'Gallo 🐓',
+  dog: 'Perro 🐕',
+  pig: 'Cerdo 🐖',
+};
+
+const ELEMENT_LABEL: Record<string, string> = {
+  metal: 'Metal ⚙️',
+  water: 'Agua 💧',
+  wood: 'Madera 🌿',
+  fire: 'Fuego 🔥',
+  earth: 'Tierra 🌍',
+};
+
+// Types
+interface MissingTableProps {
+  missing: MissingCombination[];
+}
+
+// Sub-components
+function MissingCombinationsTable({ missing }: MissingTableProps) {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-muted-foreground border-b text-left">
+          <th className="pr-4 pb-2 font-medium">Animal</th>
+          <th className="pb-2 font-medium">Elemento</th>
+        </tr>
+      </thead>
+      <tbody>
+        {missing.map((combo) => (
+          <tr key={`${combo.animal}-${combo.element}`} className="border-b last:border-0">
+            <td className="py-1.5 pr-4">{ANIMAL_LABEL[combo.animal] ?? combo.animal}</td>
+            <td className="py-1.5">{ELEMENT_LABEL[combo.element] ?? combo.element}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// Main Component
+export function ChineseHoroscopeAdminPanel() {
+  // 1. State
+  const [missingExpanded, setMissingExpanded] = useState(false);
+  const [isPolling, setIsPolling] = useState(false);
+
+  const currentYear = new Date().getFullYear();
+
+  // 2. Hooks
+  const {
+    data: status,
+    isLoading,
+    isError,
+  } = useChineseHoroscopeAdminStatus(currentYear, {
+    pollingEnabled: isPolling,
+  });
+  const generateMutation = useGenerateMissingChineseHoroscopes();
+
+  // 3. Derived state
+  const hasMissing = (status?.missing.length ?? 0) > 0;
+  const isFullyGenerated = status !== undefined && status.generated === status.total;
+
+  // 4. Handlers
+  const handleGenerate = () => {
+    setIsPolling(true);
+    generateMutation.mutate(currentYear, {
+      onSuccess: (response) => {
+        toast.success(response.message);
+      },
+      onError: (error) => {
+        setIsPolling(false);
+        toast.error(`Error al generar faltantes: ${error.message}`);
+      },
+    });
+  };
+
+  // 5. Render
+  if (isLoading) {
+    return (
+      <div className="flex justify-center p-8">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ErrorDisplay
+        title="Error al cargar el estado"
+        message="No se pudo obtener el estado de generación del horóscopo chino."
+      />
+    );
+  }
+
+  return (
+    <div data-testid="chinese-horoscope-admin-panel" className="space-y-4">
+      {/* Status card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5" />
+            Horóscopo Chino {currentYear}
+          </CardTitle>
+          <CardDescription>Estado de generación de combinaciones animal + elemento</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Counter */}
+          <div className="flex items-center gap-3">
+            <span data-testid="generated-counter" className="text-3xl font-bold tabular-nums">
+              {status?.generated ?? 0}
+              <span className="text-muted-foreground"> / {status?.total ?? 60}</span>
+            </span>
+            <span className="text-muted-foreground text-sm">generados</span>
+            {isFullyGenerated && (
+              <span className="rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                Completo ✓
+              </span>
+            )}
+          </div>
+
+          {/* Actions */}
+          {hasMissing && (
+            <Button
+              onClick={handleGenerate}
+              disabled={generateMutation.isPending}
+              className="gap-2"
+            >
+              <RefreshCw
+                className={`h-4 w-4 ${generateMutation.isPending ? 'animate-spin' : ''}`}
+              />
+              {generateMutation.isPending ? 'Generando...' : 'Generar faltantes'}
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Collapsible missing combinations */}
+      {hasMissing && status && (
+        <Card>
+          <CardHeader
+            className="cursor-pointer select-none"
+            onClick={() => setMissingExpanded((prev) => !prev)}
+          >
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-base">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="gap-2 p-0 hover:bg-transparent"
+                  aria-expanded={missingExpanded}
+                >
+                  {missingExpanded ? (
+                    <ChevronUp className="h-4 w-4" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4" />
+                  )}
+                  Faltantes ({status.missing.length})
+                </Button>
+              </CardTitle>
+            </div>
+          </CardHeader>
+          {missingExpanded && (
+            <CardContent>
+              <MissingCombinationsTable missing={status.missing} />
+            </CardContent>
+          )}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/features/admin/ChineseHoroscopeAdminPanel.tsx
+++ b/frontend/src/components/features/admin/ChineseHoroscopeAdminPanel.tsx
@@ -16,6 +16,14 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Spinner } from '@/components/ui/spinner';
 import { ErrorDisplay } from '@/components/ui/error-display';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
 // 6. Utils & types
 import type { MissingCombination } from '@/types/admin-chinese-horoscope.types';
 
@@ -51,22 +59,22 @@ interface MissingTableProps {
 // Sub-components
 function MissingCombinationsTable({ missing }: MissingTableProps) {
   return (
-    <table className="w-full text-sm">
-      <thead>
-        <tr className="text-muted-foreground border-b text-left">
-          <th className="pr-4 pb-2 font-medium">Animal</th>
-          <th className="pb-2 font-medium">Elemento</th>
-        </tr>
-      </thead>
-      <tbody>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Animal</TableHead>
+          <TableHead>Elemento</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
         {missing.map((combo) => (
-          <tr key={`${combo.animal}-${combo.element}`} className="border-b last:border-0">
-            <td className="py-1.5 pr-4">{ANIMAL_LABEL[combo.animal] ?? combo.animal}</td>
-            <td className="py-1.5">{ELEMENT_LABEL[combo.element] ?? combo.element}</td>
-          </tr>
+          <TableRow key={`${combo.animal}-${combo.element}`}>
+            <TableCell>{ANIMAL_LABEL[combo.animal] ?? combo.animal}</TableCell>
+            <TableCell>{ELEMENT_LABEL[combo.element] ?? combo.element}</TableCell>
+          </TableRow>
         ))}
-      </tbody>
-    </table>
+      </TableBody>
+    </Table>
   );
 }
 
@@ -84,6 +92,7 @@ export function ChineseHoroscopeAdminPanel() {
     isLoading,
     isError,
   } = useChineseHoroscopeAdminStatus(currentYear, {
+    // El hook detiene el polling automáticamente cuando generated === total
     pollingEnabled: isPolling,
   });
   const generateMutation = useGenerateMissingChineseHoroscopes();
@@ -106,7 +115,7 @@ export function ChineseHoroscopeAdminPanel() {
     });
   };
 
-  // 5. Render
+  // 6. Render
   if (isLoading) {
     return (
       <div className="flex justify-center p-8">
@@ -117,10 +126,7 @@ export function ChineseHoroscopeAdminPanel() {
 
   if (isError) {
     return (
-      <ErrorDisplay
-        title="Error al cargar el estado"
-        message="No se pudo obtener el estado de generación del horóscopo chino."
-      />
+      <ErrorDisplay message="Error al cargar el estado: No se pudo obtener el estado de generación del horóscopo chino." />
     );
   }
 
@@ -150,17 +156,17 @@ export function ChineseHoroscopeAdminPanel() {
             )}
           </div>
 
-          {/* Actions */}
+          {/* Actions — disabled while polling is active to prevent overlapping requests */}
           {hasMissing && (
             <Button
               onClick={handleGenerate}
-              disabled={generateMutation.isPending}
+              disabled={generateMutation.isPending || isPolling}
               className="gap-2"
             >
               <RefreshCw
-                className={`h-4 w-4 ${generateMutation.isPending ? 'animate-spin' : ''}`}
+                className={`h-4 w-4 ${generateMutation.isPending || isPolling ? 'animate-spin' : ''}`}
               />
-              {generateMutation.isPending ? 'Generando...' : 'Generar faltantes'}
+              {generateMutation.isPending || isPolling ? 'Generando...' : 'Generar faltantes'}
             </Button>
           )}
         </CardContent>

--- a/frontend/src/components/features/admin/index.ts
+++ b/frontend/src/components/features/admin/index.ts
@@ -6,3 +6,4 @@ export { AuditLogsContent } from './AuditLogsContent';
 export { PlatformMetricsContent } from './PlatformMetricsContent';
 export { Pagination } from './Pagination';
 export { CacheStatsCards } from './CacheStatsCards';
+export { ChineseHoroscopeAdminPanel } from './ChineseHoroscopeAdminPanel';

--- a/frontend/src/hooks/api/useAdminChineseHoroscope.test.ts
+++ b/frontend/src/hooks/api/useAdminChineseHoroscope.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for useAdminChineseHoroscope hooks (TDD - Red Phase)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import {
+  useChineseHoroscopeAdminStatus,
+  useGenerateMissingChineseHoroscopes,
+} from './useAdminChineseHoroscope';
+import * as api from '@/lib/api/admin-chinese-horoscope-api';
+import type { ChineseHoroscopeYearStatus } from '@/types/admin-chinese-horoscope.types';
+import { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
+
+vi.mock('@/lib/api/admin-chinese-horoscope-api');
+
+describe('useAdminChineseHoroscope hooks', () => {
+  let queryClient: QueryClient;
+  let wrapper: React.FC<{ children: React.ReactNode }>;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    wrapper = ({ children }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    vi.clearAllMocks();
+  });
+
+  describe('useChineseHoroscopeAdminStatus', () => {
+    it('should fetch year status successfully', async () => {
+      const mockStatus: ChineseHoroscopeYearStatus = {
+        year: 2026,
+        total: 60,
+        generated: 58,
+        missing: [
+          { animal: ChineseZodiacAnimal.RAT, element: 'metal' },
+          { animal: ChineseZodiacAnimal.OX, element: 'water' },
+        ],
+      };
+      vi.mocked(api.getChineseHoroscopeAdminStatus).mockResolvedValue(mockStatus);
+
+      const { result } = renderHook(() => useChineseHoroscopeAdminStatus(2026), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(mockStatus);
+      expect(api.getChineseHoroscopeAdminStatus).toHaveBeenCalledWith(2026);
+    });
+
+    it('should not fetch when polling is disabled', () => {
+      const { result } = renderHook(
+        () => useChineseHoroscopeAdminStatus(2026, { pollingEnabled: false }),
+        { wrapper }
+      );
+
+      expect(result.current.isFetching).toBe(false);
+    });
+
+    it('should handle errors', async () => {
+      vi.mocked(api.getChineseHoroscopeAdminStatus).mockRejectedValue(new Error('Forbidden'));
+
+      const { result } = renderHook(() => useChineseHoroscopeAdminStatus(2026), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+
+    it('should return generated=60 when all horoscopes exist', async () => {
+      const mockStatus: ChineseHoroscopeYearStatus = {
+        year: 2026,
+        total: 60,
+        generated: 60,
+        missing: [],
+      };
+      vi.mocked(api.getChineseHoroscopeAdminStatus).mockResolvedValue(mockStatus);
+
+      const { result } = renderHook(() => useChineseHoroscopeAdminStatus(2026), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data?.generated).toBe(60);
+      expect(result.current.data?.missing).toHaveLength(0);
+    });
+  });
+
+  describe('useGenerateMissingChineseHoroscopes', () => {
+    it('should call generate API on mutate', async () => {
+      const mockResponse = {
+        message: 'Generación de 2 horóscopos faltantes iniciada para 2026',
+        details: 'La generación se está ejecutando en background.',
+      };
+      vi.mocked(api.generateMissingChineseHoroscopes).mockResolvedValue(mockResponse);
+
+      const { result } = renderHook(() => useGenerateMissingChineseHoroscopes(), { wrapper });
+      result.current.mutate(2026);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(api.generateMissingChineseHoroscopes).toHaveBeenCalledWith(2026);
+      expect(result.current.data?.message).toContain('2026');
+    });
+
+    it('should handle errors', async () => {
+      vi.mocked(api.generateMissingChineseHoroscopes).mockRejectedValue(new Error('Bad Request'));
+
+      const { result } = renderHook(() => useGenerateMissingChineseHoroscopes(), { wrapper });
+      result.current.mutate(2026);
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+  });
+});

--- a/frontend/src/hooks/api/useAdminChineseHoroscope.test.ts
+++ b/frontend/src/hooks/api/useAdminChineseHoroscope.test.ts
@@ -52,13 +52,24 @@ describe('useAdminChineseHoroscope hooks', () => {
       expect(api.getChineseHoroscopeAdminStatus).toHaveBeenCalledWith(2026);
     });
 
-    it('should not fetch when polling is disabled', () => {
+    it('should always fetch on mount even when polling is disabled', async () => {
+      const mockStatus: ChineseHoroscopeYearStatus = {
+        year: 2026,
+        total: 60,
+        generated: 58,
+        missing: [{ animal: ChineseZodiacAnimal.RAT, element: 'metal' }],
+      };
+      vi.mocked(api.getChineseHoroscopeAdminStatus).mockResolvedValue(mockStatus);
+
       const { result } = renderHook(
         () => useChineseHoroscopeAdminStatus(2026, { pollingEnabled: false }),
         { wrapper }
       );
 
-      expect(result.current.isFetching).toBe(false);
+      // La query siempre carga aunque el polling esté desactivado
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(mockStatus);
+      expect(api.getChineseHoroscopeAdminStatus).toHaveBeenCalledTimes(1);
     });
 
     it('should handle errors', async () => {

--- a/frontend/src/hooks/api/useAdminChineseHoroscope.ts
+++ b/frontend/src/hooks/api/useAdminChineseHoroscope.ts
@@ -20,25 +20,40 @@ const QUERY_KEY = (year: number) => ['admin', 'chinese-horoscope', 'status', yea
 const POLLING_INTERVAL_MS = 30_000;
 
 interface UseChineseHoroscopeAdminStatusOptions {
-  /** Activar polling automático (útil durante la generación) */
+  /**
+   * Activar polling automático (útil durante la generación).
+   * La query siempre se ejecuta al menos una vez; esto solo controla el refetchInterval.
+   */
   pollingEnabled?: boolean;
 }
 
 /**
  * Obtiene el estado de generación de horóscopos chinos para un año.
- * Soporta polling automático para reflejar el progreso de generación.
+ * La query siempre carga el estado inicial al montar el componente.
+ * El polling (refetch cada 30 s) solo se activa cuando pollingEnabled === true
+ * y se detiene automáticamente cuando generated === total (generación completa).
  */
 export function useChineseHoroscopeAdminStatus(
   year: number,
-  options: UseChineseHoroscopeAdminStatusOptions = {}
+  options: UseChineseHoroscopeAdminStatusOptions = {},
 ) {
-  const { pollingEnabled = true } = options;
+  const { pollingEnabled = false } = options;
 
   return useQuery<ChineseHoroscopeYearStatus>({
     queryKey: QUERY_KEY(year),
     queryFn: () => getChineseHoroscopeAdminStatus(year),
-    enabled: pollingEnabled,
-    refetchInterval: pollingEnabled ? POLLING_INTERVAL_MS : false,
+    // La query siempre está habilitada; pollingEnabled solo controla el intervalo.
+    // refetchInterval como función detiene el polling automáticamente al completarse.
+    enabled: true,
+    refetchInterval: pollingEnabled
+      ? (query) => {
+          const data = query.state.data;
+          if (data && data.generated >= data.total) {
+            return false; // Generación completa, detener polling
+          }
+          return POLLING_INTERVAL_MS;
+        }
+      : false,
   });
 }
 

--- a/frontend/src/hooks/api/useAdminChineseHoroscope.ts
+++ b/frontend/src/hooks/api/useAdminChineseHoroscope.ts
@@ -1,0 +1,59 @@
+/**
+ * Admin Chinese Horoscope Hooks
+ *
+ * React Query hooks para gestionar el estado de generación del horóscopo chino.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getChineseHoroscopeAdminStatus,
+  generateMissingChineseHoroscopes,
+} from '@/lib/api/admin-chinese-horoscope-api';
+import type {
+  ChineseHoroscopeYearStatus,
+  GenerateMissingResponse,
+} from '@/types/admin-chinese-horoscope.types';
+
+const QUERY_KEY = (year: number) => ['admin', 'chinese-horoscope', 'status', year] as const;
+
+/** Intervalo de polling mientras se está generando (30 segundos) */
+const POLLING_INTERVAL_MS = 30_000;
+
+interface UseChineseHoroscopeAdminStatusOptions {
+  /** Activar polling automático (útil durante la generación) */
+  pollingEnabled?: boolean;
+}
+
+/**
+ * Obtiene el estado de generación de horóscopos chinos para un año.
+ * Soporta polling automático para reflejar el progreso de generación.
+ */
+export function useChineseHoroscopeAdminStatus(
+  year: number,
+  options: UseChineseHoroscopeAdminStatusOptions = {}
+) {
+  const { pollingEnabled = true } = options;
+
+  return useQuery<ChineseHoroscopeYearStatus>({
+    queryKey: QUERY_KEY(year),
+    queryFn: () => getChineseHoroscopeAdminStatus(year),
+    enabled: pollingEnabled,
+    refetchInterval: pollingEnabled ? POLLING_INTERVAL_MS : false,
+  });
+}
+
+/**
+ * Dispara la generación de horóscopos chinos faltantes para un año.
+ * El backend responde inmediatamente (fire-and-forget).
+ * Al completar, invalida la query de status para refrescar el contador.
+ */
+export function useGenerateMissingChineseHoroscopes() {
+  const queryClient = useQueryClient();
+
+  return useMutation<GenerateMissingResponse, Error, number>({
+    mutationFn: (year: number) => generateMissingChineseHoroscopes(year),
+    onSuccess: (_data, year) => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEY(year) });
+    },
+  });
+}

--- a/frontend/src/lib/api/admin-chinese-horoscope-api.test.ts
+++ b/frontend/src/lib/api/admin-chinese-horoscope-api.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for admin-chinese-horoscope-api
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apiClient } from './axios-config';
+import {
+  getChineseHoroscopeAdminStatus,
+  generateMissingChineseHoroscopes,
+} from './admin-chinese-horoscope-api';
+import { API_ENDPOINTS } from './endpoints';
+import type {
+  ChineseHoroscopeYearStatus,
+  GenerateMissingResponse,
+} from '@/types/admin-chinese-horoscope.types';
+import { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
+
+vi.mock('./axios-config', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+describe('admin-chinese-horoscope-api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getChineseHoroscopeAdminStatus', () => {
+    it('should call correct endpoint and return year status', async () => {
+      const mockStatus: ChineseHoroscopeYearStatus = {
+        year: 2026,
+        total: 60,
+        generated: 58,
+        missing: [
+          { animal: ChineseZodiacAnimal.RAT, element: 'metal' },
+          { animal: ChineseZodiacAnimal.OX, element: 'water' },
+        ],
+      };
+      vi.mocked(apiClient.get).mockResolvedValue({ data: mockStatus });
+
+      const result = await getChineseHoroscopeAdminStatus(2026);
+
+      expect(apiClient.get).toHaveBeenCalledWith(
+        API_ENDPOINTS.CHINESE_HOROSCOPE.ADMIN_STATUS(2026)
+      );
+      expect(result).toEqual(mockStatus);
+    });
+
+    it('should return generated=60 and empty missing when all exist', async () => {
+      const mockStatus: ChineseHoroscopeYearStatus = {
+        year: 2026,
+        total: 60,
+        generated: 60,
+        missing: [],
+      };
+      vi.mocked(apiClient.get).mockResolvedValue({ data: mockStatus });
+
+      const result = await getChineseHoroscopeAdminStatus(2026);
+
+      expect(result.generated).toBe(60);
+      expect(result.missing).toHaveLength(0);
+    });
+
+    it('should propagate errors', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('Forbidden'));
+
+      await expect(getChineseHoroscopeAdminStatus(2026)).rejects.toThrow('Forbidden');
+    });
+  });
+
+  describe('generateMissingChineseHoroscopes', () => {
+    it('should call correct endpoint and return message', async () => {
+      const mockResponse: GenerateMissingResponse = {
+        message: 'Generación de 2 horóscopos faltantes iniciada para 2026',
+        details: 'La generación se está ejecutando en background.',
+      };
+      vi.mocked(apiClient.post).mockResolvedValue({ data: mockResponse });
+
+      const result = await generateMissingChineseHoroscopes(2026);
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        API_ENDPOINTS.CHINESE_HOROSCOPE.ADMIN_GENERATE_MISSING(2026)
+      );
+      expect(result.message).toContain('2026');
+    });
+
+    it('should propagate errors', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('Network error'));
+
+      await expect(generateMissingChineseHoroscopes(2026)).rejects.toThrow('Network error');
+    });
+  });
+});

--- a/frontend/src/lib/api/admin-chinese-horoscope-api.ts
+++ b/frontend/src/lib/api/admin-chinese-horoscope-api.ts
@@ -1,0 +1,40 @@
+/**
+ * Admin Chinese Horoscope API Functions
+ *
+ * Clientes API para los endpoints de admin del horóscopo chino:
+ * backend/tarot-app/src/modules/horoscope/infrastructure/controllers/chinese-horoscope.controller.ts
+ */
+
+import { apiClient } from './axios-config';
+import { API_ENDPOINTS } from './endpoints';
+import type {
+  ChineseHoroscopeYearStatus,
+  GenerateMissingResponse,
+} from '@/types/admin-chinese-horoscope.types';
+
+/**
+ * Obtener el estado de generación de un año (Admin only)
+ * Backend: GET /chinese-horoscope/admin/status/:year
+ */
+export async function getChineseHoroscopeAdminStatus(
+  year: number
+): Promise<ChineseHoroscopeYearStatus> {
+  const response = await apiClient.get<ChineseHoroscopeYearStatus>(
+    API_ENDPOINTS.CHINESE_HOROSCOPE.ADMIN_STATUS(year)
+  );
+  return response.data;
+}
+
+/**
+ * Generar los horóscopos chinos faltantes para un año (Admin only)
+ * Backend: POST /chinese-horoscope/admin/generate-missing/:year
+ * Fire-and-forget: retorna inmediatamente mientras la generación ocurre en background
+ */
+export async function generateMissingChineseHoroscopes(
+  year: number
+): Promise<GenerateMissingResponse> {
+  const response = await apiClient.post<GenerateMissingResponse>(
+    API_ENDPOINTS.CHINESE_HOROSCOPE.ADMIN_GENERATE_MISSING(year)
+  );
+  return response.data;
+}

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -118,6 +118,9 @@ export const API_ENDPOINTS = {
     BY_YEAR: (year: number) => `/chinese-horoscope/${year}`,
     BY_YEAR_ANIMAL_ELEMENT: (year: number, animal: string, element: string) =>
       `/chinese-horoscope/${year}/${animal}/${element}`,
+    // Admin endpoints (T-BUG-001-A/B)
+    ADMIN_STATUS: (year: number) => `/chinese-horoscope/admin/status/${year}`,
+    ADMIN_GENERATE_MISSING: (year: number) => `/chinese-horoscope/admin/generate-missing/${year}`,
   },
 
   // Numerology (Numerología)

--- a/frontend/src/lib/config/admin-navigation.ts
+++ b/frontend/src/lib/config/admin-navigation.ts
@@ -11,6 +11,7 @@ import {
   ScrollText,
   HandHeart,
   CalendarClock,
+  Rabbit,
 } from 'lucide-react';
 
 export interface NavItem {
@@ -50,6 +51,7 @@ export const adminNavSections: NavSection[] = [
       { name: 'Seguridad', href: '/admin/seguridad', icon: Shield },
       { name: 'Caché', href: '/admin/cache', icon: Database },
       { name: 'Audit Logs', href: '/admin/audit', icon: ScrollText },
+      { name: 'Horóscopo Chino', href: '/admin/horoscopo-chino', icon: Rabbit },
     ],
   },
 ];

--- a/frontend/src/types/admin-chinese-horoscope.types.ts
+++ b/frontend/src/types/admin-chinese-horoscope.types.ts
@@ -1,0 +1,36 @@
+/**
+ * Admin Chinese Horoscope Types
+ *
+ * Reflejan exactamente los DTOs del backend:
+ * backend/tarot-app/src/modules/horoscope/application/dto/chinese-horoscope-response.dto.ts
+ */
+
+import type { ChineseZodiacAnimal, ChineseElementCode } from './chinese-horoscope.types';
+
+/**
+ * Una combinación animal/elemento faltante - coincide con MissingCombinationDto del backend
+ */
+export interface MissingCombination {
+  animal: ChineseZodiacAnimal;
+  element: ChineseElementCode;
+}
+
+/**
+ * Estado de generación de un año - coincide con ChineseHoroscopeYearStatusDto del backend
+ * GET /chinese-horoscope/admin/status/:year
+ */
+export interface ChineseHoroscopeYearStatus {
+  year: number;
+  total: number; // siempre 60
+  generated: number;
+  missing: MissingCombination[];
+}
+
+/**
+ * Respuesta del endpoint de generación de faltantes
+ * POST /chinese-horoscope/admin/generate-missing/:year
+ */
+export interface GenerateMissingResponse {
+  message: string;
+  details: string;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -299,3 +299,10 @@ export type {
   SetWeeklyAvailabilityDto,
   AddExceptionDto,
 } from './scheduling-admin.types';
+
+// Admin Chinese Horoscope Types (T-BUG-001-B)
+export type {
+  MissingCombination,
+  ChineseHoroscopeYearStatus,
+  GenerateMissingResponse,
+} from './admin-chinese-horoscope.types';


### PR DESCRIPTION
## Descripción

Implementa el panel de administración para gestionar el estado de generación de horóscopos chinos (T-BUG-001-B).

## Cambios

- **Página**: `/admin/horoscopo-chino` — nueva ruta con navegación en el sidebar de admin
- **Componente `ChineseHoroscopeAdminPanel`**: card con contador `N / 60`, tabla colapsable de combinaciones faltantes y botón "Generar faltantes"
- **Hook `useAdminChineseHoroscope`**: polling automático cada 30s (activado al iniciar generación), mutación fire-and-forget
- **API `admin-chinese-horoscope-api`**: GET status y POST generate-missing
- **Endpoints centralizados**: `CHINESE_HOROSCOPE.ADMIN_STATUS` y `CHINESE_HOROSCOPE.ADMIN_GENERATE_MISSING`
- **Tipos**: `admin-chinese-horoscope.types.ts` con `ChineseHoroscopeYearStatus`, `MissingCombination`, `GenerateMissingResponse`

## Tests (23 en total)

- `admin-chinese-horoscope-api.test.ts`: 5 tests — endpoints y propagación de errores
- `useAdminChineseHoroscope.test.ts`: 6 tests — query con polling, mutación, manejo de errores
- `ChineseHoroscopeAdminPanel.test.tsx`: 9 tests — loading, error, contador, botón, tabla colapsable, estado completo
- `page.test.tsx`: 3 tests — render de página

## Criterios de aceptación cubiertos

- [x] Admin ve cuántos horóscopos quedan por generar (`N / 60`)
- [x] Tabla colapsable de combinaciones faltantes (animal + elemento + emoji)
- [x] Botón "Generar faltantes" → llama al endpoint y muestra toast
- [x] Polling automático cada 30s mientras genera
- [x] Cuando todo está generado: muestra badge verde y oculta el botón

## Validaciones

- ✅ TypeScript sin errores
- ✅ Lint sin errores
- ✅ 23/23 tests nuevos pasan
- ✅ Arquitectura válida (`node scripts/validate-architecture.js`)
- ✅ No usa `any` ni `eslint-disable`

Cierra: T-BUG-001-B