### PR TITLE
feat(admin): implementar modal Gestionar Roles en panel usuarios (T-BUG-010-B)

### DIFF
--- a/docs/BACKLOG_BUGFIXES_2026_05.md
+++ b/docs/BACKLOG_BUGFIXES_2026_05.md
@@ -545,7 +545,7 @@ Varias acciones del admin muestran `toast.info('...próximamente')` aunque los e
 | T-BUG-008   | **AI Usage consolidada** — pricing real + tipos lowercase + date range + daily limit       | Full-stack  | ✅ COMPLETADA | 6 pts ⬆️    |
 | T-BUG-009   | _Absorbida por T-BUG-008 (consolidación 2026-05-18)_                                       | —           | —           | —          |
 | T-BUG-010-A | **Seguridad consolidada** — IP blocks persistidos + desbloqueo + fix SelectItem + audit `{data,meta}` | Full-stack | ✅ COMPLETADA | 7.5 pts ⬆️  |
-| T-BUG-010-B | Implementar "Gestionar roles" en Usuarios admin                                            | Frontend    | 🟠 Alta     | 3 pts      |
+| T-BUG-010-B | Implementar "Gestionar roles" en Usuarios admin                                            | Frontend    | ✅ COMPLETADA | 3 pts      |
 | T-BUG-010-C | _Absorbida por T-BUG-007-B (consolidación 2026-05-18)_                                     | —           | —           | —          |
 | T-BUG-011   | _Absorbida por T-BUG-010-A (consolidación 2026-05-18)_                                     | —           | —           | —          |
 | T-BUG-012   | _Absorbida por T-BUG-010-A (consolidación 2026-05-18)_                                     | —           | —           | —          |
@@ -555,7 +555,7 @@ Varias acciones del admin muestran `toast.info('...próximamente')` aunque los e
 
 **Estimación total:** ~49 puntos (~25 días con TDD + ciclo de calidad).
 **Tras consolidación 2026-05-18:** 4 tareas pendientes (T-BUG-007-B, T-BUG-008, T-BUG-010-A, T-BUG-010-B) = 22.5 pts, en lugar de 11 — sin pérdida de alcance. Ver detalle al final del archivo.
-> T-BUG-008 ✅ completada (2026-05-18). T-BUG-010-A ✅ completada (2026-05-19).
+> T-BUG-008 ✅ completada (2026-05-18). T-BUG-010-A ✅ completada (2026-05-19). T-BUG-010-B ✅ completada (2026-05-20).
 
 ---
 
@@ -1179,14 +1179,14 @@ Convertir el botón hamburguesa estático del `Header` en un menú lateral funci
 
 > Mantenida sin consolidar: agrega un modal nuevo con flujo de diff y confirmaciones — alcance independiente del resto del admin FE. No tiene sentido mezclarla con T-BUG-007-B.
 
-#### ✅ Tareas
+**Estado:** ✅ COMPLETADA
 
-- [ ] Crear modal `ManageRolesModal` en `frontend/src/components/features/admin/` con checkboxes para CONSUMER/TAROTIST/ADMIN.
-- [ ] Hooks de mutation para los 4 endpoints existentes en backend (`ADD_TAROTIST_ROLE`, `REMOVE_TAROTIST_ROLE`, `ADD_ADMIN_ROLE`, `REMOVE_ADMIN_ROLE`).
-- [ ] Lógica de "diff": comparar roles actuales con los seleccionados y disparar solo las mutaciones necesarias.
-- [ ] Confirmación adicional al quitar rol ADMIN ("Esto removerá el acceso al panel admin. ¿Continuar?").
-- [ ] En `UsersManagementContent.tsx:56-60`, reemplazar `toast.info` por abrir el modal.
-- [ ] Tests del modal y del flujo.
+- [x] Crear modal `ManageRolesModal` en `frontend/src/components/features/admin/` con checkboxes para CONSUMER/TAROTIST/ADMIN.
+- [x] Hooks de mutation para los 4 endpoints existentes en backend (`ADD_TAROTIST_ROLE`, `REMOVE_TAROTIST_ROLE`, `ADD_ADMIN_ROLE`, `REMOVE_ADMIN_ROLE`).
+- [x] Lógica de "diff": comparar roles actuales con los seleccionados y disparar solo las mutaciones necesarias.
+- [x] Confirmación adicional al quitar rol ADMIN ("Esto removerá el acceso al panel admin. ¿Continuar?").
+- [x] En `UsersManagementContent.tsx:56-60`, reemplazar `toast.info` por abrir el modal.
+- [x] Tests del modal y del flujo.
 
 #### 📁 Archivos
 

