### PR TITLE
fix(chinese-horoscope): T-BUG-001-C - Mensaje accionable cuando falta horóscopo en página pública

### DIFF
--- a/docs/BACKLOG_BUGFIXES_2026_05.md
+++ b/docs/BACKLOG_BUGFIXES_2026_05.md
@@ -668,13 +668,14 @@ Hacer robusta la generación masiva agregando reintentos por combinación fallid
 **Estimación:** 1 punto
 **Dependencias:** ninguna (puede ir en paralelo con T-BUG-001-A)
 **Cubre BUG:** BUG-001
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] En `frontend/src/components/features/chinese-horoscope/AnimalHoroscopePage.tsx` (línea 124) reemplazar el texto plano "Horóscopo no disponible para {currentYear}" por un componente más empático: ícono + mensaje + botón "Volver al listado".
-- [ ] Si el error es 404, sugerir reintentar más tarde; si es 5xx, ofrecer reintento inmediato.
-- [ ] Asegurar que el `Spinner` siga funcionando durante `isLoading`.
-- [ ] Test de renderizado por estado (loading / error 404 / error 5xx / éxito).
+- [x] En `frontend/src/components/features/chinese-horoscope/AnimalHoroscopePage.tsx` (línea 124) reemplazar el texto plano "Horóscopo no disponible para {currentYear}" por un componente más empático: ícono + mensaje + botón "Volver al listado".
+- [x] Si el error es 404, sugerir reintentar más tarde; si es 5xx, ofrecer reintento inmediato.
+- [x] Asegurar que el `Spinner` siga funcionando durante `isLoading`.
+- [x] Test de renderizado por estado (loading / error 404 / error 5xx / éxito).
 
 #### 🎯 Criterios de Aceptación
 

