### PR TITLE
feat(metricas): consumir sesiones reales en panel de métricas admin [T-ADM-002-B]

### DIFF
--- a/docs/BACKLOG_ADMIN_AUDIT_2026_05.md
+++ b/docs/BACKLOG_ADMIN_AUDIT_2026_05.md
@@ -413,17 +413,19 @@ El backend expone un CRUD de IP whitelist (`GET/POST/DELETE /admin/ip-whitelist`
 **Estimación:** 1 punto
 **Dependencias:** T-ADM-002-A
 **Cubre hallazgo:** ADM-002
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] Reemplazar el `0` + badge "Próximamente" (`PlatformMetricsContent.tsx:126-128`) por `metrics.completedSessions`.
-- [ ] Reemplazar el `-` de la columna "Sesiones" (`:194`) por `tarotista.completedSessions`.
-- [ ] Actualizar tipos `PlatformMetrics` en `types/`.
-- [ ] Tests actualizados; ciclo de calidad.
+- [x] Reemplazar el `0` + badge "Próximamente" (`PlatformMetricsContent.tsx:126-128`) por `metrics.completedSessions`.
+- [x] Reemplazar el `-` de la columna "Sesiones" (`:194`) por `tarotista.completedSessions`.
+- [x] Actualizar tipos `PlatformMetrics` en `types/` (`completedSessions` en `PlatformMetricsDto` y `TarotistaMetricsDto`).
+- [x] Tests actualizados (nuevo `PlatformMetricsContent.test.tsx` + mocks en `usePlatformMetrics.test.ts` + `page.test.tsx`); 24 tests pasando.
+- [x] Ciclo de calidad frontend completo (format, lint:fix, type-check, build, validate-architecture).
 
 #### 🎯 Criterios de Aceptación
 
-- [ ] La tarjeta y la columna muestran datos reales sin badge "Próximamente".
+- [x] La tarjeta y la columna muestran datos reales sin badge "Próximamente".
 
 #### 📁 Archivos involucrados
 