--- a/frontend/src/app/admin/usuarios/page.test.tsx
+++ b/frontend/src/app/admin/usuarios/page.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@/hooks/api/useAdminUserActions', () => ({
   useBanUser: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUnbanUser: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useUpdateUserPlan: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useManageRoles: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 describe('AdminUsuariosPage', () => {

--- a/frontend/src/components/features/admin/ManageRolesModal.test.tsx
+++ b/frontend/src/components/features/admin/ManageRolesModal.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * Tests for ManageRolesModal component
+ * TDD Red phase - written before implementation
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ManageRolesModal } from './ManageRolesModal';
+import type { AdminUser } from '@/types/admin-users.types';
+
+describe('ManageRolesModal', () => {
+  const mockUser: AdminUser = {
+    id: 1,
+    email: 'test@test.com',
+    name: 'Test User',
+    roles: ['consumer'],
+    plan: 'free',
+    lastLogin: null,
+    createdAt: '2025-11-01T10:00:00Z',
+    updatedAt: '2025-12-01T10:00:00Z',
+    bannedAt: null,
+    banReason: null,
+  };
+
+  const mockOnClose = vi.fn();
+  const mockOnSave = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOnSave.mockResolvedValue(undefined);
+  });
+
+  it('should render modal when open', () => {
+    render(
+      <ManageRolesModal
+        user={mockUser}
+        open={true}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={false}
+      />
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Gestionar Roles')).toBeInTheDocument();
+    expect(screen.getByText(mockUser.name)).toBeInTheDocument();
+  });
+
+  it('should not render modal when closed', () => {
+    render(
+      <ManageRolesModal
+        user={mockUser}
+        open={false}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={false}
+      />
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should show role checkboxes for consumer, tarotist and admin', () => {
+    render(
+      <ManageRolesModal
+        user={mockUser}
+        open={true}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={false}
+      />
+    );
+
+    expect(screen.getByTestId('role-checkbox-consumer')).toBeInTheDocument();
+    expect(screen.getByTestId('role-checkbox-tarotist')).toBeInTheDocument();
+    expect(screen.getByTestId('role-checkbox-admin')).toBeInTheDocument();
+  });
+
+  it('should pre-check roles that user already has', () => {
+    const userWithMultipleRoles: AdminUser = {
+      ...mockUser,
+      roles: ['consumer', 'tarotist'],
+    };
+
+    render(
+      <ManageRolesModal
+        user={userWithMultipleRoles}
+        open={true}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={false}
+      />
+    );
+
+    expect(screen.getByTestId('role-checkbox-consumer')).toBeChecked();
+    expect(screen.getByTestId('role-checkbox-tarotist')).toBeChecked();
+    expect(screen.getByTestId('role-checkbox-admin')).not.toBeChecked();
+  });
+
+  it('should show confirmation dialog when removing admin role', async () => {
+    const adminUser: AdminUser = {
+      ...mockUser,
+      roles: ['consumer', 'admin'],
+    };
+
+    render(
+      <ManageRolesModal
+        user={adminUser}
+        open={true}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={false}
+      />
+    );
+
+    // Uncheck admin role
+    fireEvent.click(screen.getByTestId('role-checkbox-admin'));
+
+    // Click save to trigger confirmation
+    fireEvent.click(screen.getByRole('button', { name: /guardar cambios/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/removerá el acceso al panel admin/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should call onSave with only the roles diff (add tarotist)', async () => {
+    render(
+      <ManageRolesModal
+        user={mockUser}
+        open={true}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={false}
+      />
+    );
+
+    // Check tarotist
+    fireEvent.click(screen.getByTestId('role-checkbox-tarotist'));
+
+    fireEvent.click(screen.getByRole('button', { name: /guardar cambios/i }));
+
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalledWith({
+        toAdd: ['tarotist'],
+        toRemove: [],
+      });
+    });
+  });
+
+  it('should call onSave with diff when removing a role', async () => {
+    const userWithTarotist: AdminUser = {
+      ...mockUser,
+      roles: ['consumer', 'tarotist'],
+    };
+
+    render(
+      <ManageRolesModal
+        user={userWithTarotist}
+        open={true}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={false}
+      />
+    );
+
+    // Uncheck tarotist
+    fireEvent.click(screen.getByTestId('role-checkbox-tarotist'));
+
+    fireEvent.click(screen.getByRole('button', { name: /guardar cambios/i }));
+
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalledWith({
+        toAdd: [],
+        toRemove: ['tarotist'],
+      });
+    });
+  });
+
+  it('should not call onSave if no changes', () => {
+    render(
+      <ManageRolesModal
+        user={mockUser}
+        open={true}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={false}
+      />
+    );
+
+    // No changes, click save directly
+    fireEvent.click(screen.getByRole('button', { name: /guardar cambios/i }));
+
+    expect(mockOnSave).not.toHaveBeenCalled();
+  });
+
+  it('should call onClose when cancel is clicked', () => {
+    render(
+      <ManageRolesModal
+        user={mockUser}
+        open={true}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /cancelar/i }));
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('should disable buttons when isPending is true', () => {
+    render(
+      <ManageRolesModal
+        user={mockUser}
+        open={true}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={true}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /guardando/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /cancelar/i })).toBeDisabled();
+  });
+
+  it('should show current user email in description', () => {
+    render(
+      <ManageRolesModal
+        user={mockUser}
+        open={true}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={false}
+      />
+    );
+
+    expect(screen.getByText(mockUser.email, { exact: false })).toBeInTheDocument();
+  });
+
+  it('should display role labels in Spanish', () => {
+    render(
+      <ManageRolesModal
+        user={mockUser}
+        open={true}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={false}
+      />
+    );
+
+    expect(screen.getByText('Consumidor')).toBeInTheDocument();
+    expect(screen.getByText('Tarotista')).toBeInTheDocument();
+    expect(screen.getByText('Administrador')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/admin/ManageRolesModal.test.tsx
+++ b/frontend/src/components/features/admin/ManageRolesModal.test.tsx
@@ -254,4 +254,20 @@ describe('ManageRolesModal', () => {
     expect(screen.getByText('Tarotista')).toBeInTheDocument();
     expect(screen.getByText('Administrador')).toBeInTheDocument();
   });
+
+  it('should always disable the consumer checkbox (rol solo lectura)', () => {
+    render(
+      <ManageRolesModal
+        user={mockUser}
+        open={true}
+        onClose={mockOnClose}
+        onSave={mockOnSave}
+        isPending={false}
+      />
+    );
+
+    expect(screen.getByTestId('role-checkbox-consumer')).toBeDisabled();
+    expect(screen.getByTestId('role-checkbox-tarotist')).not.toBeDisabled();
+    expect(screen.getByTestId('role-checkbox-admin')).not.toBeDisabled();
+  });
 });

--- a/frontend/src/components/features/admin/ManageRolesModal.tsx
+++ b/frontend/src/components/features/admin/ManageRolesModal.tsx
@@ -1,0 +1,214 @@
+/**
+ * ManageRolesModal Component
+ *
+ * Modal para gestionar roles de un usuario admin.
+ * Muestra checkboxes para CONSUMER/TAROTIST/ADMIN con lógica de diff.
+ * Pide confirmación adicional al remover el rol ADMIN.
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import type { AdminUser } from '@/types/admin-users.types';
+import type { UserRole } from '@/types/user.types';
+
+interface RoleDiff {
+  toAdd: UserRole[];
+  toRemove: UserRole[];
+}
+
+interface ManageRolesModalProps {
+  user: AdminUser;
+  open: boolean;
+  onClose: () => void;
+  onSave: (diff: RoleDiff) => void;
+  isPending: boolean;
+}
+
+const AVAILABLE_ROLES: { role: UserRole; label: string; description: string }[] = [
+  {
+    role: 'consumer',
+    label: 'Consumidor',
+    description: 'Acceso básico a la plataforma',
+  },
+  {
+    role: 'tarotist',
+    label: 'Tarotista',
+    description: 'Puede gestionar lecturas de tarot',
+  },
+  {
+    role: 'admin',
+    label: 'Administrador',
+    description: 'Acceso completo al panel de administración',
+  },
+];
+
+function computeDiff(original: UserRole[], current: UserRole[]): RoleDiff {
+  const originalSet = new Set(original);
+  const currentSet = new Set(current);
+
+  const toAdd = current.filter((r) => !originalSet.has(r));
+  const toRemove = original.filter((r) => !currentSet.has(r));
+
+  return { toAdd, toRemove };
+}
+
+interface ManageRolesModalInnerProps extends ManageRolesModalProps {
+  initialRoles: UserRole[];
+}
+
+function ManageRolesModalInner({
+  user,
+  open,
+  onClose,
+  onSave,
+  isPending,
+  initialRoles,
+}: ManageRolesModalInnerProps) {
+  const [selectedRoles, setSelectedRoles] = useState<UserRole[]>(initialRoles);
+  const [showAdminConfirm, setShowAdminConfirm] = useState(false);
+  const [pendingDiff, setPendingDiff] = useState<RoleDiff | null>(null);
+
+  const toggleRole = (role: UserRole) => {
+    setSelectedRoles((prev) =>
+      prev.includes(role) ? prev.filter((r) => r !== role) : [...prev, role]
+    );
+  };
+
+  const handleSave = () => {
+    const diff = computeDiff(user.roles, selectedRoles);
+
+    // No changes
+    if (diff.toAdd.length === 0 && diff.toRemove.length === 0) {
+      return;
+    }
+
+    // Warn before removing admin role
+    if (diff.toRemove.includes('admin')) {
+      setPendingDiff(diff);
+      setShowAdminConfirm(true);
+      return;
+    }
+
+    onSave(diff);
+  };
+
+  const handleConfirmAdminRemoval = () => {
+    setShowAdminConfirm(false);
+    if (pendingDiff) {
+      onSave(pendingDiff);
+      setPendingDiff(null);
+    }
+  };
+
+  const handleCancelAdminConfirm = () => {
+    setShowAdminConfirm(false);
+    setPendingDiff(null);
+  };
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onClose}>
+        <DialogContent data-testid="manage-roles-modal">
+          <DialogHeader>
+            <DialogTitle>Gestionar Roles</DialogTitle>
+            <DialogDescription>
+              Modificando roles de <span className="font-semibold">{user.name}</span> ({user.email})
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            {AVAILABLE_ROLES.map(({ role, label, description }) => (
+              <div key={role} className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  id={`role-${role}`}
+                  data-testid={`role-checkbox-${role}`}
+                  checked={selectedRoles.includes(role)}
+                  onChange={() => toggleRole(role)}
+                  disabled={isPending}
+                  className="mt-1 h-4 w-4 cursor-pointer rounded border-gray-300"
+                />
+                <div className="grid gap-0.5">
+                  <Label htmlFor={`role-${role}`} className="cursor-pointer font-medium">
+                    {label}
+                  </Label>
+                  <p className="text-muted-foreground text-sm">{description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>
+              Cancelar
+            </Button>
+            <Button type="button" onClick={handleSave} disabled={isPending}>
+              {isPending ? 'Guardando...' : 'Guardar cambios'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Confirmación al remover rol ADMIN */}
+      <AlertDialog open={showAdminConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="text-destructive size-5" />
+              Confirmar remoción de rol Admin
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Esto removerá el acceso al panel admin de{' '}
+              <span className="font-semibold">{user.name}</span>. ¿Continuar?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleCancelAdminConfirm}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmAdminRemoval}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Confirmar
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+/**
+ * Wrapper público que garantiza reset de estado al abrir/cerrar el modal
+ * usando la prop key para forzar remontado del componente interno
+ */
+export function ManageRolesModal(props: ManageRolesModalProps) {
+  return (
+    <ManageRolesModalInner
+      key={props.open ? `open-${props.user.id}` : 'closed'}
+      {...props}
+      initialRoles={props.user.roles}
+    />
+  );
+}