--- a/frontend/src/app/horoscopo-chino/[animal]/page.test.tsx
+++ b/frontend/src/app/horoscopo-chino/[animal]/page.test.tsx
@@ -138,13 +138,12 @@ describe('ChineseHoroscopeAnimalPage', () => {
     mockUseChineseHoroscopeByElement.mockReturnValue({
       isLoading: false,
       data: null,
-      error: new Error('Not found'),
+      error: Object.assign(new Error('Not found'), { response: { status: 404 } }),
     });
 
     renderWithProviders(<ChineseHoroscopeAnimalPage />);
 
-    const currentYear = new Date().getFullYear();
-    expect(screen.getByText(`Horóscopo no disponible para ${currentYear}`)).toBeInTheDocument();
+    expect(screen.getByText(/horóscopo en preparación/i)).toBeInTheDocument();
   });
 
   it('should render horoscope detail when data is loaded', () => {

--- a/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePage.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePage.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * AnimalHoroscopePage - Tests
+ *
+ * Cubre estados: loading, error 404, error 5xx, éxito
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { AnimalHoroscopePage } from './AnimalHoroscopePage';
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ animal: 'rata' }),
+  useSearchParams: () => ({ get: () => 'metal' }),
+}));
+
+// Mock hook
+const mockUseAnimalHoroscopePage = vi.fn();
+vi.mock('@/hooks/utils/useAnimalHoroscopePage', () => ({
+  useAnimalHoroscopePage: () => mockUseAnimalHoroscopePage(),
+}));
+
+// Mock child components to simplify tests
+vi.mock('@/components/features/chinese-horoscope', () => ({
+  ChineseHoroscopeDetail: () => <div data-testid="horoscope-detail">Detalle horóscopo</div>,
+  ChineseAnimalSelector: () => <div data-testid="animal-selector">Selector</div>,
+  ElementSelectorModal: () => null,
+}));
+
+vi.mock('@/lib/constants/routes', () => ({
+  ROUTES: {
+    HOROSCOPO_CHINO: '/horoscopo-chino',
+    HOROSCOPO_CHINO_ANIMAL: (a: string) => `/horoscopo-chino/${a}`,
+  },
+}));
+
+function createBaseHookResult(overrides = {}) {
+  return {
+    animal: 'rata' as const,
+    isValidAnimal: true,
+    animalInfo: { nameEs: 'Rata', emoji: '🐭' },
+    userAnimal: undefined,
+    isMyAnimal: false,
+    element: 'metal' as const,
+    horoscopeData: undefined,
+    isLoading: false,
+    error: null,
+    currentYear: 2025,
+    showElementModal: false,
+    handleElementSelect: vi.fn(),
+  };
+}
+
+describe('AnimalHoroscopePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Estado: cargando', () => {
+    it('muestra Spinner mientras carga', () => {
+      mockUseAnimalHoroscopePage.mockReturnValue({
+        ...createBaseHookResult(),
+        isLoading: true,
+      });
+
+      render(<AnimalHoroscopePage />);
+
+      expect(screen.getByText(/cargando horóscopo/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Estado: error 404', () => {
+    it('muestra mensaje empático cuando el horóscopo no está disponible (404)', () => {
+      const error404 = Object.assign(new Error('Not Found'), {
+        response: { status: 404 },
+      });
+
+      mockUseAnimalHoroscopePage.mockReturnValue({
+        ...createBaseHookResult(),
+        error: error404,
+      });
+
+      render(<AnimalHoroscopePage />);
+
+      expect(screen.getByText(/en preparación/i)).toBeInTheDocument();
+    });
+
+    it('muestra botón para volver al listado en error 404', () => {
+      const error404 = Object.assign(new Error('Not Found'), {
+        response: { status: 404 },
+      });
+
+      mockUseAnimalHoroscopePage.mockReturnValue({
+        ...createBaseHookResult(),
+        error: error404,
+      });
+
+      render(<AnimalHoroscopePage />);
+
+      expect(screen.getByRole('button', { name: /volver al listado/i })).toBeInTheDocument();
+    });
+
+    it('navega al listado al hacer clic en "Volver al listado" (error 404)', async () => {
+      const error404 = Object.assign(new Error('Not Found'), {
+        response: { status: 404 },
+      });
+
+      mockUseAnimalHoroscopePage.mockReturnValue({
+        ...createBaseHookResult(),
+        error: error404,
+      });
+
+      render(<AnimalHoroscopePage />);
+
+      await userEvent.click(screen.getByRole('button', { name: /volver al listado/i }));
+
+      expect(mockPush).toHaveBeenCalledWith('/horoscopo-chino');
+    });
+  });
+
+  describe('Estado: error 5xx', () => {
+    it('muestra mensaje con opción de reintento en error de servidor', () => {
+      const error500 = Object.assign(new Error('Internal Server Error'), {
+        response: { status: 500 },
+      });
+
+      mockUseAnimalHoroscopePage.mockReturnValue({
+        ...createBaseHookResult(),
+        error: error500,
+      });
+
+      render(<AnimalHoroscopePage />);
+
+      expect(screen.getByRole('button', { name: /reintentar/i })).toBeInTheDocument();
+    });
+
+    it('muestra mensaje indicando error del servidor en 5xx', () => {
+      const error503 = Object.assign(new Error('Service Unavailable'), {
+        response: { status: 503 },
+      });
+
+      mockUseAnimalHoroscopePage.mockReturnValue({
+        ...createBaseHookResult(),
+        error: error503,
+      });
+
+      render(<AnimalHoroscopePage />);
+
+      expect(screen.getByTestId('error-server')).toBeInTheDocument();
+    });
+  });
+
+  describe('Estado: éxito', () => {
+    it('muestra ChineseHoroscopeDetail cuando hay datos', () => {
+      mockUseAnimalHoroscopePage.mockReturnValue({
+        ...createBaseHookResult(),
+        horoscopeData: { id: 1, year: 2025 },
+      });
+
+      render(<AnimalHoroscopePage />);
+
+      expect(screen.getByTestId('horoscope-detail')).toBeInTheDocument();
+    });
+
+    it('no muestra error cuando la carga es exitosa', () => {
+      mockUseAnimalHoroscopePage.mockReturnValue({
+        ...createBaseHookResult(),
+        horoscopeData: { id: 1, year: 2025 },
+      });
+
+      render(<AnimalHoroscopePage />);
+
+      expect(screen.queryByText(/en preparación/i)).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /reintentar/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Estado: animal inválido', () => {
+    it('muestra mensaje de animal no válido', () => {
+      mockUseAnimalHoroscopePage.mockReturnValue({
+        ...createBaseHookResult(),
+        isValidAnimal: false,
+        animalInfo: null,
+      });
+
+      render(<AnimalHoroscopePage />);
+
+      expect(screen.getByText(/animal no válido/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePage.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePage.tsx
@@ -8,7 +8,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, Calculator } from 'lucide-react';
+import { ArrowLeft, Calculator, Clock, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Spinner } from '@/components/ui/spinner';
@@ -19,6 +19,15 @@ import {
 } from '@/components/features/chinese-horoscope';
 import { useAnimalHoroscopePage } from '@/hooks/utils/useAnimalHoroscopePage';
 import { ROUTES } from '@/lib/constants/routes';
+
+interface ErrorWithResponse {
+  response?: { status: number };
+}
+
+function getErrorStatus(error: Error): number | null {
+  const err = error as ErrorWithResponse;
+  return err.response?.status ?? null;
+}
 
 export function AnimalHoroscopePage() {
   const router = useRouter();
@@ -120,9 +129,33 @@ export function AnimalHoroscopePage() {
               <Spinner size="md" text="Cargando horóscopo..." />
             </div>
           ) : error ? (
-            <div className="py-8 text-center">
-              <p className="text-muted-foreground">Horóscopo no disponible para {currentYear}</p>
-            </div>
+            getErrorStatus(error) === 404 ? (
+              <div className="space-y-4 py-8 text-center" data-testid="error-not-found">
+                <Clock className="text-muted-foreground mx-auto h-10 w-10" />
+                <div>
+                  <p className="text-lg font-medium">Horóscopo en preparación</p>
+                  <p className="text-muted-foreground mt-1">
+                    El horóscopo para {currentYear} todavía no está disponible. No es un error tuyo
+                    — estamos trabajando en ello.
+                  </p>
+                </div>
+                <Button variant="outline" onClick={() => router.push(ROUTES.HOROSCOPO_CHINO)}>
+                  <ArrowLeft className="mr-2 h-4 w-4" />
+                  Volver al listado
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-4 py-8 text-center" data-testid="error-server">
+                <p className="text-lg font-medium">Ocurrió un error al cargar el horóscopo</p>
+                <p className="text-muted-foreground">
+                  Por favor, intenta de nuevo en unos momentos.
+                </p>
+                <Button variant="outline" onClick={() => window.location.reload()}>
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                  Reintentar
+                </Button>
+              </div>
+            )
           ) : horoscopeData ? (
             <ChineseHoroscopeDetail horoscope={horoscopeData} element={element} />
           ) : null}


### PR DESCRIPTION
## Descripción

Reemplaza el texto plano genérico por mensajes empáticos y accionables cuando el horóscopo chino no está disponible.

## Cambios

- **Error 404:** Muestra ícono `Clock` + mensaje 'Horóscopo en preparación' + botón 'Volver al listado'. Comunica al usuario que no es un error suyo.
- **Error 5xx:** Muestra mensaje de error del servidor + botón 'Reintentar' para reintento inmediato.
- **Loading:** El `Spinner` sigue funcionando correctamente.
- **Tests TDD:** Nuevo archivo `AnimalHoroscopePage.test.tsx` con 9 tests cubriendo todos los estados (loading / error 404 / error 5xx / éxito / animal inválido).
- Actualiza test existente en `page.test.tsx` para usar el nuevo mensaje.

## Archivos modificados

- `frontend/src/components/features/chinese-horoscope/AnimalHoroscopePage.tsx`
- `frontend/src/components/features/chinese-horoscope/AnimalHoroscopePage.test.tsx` (nuevo)
- `frontend/src/app/horoscopo-chino/[animal]/page.test.tsx`
- `docs/BACKLOG_BUGFIXES_2026_05.md`

## Criterios de Aceptación

- [x] El mensaje deja claro que el horóscopo está 'en preparación' y no es un error del usuario
- [x] El usuario tiene una vía de salida visible (volver al listado)
- [x] Todos los tests pasan
- [x] Arquitectura validada

Closes T-BUG-001-C | Cubre BUG-001