--- a/frontend/src/app/admin/metricas/page.test.tsx
+++ b/frontend/src/app/admin/metricas/page.test.tsx
@@ -35,6 +35,7 @@ function createWrapper() {
 describe('PlatformMetricsPage', () => {
   const mockMetrics: PlatformMetricsDto = {
     totalReadings: 1500,
+    completedSessions: 87,
     totalRevenueShare: 52500.0,
     totalPlatformFee: 22500.0,
     totalGrossRevenue: 75000.0,
@@ -49,6 +50,7 @@ describe('PlatformMetricsPage', () => {
         tarotistaId: 1,
         nombrePublico: 'Luna Misteriosa',
         totalReadings: 150,
+        completedSessions: 30,
         totalRevenueShare: 5250.0,
         totalPlatformFee: 2250.0,
         totalGrossRevenue: 7500.0,
@@ -63,6 +65,7 @@ describe('PlatformMetricsPage', () => {
         tarotistaId: 2,
         nombrePublico: 'Estrella Mística',
         totalReadings: 130,
+        completedSessions: 25,
         totalRevenueShare: 4550.0,
         totalPlatformFee: 1950.0,
         totalGrossRevenue: 6500.0,

--- a/frontend/src/components/features/admin/PlatformMetricsContent.test.tsx
+++ b/frontend/src/components/features/admin/PlatformMetricsContent.test.tsx
@@ -6,7 +6,6 @@ import { render, screen } from '@testing-library/react';
 import { PlatformMetricsContent } from './PlatformMetricsContent';
 import * as usePlatformMetricsModule from '@/hooks/api/usePlatformMetrics';
 import type { PlatformMetricsDto } from '@/types';
-import { MetricsPeriod } from '@/types';
 
 vi.mock('@/hooks/api/usePlatformMetrics');
 
@@ -143,6 +142,14 @@ describe('PlatformMetricsContent', () => {
 
     // Should show 0, not '-' or 'Próximamente'
     expect(screen.queryByText('Próximamente')).not.toBeInTheDocument();
+    // The card header should still be visible
+    expect(screen.getByText('Sesiones Completadas')).toBeInTheDocument();
+    // 0 should be rendered (formatted as "0" by formatLargeNumber)
+    const zeroCells = screen.getAllByText('0');
+    // At least 2 occurrences of "0": one in the card, one in the table session column
+    expect(zeroCells.length).toBeGreaterThanOrEqual(2);
+    // No '-' placeholders in the table
+    expect(screen.queryAllByText('-')).toHaveLength(0);
   });
 
   it('should show error alert when there is an error', () => {

--- a/frontend/src/components/features/admin/PlatformMetricsContent.test.tsx
+++ b/frontend/src/components/features/admin/PlatformMetricsContent.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Tests for PlatformMetricsContent component
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PlatformMetricsContent } from './PlatformMetricsContent';
+import * as usePlatformMetricsModule from '@/hooks/api/usePlatformMetrics';
+import type { PlatformMetricsDto } from '@/types';
+import { MetricsPeriod } from '@/types';
+
+vi.mock('@/hooks/api/usePlatformMetrics');
+
+const mockMetrics: PlatformMetricsDto = {
+  totalReadings: 1500,
+  completedSessions: 87,
+  totalRevenueShare: 52500.0,
+  totalPlatformFee: 22500.0,
+  totalGrossRevenue: 75000.0,
+  activeTarotistas: 10,
+  activeUsers: 500,
+  period: {
+    start: new Date('2024-12-01T00:00:00Z'),
+    end: new Date('2024-12-31T23:59:59Z'),
+  },
+  topTarotistas: [
+    {
+      tarotistaId: 1,
+      nombrePublico: 'Luna Misteriosa',
+      totalReadings: 150,
+      completedSessions: 30,
+      totalRevenueShare: 5250.0,
+      totalPlatformFee: 2250.0,
+      totalGrossRevenue: 7500.0,
+      averageRating: 4.8,
+      totalReviews: 50,
+      period: {
+        start: new Date('2024-12-01T00:00:00Z'),
+        end: new Date('2024-12-31T23:59:59Z'),
+      },
+    },
+  ],
+};
+
+describe('PlatformMetricsContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render loading skeletons when isLoading is true', () => {
+    vi.mocked(usePlatformMetricsModule.usePlatformMetrics).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      isError: false,
+      isSuccess: false,
+    } as ReturnType<typeof usePlatformMetricsModule.usePlatformMetrics>);
+
+    render(<PlatformMetricsContent />);
+
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+  });
+
+  it('should render completedSessions value (not hardcoded 0)', () => {
+    vi.mocked(usePlatformMetricsModule.usePlatformMetrics).mockReturnValue({
+      data: mockMetrics,
+      isLoading: false,
+      error: null,
+      isError: false,
+      isSuccess: true,
+    } as ReturnType<typeof usePlatformMetricsModule.usePlatformMetrics>);
+
+    render(<PlatformMetricsContent />);
+
+    expect(screen.getByText('87')).toBeInTheDocument();
+  });
+
+  it('should NOT render "Próximamente" badge when completedSessions data is available', () => {
+    vi.mocked(usePlatformMetricsModule.usePlatformMetrics).mockReturnValue({
+      data: mockMetrics,
+      isLoading: false,
+      error: null,
+      isError: false,
+      isSuccess: true,
+    } as ReturnType<typeof usePlatformMetricsModule.usePlatformMetrics>);
+
+    render(<PlatformMetricsContent />);
+
+    expect(screen.queryByText('Próximamente')).not.toBeInTheDocument();
+  });
+
+  it('should render completedSessions in top tarotistas table', () => {
+    vi.mocked(usePlatformMetricsModule.usePlatformMetrics).mockReturnValue({
+      data: mockMetrics,
+      isLoading: false,
+      error: null,
+      isError: false,
+      isSuccess: true,
+    } as ReturnType<typeof usePlatformMetricsModule.usePlatformMetrics>);
+
+    render(<PlatformMetricsContent />);
+
+    // The tarotista row should show 30 sessions (not '-')
+    expect(screen.getByText('30')).toBeInTheDocument();
+  });
+
+  it('should NOT render "-" in sessions column when data is available', () => {
+    vi.mocked(usePlatformMetricsModule.usePlatformMetrics).mockReturnValue({
+      data: mockMetrics,
+      isLoading: false,
+      error: null,
+      isError: false,
+      isSuccess: true,
+    } as ReturnType<typeof usePlatformMetricsModule.usePlatformMetrics>);
+
+    render(<PlatformMetricsContent />);
+
+    // There should be no '-' text in the table cells
+    const cells = screen.queryAllByText('-');
+    expect(cells).toHaveLength(0);
+  });
+
+  it('should render completedSessions = 0 correctly (not hiding zero)', () => {
+    const metricsWithZeroSessions: PlatformMetricsDto = {
+      ...mockMetrics,
+      completedSessions: 0,
+      topTarotistas: [
+        {
+          ...mockMetrics.topTarotistas[0],
+          completedSessions: 0,
+        },
+      ],
+    };
+
+    vi.mocked(usePlatformMetricsModule.usePlatformMetrics).mockReturnValue({
+      data: metricsWithZeroSessions,
+      isLoading: false,
+      error: null,
+      isError: false,
+      isSuccess: true,
+    } as ReturnType<typeof usePlatformMetricsModule.usePlatformMetrics>);
+
+    render(<PlatformMetricsContent />);
+
+    // Should show 0, not '-' or 'Próximamente'
+    expect(screen.queryByText('Próximamente')).not.toBeInTheDocument();
+  });
+
+  it('should show error alert when there is an error', () => {
+    vi.mocked(usePlatformMetricsModule.usePlatformMetrics).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('API Error'),
+      isError: true,
+      isSuccess: false,
+    } as ReturnType<typeof usePlatformMetricsModule.usePlatformMetrics>);
+
+    render(<PlatformMetricsContent />);
+
+    expect(
+      screen.getByText('Error al cargar métricas. Por favor, intenta de nuevo.')
+    ).toBeInTheDocument();
+  });
+
+  it('should render period selector', () => {
+    vi.mocked(usePlatformMetricsModule.usePlatformMetrics).mockReturnValue({
+      data: mockMetrics,
+      isLoading: false,
+      error: null,
+      isError: false,
+      isSuccess: true,
+    } as ReturnType<typeof usePlatformMetricsModule.usePlatformMetrics>);
+
+    render(<PlatformMetricsContent />);
+
+    expect(screen.getByText('30 días')).toBeInTheDocument();
+  });
+
+  it('should render top tarotistas table with tarotista name', () => {
+    vi.mocked(usePlatformMetricsModule.usePlatformMetrics).mockReturnValue({
+      data: mockMetrics,
+      isLoading: false,
+      error: null,
+      isError: false,
+      isSuccess: true,
+    } as ReturnType<typeof usePlatformMetricsModule.usePlatformMetrics>);
+
+    render(<PlatformMetricsContent />);
+
+    expect(screen.getByText('Luna Misteriosa')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/admin/PlatformMetricsContent.tsx
+++ b/frontend/src/components/features/admin/PlatformMetricsContent.tsx
@@ -12,7 +12,6 @@ import { MetricsPeriod } from '@/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
 import {
   Select,
   SelectContent,
@@ -123,10 +122,10 @@ export function PlatformMetricsContent() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">0</div>
-                <p className="text-xs text-gray-500">
-                  <Badge variant="secondary">Próximamente</Badge>
-                </p>
+                <div className="text-2xl font-bold">
+                  {formatLargeNumber(metrics.completedSessions)}
+                </div>
+                <p className="text-xs text-gray-500">En el período seleccionado</p>
               </CardContent>
             </Card>
 
@@ -191,7 +190,9 @@ export function PlatformMetricsContent() {
                     <TableCell className="text-right">
                       {formatLargeNumber(tarotista.totalReadings)}
                     </TableCell>
-                    <TableCell className="text-right text-gray-500">-</TableCell>
+                    <TableCell className="text-right">
+                      {formatLargeNumber(tarotista.completedSessions)}
+                    </TableCell>
                     <TableCell className="text-right font-medium">
                       {formatCurrency(tarotista.totalGrossRevenue)}
                     </TableCell>

--- a/frontend/src/hooks/api/usePlatformMetrics.test.ts
+++ b/frontend/src/hooks/api/usePlatformMetrics.test.ts
@@ -39,6 +39,7 @@ describe('usePlatformMetrics', () => {
   it('should fetch platform metrics with default period (MONTH)', async () => {
     const mockData: PlatformMetricsDto = {
       totalReadings: 1500,
+      completedSessions: 120,
       totalRevenueShare: 52500.0,
       totalPlatformFee: 22500.0,
       totalGrossRevenue: 75000.0,
@@ -53,6 +54,7 @@ describe('usePlatformMetrics', () => {
           tarotistaId: 1,
           nombrePublico: 'Luna Misteriosa',
           totalReadings: 150,
+          completedSessions: 30,
           totalRevenueShare: 5250.0,
           totalPlatformFee: 2250.0,
           totalGrossRevenue: 7500.0,
@@ -87,6 +89,7 @@ describe('usePlatformMetrics', () => {
   it('should fetch platform metrics with WEEK period', async () => {
     const mockData: PlatformMetricsDto = {
       totalReadings: 350,
+      completedSessions: 40,
       totalRevenueShare: 12250.0,
       totalPlatformFee: 5250.0,
       totalGrossRevenue: 17500.0,
@@ -116,6 +119,7 @@ describe('usePlatformMetrics', () => {
   it('should fetch platform metrics with custom date range', async () => {
     const mockData: PlatformMetricsDto = {
       totalReadings: 500,
+      completedSessions: 60,
       totalRevenueShare: 17500.0,
       totalPlatformFee: 7500.0,
       totalGrossRevenue: 25000.0,
@@ -167,6 +171,7 @@ describe('usePlatformMetrics', () => {
   it('should refetch when period changes', async () => {
     const mockDataMonth: PlatformMetricsDto = {
       totalReadings: 1500,
+      completedSessions: 120,
       totalRevenueShare: 52500.0,
       totalPlatformFee: 22500.0,
       totalGrossRevenue: 75000.0,
@@ -181,6 +186,7 @@ describe('usePlatformMetrics', () => {
 
     const mockDataWeek: PlatformMetricsDto = {
       totalReadings: 350,
+      completedSessions: 40,
       totalRevenueShare: 12250.0,
       totalPlatformFee: 5250.0,
       totalGrossRevenue: 17500.0,
@@ -222,6 +228,7 @@ describe('usePlatformMetrics', () => {
   it('should use default period MONTH when no period provided', async () => {
     const mockData: PlatformMetricsDto = {
       totalReadings: 1500,
+      completedSessions: 120,
       totalRevenueShare: 52500.0,
       totalPlatformFee: 22500.0,
       totalGrossRevenue: 75000.0,

--- a/frontend/src/types/platform-metrics.types.ts
+++ b/frontend/src/types/platform-metrics.types.ts
@@ -29,6 +29,7 @@ export interface TarotistaMetricsDto {
   tarotistaId: number;
   nombrePublico: string;
   totalReadings: number;
+  completedSessions: number;
   totalRevenueShare: number;
   totalPlatformFee: number;
   totalGrossRevenue: number;
@@ -42,6 +43,7 @@ export interface TarotistaMetricsDto {
 
 export interface PlatformMetricsDto {
   totalReadings: number;
+  completedSessions: number;
   totalRevenueShare: number;
   totalPlatformFee: number;
   totalGrossRevenue: number;


### PR DESCRIPTION
## Descripción

Implementa el consumo de  reales en la página `/admin/metricas`, eliminando el valor hardcoded `0` y el badge "Próximamente".

## Cambios

- **Tipos:** Agrega `completedSessions: number` a `PlatformMetricsDto` y `TarotistaMetricsDto`
- **Componente:** `PlatformMetricsContent.tsx` — tarjeta "Sesiones Completadas" usa `metrics.completedSessions`; columna "Sesiones" en la tabla usa `tarotista.completedSessions`
- **Tests:** Crea `PlatformMetricsContent.test.tsx` con 9 tests TDD; actualiza mocks en `usePlatformMetrics.test.ts` y `page.test.tsx` para incluir el nuevo campo

## Validaciones

- [x] 24 tests de métricas pasando
- [x] `npm run format` ✅
- [x] `npm run lint:fix` ✅ (0 errors)
- [x] `npm run type-check` ✅
- [x] `npm run build` ✅
- [x] `node scripts/validate-architecture.js` ✅
- [x] Backlog actualizado

## Dependencias

Depende de T-ADM-002-A (backend ya completado en `feature/T-ADM-002-A-completed-sessions-metrics`).

## Referencia

Cubre hallazgo **ADM-002** de `BACKLOG_ADMIN_AUDIT_2026_05.md`