--- a/frontend/src/components/features/admin/ManageRolesModal.tsx
+++ b/frontend/src/components/features/admin/ManageRolesModal.tsx
@@ -33,9 +33,11 @@ import { Label } from '@/components/ui/label';
 import type { AdminUser } from '@/types/admin-users.types';
 import type { UserRole } from '@/types/user.types';
 
+type AssignableRole = Exclude<UserRole, 'consumer'>;
+
 interface RoleDiff {
-  toAdd: UserRole[];
-  toRemove: UserRole[];
+  toAdd: AssignableRole[];
+  toRemove: AssignableRole[];
 }
 
 interface ManageRolesModalProps {
@@ -64,12 +66,20 @@ const AVAILABLE_ROLES: { role: UserRole; label: string; description: string }[] 
   },
 ];
 
+function isAssignableRole(role: UserRole): role is AssignableRole {
+  return role !== 'consumer';
+}
+
 function computeDiff(original: UserRole[], current: UserRole[]): RoleDiff {
   const originalSet = new Set(original);
   const currentSet = new Set(current);
 
-  const toAdd = current.filter((r) => !originalSet.has(r));
-  const toRemove = original.filter((r) => !currentSet.has(r));
+  const toAdd = current.filter(
+    (r) => !originalSet.has(r) && isAssignableRole(r)
+  ) as AssignableRole[];
+  const toRemove = original.filter(
+    (r) => !currentSet.has(r) && isAssignableRole(r)
+  ) as AssignableRole[];
 
   return { toAdd, toRemove };
 }
