### PR TITLE
fix(admin): crear página placeholder /admin/lecturas (T-BUG-006)

### DIFF
--- a/docs/BACKLOG_BUGFIXES_2026_05.md
+++ b/docs/BACKLOG_BUGFIXES_2026_05.md
@@ -539,7 +539,7 @@ Varias acciones del admin muestran `toast.info('...próximamente')` aunque los e
 | T-BUG-003-C | Acción de usuario "Eliminar compra vencida" + filtros en Mis Servicios     | Frontend    | ✅ COMPLETADA | 2 pts      |
 | T-BUG-004   | Implementar menú hamburguesa mobile en Header con Sheet                    | Frontend    | ✅ COMPLETADA  | 3 pts      |
 | T-BUG-005   | Corregir credenciales impresas por `db-seed-users.ts`                      | Backend     | ✅ COMPLETADA | 0.5 pt     |
-| T-BUG-006   | Crear página placeholder `/admin/lecturas` (o quitar del sidebar)          | Frontend    | 🔴 Crítica  | 1 pt       |
+| T-BUG-006   | Crear página placeholder `/admin/lecturas` (o quitar del sidebar)          | Frontend    | ✅ COMPLETADA | 1 pt       |
 | T-BUG-007-A | Backend: extender `/admin/dashboard/stats` con `recentReadings` + counts reales | Backend  | 🔴 Crítica  | 3 pts      |
 | T-BUG-007-B | Frontend: corregir tipos + eliminar mocks del dashboard                    | Frontend    | 🔴 Crítica  | 2 pts      |
 | T-BUG-008   | Actualizar pricing table de IA + recalcular costos históricos              | Backend     | 🔴 Crítica  | 3 pts      |
@@ -960,26 +960,24 @@ Convertir el botón hamburguesa estático del `Header` en un menú lateral funci
 
 ### T-BUG-006: Crear Página Placeholder `/admin/lecturas` (o Quitar del Sidebar)
 
+**Estado:** ✅ COMPLETADA
 **Prioridad:** 🔴 Crítica · **Estimación:** 1 pt · **Cubre BUG:** BUG-006
 
 #### ✅ Tareas
 
-**Decisión de producto (rápida, en este PR):** crear placeholder o eliminar del sidebar.
+**Decisión tomada:** Opción A — Placeholder (sidebar se mantiene, ruta ya no da 404).
 
-**Opción A — Placeholder (recomendada):**
+**Opción A — Placeholder:**
 
-- [ ] Crear `frontend/src/app/admin/lecturas/page.tsx` con título y mensaje "Sección en construcción".
-- [ ] Test de renderizado mínimo.
-
-**Opción B — Eliminar del sidebar:**
-
-- [ ] Quitar la entrada `'Lecturas'` de `admin-navigation.ts:40`.
-- [ ] Test de sidebar actualizado.
+- [x] Crear `frontend/src/app/admin/lecturas/page.tsx` con título y mensaje "En construcción".
+- [x] Crear `frontend/src/components/features/admin/LecturasPlaceholderContent.tsx`.
+- [x] Test de renderizado mínimo (4 tests).
 
 #### 📁 Archivos
 
-- `frontend/src/app/admin/lecturas/page.tsx` (nuevo, opción A)
-- `frontend/src/lib/config/admin-navigation.ts` (opción B)
+- `frontend/src/app/admin/lecturas/page.tsx` (nuevo)
+- `frontend/src/components/features/admin/LecturasPlaceholderContent.tsx` (nuevo)
+- `frontend/src/components/features/admin/LecturasPlaceholderContent.test.tsx` (nuevo)
 
 ---
 

--- a/frontend/src/app/admin/lecturas/page.tsx
+++ b/frontend/src/app/admin/lecturas/page.tsx
@@ -1,0 +1,9 @@
+import { LecturasPlaceholderContent } from '@/components/features/admin/LecturasPlaceholderContent';
+
+export default function AdminLecturasPage() {
+  return (
+    <div className="container py-8">
+      <LecturasPlaceholderContent />
+    </div>
+  );
+}

--- a/frontend/src/components/features/admin/LecturasPlaceholderContent.test.tsx
+++ b/frontend/src/components/features/admin/LecturasPlaceholderContent.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { LecturasPlaceholderContent } from './LecturasPlaceholderContent';
+
+describe('LecturasPlaceholderContent', () => {
+  it('should render the main heading', () => {
+    render(<LecturasPlaceholderContent />);
+    expect(screen.getByRole('heading', { name: /lecturas/i })).toBeInTheDocument();
+  });
+
+  it('should render construction message', () => {
+    render(<LecturasPlaceholderContent />);
+    expect(screen.getByText(/en construcción/i)).toBeInTheDocument();
+  });
+
+  it('should render data-testid for the container', () => {
+    render(<LecturasPlaceholderContent />);
+    expect(screen.getByTestId('lecturas-placeholder')).toBeInTheDocument();
+  });
+
+  it('should render informative description text', () => {
+    render(<LecturasPlaceholderContent />);
+    expect(screen.getByTestId('lecturas-placeholder-description')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/admin/LecturasPlaceholderContent.tsx
+++ b/frontend/src/components/features/admin/LecturasPlaceholderContent.tsx
@@ -1,0 +1,26 @@
+import { BookOpen, Clock } from 'lucide-react';
+
+export function LecturasPlaceholderContent() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center py-24 text-center"
+      data-testid="lecturas-placeholder"
+    >
+      <div className="bg-muted mb-6 flex size-20 items-center justify-center rounded-full">
+        <BookOpen className="text-muted-foreground size-10" />
+      </div>
+
+      <h1 className="mb-2 font-serif text-3xl font-bold">Lecturas</h1>
+
+      <div className="mb-4 flex items-center gap-2 text-sm font-medium text-amber-600">
+        <Clock className="size-4" />
+        <span>En construcción</span>
+      </div>
+
+      <p className="text-muted-foreground max-w-md" data-testid="lecturas-placeholder-description">
+        El módulo de gestión de lecturas está en desarrollo. Próximamente podrás visualizar, filtrar
+        y administrar todas las lecturas de tarot realizadas en la plataforma.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Descripción

Resuelve el BUG-006: el link **Lecturas** en el sidebar de admin llevaba a un 404 porque la ruta `/admin/lecturas` no existía.

## Cambios

- **Nuevo:** `frontend/src/app/admin/lecturas/page.tsx` — resuelve el 404
- **Nuevo:** `frontend/src/components/features/admin/LecturasPlaceholderContent.tsx` — componente con mensaje 'En construcción'
- **Nuevo:** `frontend/src/components/features/admin/LecturasPlaceholderContent.test.tsx` — 4 tests TDD
- **Docs:** backlog T-BUG-006 marcada como ✅ COMPLETADA

## Decisión tomada

Se optó por **Opción A (placeholder)**: la entrada del sidebar se mantiene y la ruta ahora muestra un mensaje 'En construcción' en lugar de 404. Esto preserva la navegación y comunica claramente que la sección está planificada.

## Validaciones

- [x] Tests pasan (4/4)
- [x] `npm run format` ✅
- [x] `npm run lint:fix` ✅ (solo warnings pre-existentes)
- [x] `npm run type-check` ✅
- [x] `npm run build` ✅
- [x] `node scripts/validate-architecture.js` ✅
- [x] PR apunta a `develop`

Cierra BUG-006 / T-BUG-006