@@ -147,7 +157,7 @@ function ManageRolesModalInner({
                   data-testid={`role-checkbox-${role}`}
                   checked={selectedRoles.includes(role)}
                   onChange={() => toggleRole(role)}
-                  disabled={isPending}
+                  disabled={isPending || role === 'consumer'}
                   className="mt-1 h-4 w-4 cursor-pointer rounded border-gray-300"
                 />
                 <div className="grid gap-0.5">
@@ -172,7 +182,12 @@ function ManageRolesModalInner({
       </Dialog>
 
       {/* Confirmación al remover rol ADMIN */}
-      <AlertDialog open={showAdminConfirm}>
+      <AlertDialog
+        open={showAdminConfirm}
+        onOpenChange={(open) => {
+          if (!open) handleCancelAdminConfirm();
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2">

--- a/frontend/src/components/features/admin/UsersManagementContent.tsx
+++ b/frontend/src/components/features/admin/UsersManagementContent.tsx
@@ -13,24 +13,37 @@ import { UsersFilters } from './UsersFilters';
 import { Pagination } from './Pagination';
 import { ChangePlanModal } from './ChangePlanModal';
 import { BanUserModal } from './BanUserModal';
+import { ManageRolesModal } from './ManageRolesModal';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useAdminUsers } from '@/hooks/api/useAdminUsers';
-import { useBanUser, useUnbanUser, useUpdateUserPlan } from '@/hooks/api/useAdminUserActions';
+import {
+  useBanUser,
+  useUnbanUser,
+  useUpdateUserPlan,
+  useManageRoles,
+} from '@/hooks/api/useAdminUserActions';
 import type { AdminUser, UserFilters } from '@/types/admin-users.types';
 import type { UpdateUserPlanForm } from '@/lib/validations/admin-users.schemas';
 import type { BanUserForm } from '@/lib/validations/admin-users.schemas';
+import type { UserRole } from '@/types/user.types';
 import { toast } from 'sonner';
+
+interface RoleDiff {
+  toAdd: UserRole[];
+  toRemove: UserRole[];
+}
 
 export function UsersManagementContent() {
   const [filters, setFilters] = useState<UserFilters>({ page: 1, limit: 10 });
   const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
-  const [modalOpen, setModalOpen] = useState<'plan' | 'ban' | null>(null);
+  const [modalOpen, setModalOpen] = useState<'plan' | 'ban' | 'roles' | null>(null);
 
   const { data, isLoading, error } = useAdminUsers(filters);
   const banUserMutation = useBanUser();
   const unbanUserMutation = useUnbanUser();
   const updatePlanMutation = useUpdateUserPlan();
+  const manageRolesMutation = useManageRoles();
 
   const handleFilterChange = (newFilters: Partial<UserFilters>) => {
     setFilters((prev) => ({ ...prev, ...newFilters, page: 1 }));
@@ -54,9 +67,7 @@ export function UsersManagementContent() {
         handleUnban(user);
         break;
       case 'manage-roles':
-        // TODO: Implement ManageRolesModal in future task
-        toast.info('Gestión de roles: próximamente');
-        setSelectedUser(null);
+        setModalOpen('roles');
         break;
       default:
         break;
@@ -108,6 +119,24 @@ export function UsersManagementContent() {
         toast.error(`Error al desbanear usuario: ${error.message}`);
       },
     });
+  };
+
+  const handleManageRoles = (diff: RoleDiff) => {
+    if (!selectedUser) return;
+
+    manageRolesMutation.mutate(
+      { userId: selectedUser.id, ...diff },
+      {
+        onSuccess: () => {
+          toast.success('Roles actualizados correctamente');
+          setModalOpen(null);
+          setSelectedUser(null);
+        },
+        onError: (error) => {
+          toast.error(`Error al actualizar roles: ${error.message}`);
+        },
+      }
+    );
   };
 
   if (isLoading) {
@@ -177,6 +206,17 @@ export function UsersManagementContent() {
             }}
             onSubmit={handleBan}
             isPending={banUserMutation.isPending}
+          />
+
+          <ManageRolesModal
+            user={selectedUser}
+            open={modalOpen === 'roles'}
+            onClose={() => {
+              setModalOpen(null);
+              setSelectedUser(null);
+            }}
+            onSave={handleManageRoles}
+            isPending={manageRolesMutation.isPending}
           />
         </>
       )}

--- a/frontend/src/components/features/admin/UsersManagementContent.tsx
+++ b/frontend/src/components/features/admin/UsersManagementContent.tsx
@@ -30,8 +30,8 @@ import type { UserRole } from '@/types/user.types';
 import { toast } from 'sonner';
 
 interface RoleDiff {
-  toAdd: UserRole[];
-  toRemove: UserRole[];
+  toAdd: Exclude<UserRole, 'consumer'>[];
+  toRemove: Exclude<UserRole, 'consumer'>[];
 }
 
 export function UsersManagementContent() {

--- a/frontend/src/components/features/admin/index.ts
+++ b/frontend/src/components/features/admin/index.ts
@@ -7,3 +7,4 @@ export { PlatformMetricsContent } from './PlatformMetricsContent';
 export { Pagination } from './Pagination';
 export { CacheStatsCards } from './CacheStatsCards';
 export { ChineseHoroscopeAdminPanel } from './ChineseHoroscopeAdminPanel';
+export { ManageRolesModal } from './ManageRolesModal';

--- a/frontend/src/hooks/api/useAdminUserActions.ts
+++ b/frontend/src/hooks/api/useAdminUserActions.ts
@@ -13,6 +13,13 @@ import {
   removeAdminRole,
 } from '@/lib/api/admin-users-api';
 import type { UpdateUserPlanDto } from '@/types/admin-users.types';
+import type { UserRole } from '@/types/user.types';
+
+interface RoleDiff {
+  userId: number;
+  toAdd: UserRole[];
+  toRemove: UserRole[];
+}
 
 /**
  * Hook para banear usuario
@@ -108,6 +115,36 @@ export function useRemoveAdminRole() {
 
   return useMutation({
     mutationFn: (userId: number) => removeAdminRole(userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
+    },
+  });
+}
+
+const ROLE_ADD_FN: Record<UserRole, (userId: number) => Promise<unknown>> = {
+  consumer: () => Promise.resolve(),
+  tarotist: addTarotistRole,
+  admin: addAdminRole,
+};
+
+const ROLE_REMOVE_FN: Record<UserRole, (userId: number) => Promise<unknown>> = {
+  consumer: () => Promise.resolve(),
+  tarotist: removeTarotistRole,
+  admin: removeAdminRole,
+};
+
+/**
+ * Hook para gestionar roles de un usuario (agrega y/o remueve según diff)
+ */
+export function useManageRoles() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ userId, toAdd, toRemove }: RoleDiff) => {
+      const addPromises = toAdd.map((role) => ROLE_ADD_FN[role](userId));
+      const removePromises = toRemove.map((role) => ROLE_REMOVE_FN[role](userId));
+      await Promise.all([...addPromises, ...removePromises]);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
     },

--- a/frontend/src/hooks/api/useAdminUserActions.ts
+++ b/frontend/src/hooks/api/useAdminUserActions.ts
@@ -15,10 +15,12 @@ import {
 import type { UpdateUserPlanDto } from '@/types/admin-users.types';
 import type { UserRole } from '@/types/user.types';
 
+type AssignableRole = Exclude<UserRole, 'consumer'>;
+
 interface RoleDiff {
   userId: number;
-  toAdd: UserRole[];
-  toRemove: UserRole[];
+  toAdd: AssignableRole[];
+  toRemove: AssignableRole[];
 }
 
 /**
@@ -121,14 +123,12 @@ export function useRemoveAdminRole() {
   });
 }
 
-const ROLE_ADD_FN: Record<UserRole, (userId: number) => Promise<unknown>> = {
-  consumer: () => Promise.resolve(),
+const ROLE_ADD_FN: Record<AssignableRole, (userId: number) => Promise<unknown>> = {
   tarotist: addTarotistRole,
   admin: addAdminRole,
 };
 
-const ROLE_REMOVE_FN: Record<UserRole, (userId: number) => Promise<unknown>> = {
-  consumer: () => Promise.resolve(),
+const ROLE_REMOVE_FN: Record<AssignableRole, (userId: number) => Promise<unknown>> = {
   tarotist: removeTarotistRole,
   admin: removeAdminRole,
 };

--- a/frontend/src/hooks/api/useManageRoles.test.tsx
+++ b/frontend/src/hooks/api/useManageRoles.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for useManageRoles hook
+ * TDD Red phase - written before implementation
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useManageRoles } from './useAdminUserActions';
+import * as adminUsersApi from '@/lib/api/admin-users-api';
+import type { AdminActionResponse } from '@/types/admin-users.types';
+
+// Mock API module
+vi.mock('@/lib/api/admin-users-api');
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+  Wrapper.displayName = 'QueryClientWrapper';
+  return Wrapper;
+};
+
+const mockActionResponse: AdminActionResponse = {
+  message: 'Operación exitosa',
+  user: {
+    id: 1,
+    email: 'test@test.com',
+    name: 'Test User',
+    roles: ['consumer'],
+    plan: 'free',
+    lastLogin: null,
+    createdAt: '2025-11-01T10:00:00Z',
+    updatedAt: '2025-12-01T10:00:00Z',
+    bannedAt: null,
+    banReason: null,
+  },
+};
+
+describe('useManageRoles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should add and remove roles based on diff', async () => {
+    vi.mocked(adminUsersApi.addTarotistRole).mockResolvedValue(mockActionResponse);
+    vi.mocked(adminUsersApi.removeAdminRole).mockResolvedValue(mockActionResponse);
+
+    const { result } = renderHook(() => useManageRoles(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      userId: 1,
+      toAdd: ['tarotist'],
+      toRemove: ['admin'],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(adminUsersApi.addTarotistRole).toHaveBeenCalledWith(1);
+    expect(adminUsersApi.removeAdminRole).toHaveBeenCalledWith(1);
+  });
+
+  it('should only add roles when toRemove is empty', async () => {
+    vi.mocked(adminUsersApi.addAdminRole).mockResolvedValue(mockActionResponse);
+
+    const { result } = renderHook(() => useManageRoles(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      userId: 1,
+      toAdd: ['admin'],
+      toRemove: [],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(adminUsersApi.addAdminRole).toHaveBeenCalledWith(1);
+    expect(adminUsersApi.removeTarotistRole).not.toHaveBeenCalled();
+  });
+
+  it('should only remove roles when toAdd is empty', async () => {
+    vi.mocked(adminUsersApi.removeTarotistRole).mockResolvedValue(mockActionResponse);
+
+    const { result } = renderHook(() => useManageRoles(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      userId: 1,
+      toAdd: [],
+      toRemove: ['tarotist'],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(adminUsersApi.removeTarotistRole).toHaveBeenCalledWith(1);
+    expect(adminUsersApi.addAdminRole).not.toHaveBeenCalled();
+  });
+
+  it('should handle error in role mutation', async () => {
+    vi.mocked(adminUsersApi.addTarotistRole).mockRejectedValue(new Error('Failed to add role'));
+
+    const { result } = renderHook(() => useManageRoles(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      userId: 1,
+      toAdd: ['tarotist'],
+      toRemove: [],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Descripción

Implementa el modal "Gestionar Roles" en el panel admin de usuarios, reemplazando el `toast.info('próximamente')` existente.

## Cambios

- **Nuevo componente** `ManageRolesModal.tsx`: checkboxes para CONSUMER/TAROTIST/ADMIN con rol consumer deshabilitado (solo lectura)
- **Lógica de diff**: compara roles actuales con seleccionados y dispara solo las mutaciones necesarias (`Promise.all`)
- **Confirmación adicional** (`AlertDialog`) al remover rol admin: "Esto removerá el acceso al panel admin. ¿Continuar?"
- **Hook `useManageRoles`** en `useAdminUserActions.ts`: ejecuta add/remove en paralelo según diff
- **`UsersManagementContent.tsx`**: integra el modal, reemplaza `toast.info`
- **16 tests TDD**: 12 en `ManageRolesModal.test.tsx` + 4 en `useManageRoles.test.tsx`
- Usa `key` prop para reset de estado sin `useEffect` (evita lint error de React Compiler)

## Quality Gates

- ✅ `npm run format`
- ✅ `npm run lint:fix` (0 errores, 6 warnings pre-existentes)
- ✅ `npm run type-check`
- ✅ `npm run test:run` (todos los tests nuevos pasan; fallos pre-existentes confirmados)
- ✅ `npm run build`
- ✅ `node scripts/validate-architecture.js`

## Tarea

Cierra T-BUG-010-B