### PR TITLE
feat(security): T-ADM-004 — Estandarizar paginación de Security Events

### DIFF
--- a/backend/tarot-app/src/modules/security/security-event.service.spec.ts
+++ b/backend/tarot-app/src/modules/security/security-event.service.spec.ts
@@ -1,0 +1,218 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SecurityEventService } from './security-event.service';
+import { SecurityEvent } from './entities/security-event.entity';
+import { SecurityEventType } from './enums/security-event-type.enum';
+import { SecurityEventSeverity } from './enums/security-event-severity.enum';
+import { LoggerService } from '../../common/logger/logger.service';
+
+describe('SecurityEventService', () => {
+  let service: SecurityEventService;
+
+  const mockEvent = {
+    id: 'abc-123',
+    eventType: SecurityEventType.FAILED_LOGIN,
+    userId: 1,
+    ipAddress: '192.168.1.1',
+    userAgent: null,
+    severity: SecurityEventSeverity.MEDIUM,
+    details: { message: 'Login failed' },
+    createdAt: new Date('2026-01-01T10:00:00Z'),
+    user: null,
+  };
+
+  const mockRepository: jest.Mocked<
+    Pick<
+      Repository<SecurityEvent>,
+      'create' | 'save' | 'findAndCount' | 'count'
+    >
+  > = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findAndCount: jest.fn(),
+    count: jest.fn(),
+  };
+
+  const mockLogger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+    log: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SecurityEventService,
+        {
+          provide: getRepositoryToken(SecurityEvent),
+          useValue: mockRepository,
+        },
+        {
+          provide: LoggerService,
+          useValue: mockLogger,
+        },
+      ],
+    }).compile();
+
+    service = module.get<SecurityEventService>(SecurityEventService);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should return standard paginated contract {data, meta: {page, limit, totalItems, totalPages}}', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[mockEvent], 1]);
+
+      const result = await service.findAll({ page: 1, limit: 20 });
+
+      expect(result).toEqual({
+        data: [mockEvent],
+        meta: {
+          page: 1,
+          limit: 20,
+          totalItems: 1,
+          totalPages: 1,
+        },
+      });
+    });
+
+    it('should NOT use events key or currentPage/itemsPerPage in response', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[mockEvent], 1]);
+
+      const result = await service.findAll({ page: 1, limit: 20 });
+
+      expect(result).not.toHaveProperty('events');
+      expect(result.meta).not.toHaveProperty('currentPage');
+      expect(result.meta).not.toHaveProperty('itemsPerPage');
+    });
+
+    it('should calculate totalPages correctly', async () => {
+      mockRepository.findAndCount.mockResolvedValue([
+        [mockEvent, mockEvent, mockEvent],
+        25,
+      ]);
+
+      const result = await service.findAll({ page: 1, limit: 10 });
+
+      expect(result.meta.totalPages).toBe(3);
+      expect(result.meta.totalItems).toBe(25);
+    });
+
+    it('should return page 1 with no events when there are none', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      const result = await service.findAll({ page: 1, limit: 20 });
+
+      expect(result.data).toHaveLength(0);
+      expect(result.meta.totalItems).toBe(0);
+      expect(result.meta.totalPages).toBe(0);
+    });
+
+    it('should apply pagination skip correctly for page 2', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[mockEvent], 21]);
+
+      await service.findAll({ page: 2, limit: 10 });
+
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 10, take: 10 }),
+      );
+    });
+
+    it('should filter by userId when provided', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({ userId: 5, page: 1, limit: 20 });
+
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ userId: 5 }),
+        }),
+      );
+    });
+
+    it('should filter by eventType when provided', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({
+        eventType: SecurityEventType.FAILED_LOGIN,
+        page: 1,
+        limit: 20,
+      });
+
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            eventType: SecurityEventType.FAILED_LOGIN,
+          }),
+        }),
+      );
+    });
+
+    it('should filter by severity when provided', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({
+        severity: SecurityEventSeverity.CRITICAL,
+        page: 1,
+        limit: 20,
+      });
+
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            severity: SecurityEventSeverity.CRITICAL,
+          }),
+        }),
+      );
+    });
+
+    it('should default to page 1 and limit 20 when not provided', async () => {
+      mockRepository.findAndCount.mockResolvedValue([[], 0]);
+
+      await service.findAll({});
+
+      expect(mockRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 20 }),
+      );
+    });
+  });
+
+  describe('logSecurityEvent', () => {
+    it('should create and save a security event', async () => {
+      mockRepository.create.mockReturnValue(mockEvent);
+      mockRepository.save.mockResolvedValue(mockEvent);
+
+      const dto = {
+        eventType: SecurityEventType.FAILED_LOGIN,
+        severity: SecurityEventSeverity.MEDIUM,
+        ipAddress: '192.168.1.1',
+        details: { message: 'Test' },
+      };
+
+      const result = await service.logSecurityEvent(dto);
+
+      expect(mockRepository.create).toHaveBeenCalledWith(dto);
+      expect(mockRepository.save).toHaveBeenCalledWith(mockEvent);
+      expect(result).toEqual(mockEvent);
+    });
+  });
+
+  describe('detectSuspiciousActivity', () => {
+    it('should return true when failed attempts >= 5', async () => {
+      mockRepository.count.mockResolvedValue(5);
+      const result = await service.detectSuspiciousActivity('192.168.1.1');
+      expect(result).toBe(true);
+    });
+
+    it('should return false when failed attempts < 5', async () => {
+      mockRepository.count.mockResolvedValue(4);
+      const result = await service.detectSuspiciousActivity('192.168.1.1');
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/backend/tarot-app/src/modules/security/security-event.service.ts
+++ b/backend/tarot-app/src/modules/security/security-event.service.ts
@@ -15,10 +15,10 @@ import { SecurityEventSeverity } from './enums/security-event-severity.enum';
 import { LoggerService } from '../../common/logger/logger.service';
 
 export interface SecurityEventListResponse {
-  events: SecurityEvent[];
+  data: SecurityEvent[];
   meta: {
-    currentPage: number;
-    itemsPerPage: number;
+    page: number;
+    limit: number;
     totalItems: number;
     totalPages: number;
   };
@@ -130,10 +130,10 @@ export class SecurityEventService {
       });
 
     return {
-      events,
+      data: events,
       meta: {
-        currentPage: page,
-        itemsPerPage: limit,
+        page,
+        limit,
         totalItems,
         totalPages: Math.ceil(totalItems / limit),
       },

--- a/backend/tarot-app/src/modules/security/security-events.controller.spec.ts
+++ b/backend/tarot-app/src/modules/security/security-events.controller.spec.ts
@@ -20,10 +20,10 @@ describe('SecurityEventsController', () => {
 
   const mockService = {
     findAll: jest.fn().mockResolvedValue({
-      events: [mockEvent],
+      data: [mockEvent],
       meta: {
-        currentPage: 1,
-        itemsPerPage: 20,
+        page: 1,
+        limit: 20,
         totalItems: 1,
         totalPages: 1,
       },
@@ -52,7 +52,7 @@ describe('SecurityEventsController', () => {
   });
 
   describe('findAll', () => {
-    it('should return paginated security events', async () => {
+    it('should return paginated security events with standard contract', async () => {
       const query = {
         page: 1,
         limit: 20,
@@ -62,14 +62,30 @@ describe('SecurityEventsController', () => {
 
       expect(service.findAll).toHaveBeenCalledWith(query);
       expect(result).toEqual({
-        events: [mockEvent],
+        data: [mockEvent],
         meta: {
-          currentPage: 1,
-          itemsPerPage: 20,
+          page: 1,
+          limit: 20,
           totalItems: 1,
           totalPages: 1,
         },
       });
+    });
+
+    it('should use data key (not events) in response', async () => {
+      const query = { page: 1, limit: 20 };
+      const result = await controller.findAll(query);
+      expect(result).toHaveProperty('data');
+      expect(result).not.toHaveProperty('events');
+    });
+
+    it('should use page and limit keys in meta (not currentPage/itemsPerPage)', async () => {
+      const query = { page: 1, limit: 20 };
+      const result = await controller.findAll(query);
+      expect(result.meta).toHaveProperty('page');
+      expect(result.meta).toHaveProperty('limit');
+      expect(result.meta).not.toHaveProperty('currentPage');
+      expect(result.meta).not.toHaveProperty('itemsPerPage');
     });
 
     it('should filter by eventType', async () => {

--- a/docs/BACKLOG_ADMIN_AUDIT_2026_05.md
+++ b/docs/BACKLOG_ADMIN_AUDIT_2026_05.md
@@ -475,26 +475,32 @@ El backend expone un CRUD de IP whitelist (`GET/POST/DELETE /admin/ip-whitelist`
 **Estimación:** 3 puntos
 **Dependencias:** ninguna
 **Cubre hallazgo:** ADM-004
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] Backend: refactor `SecurityEventService.findAll` para devolver `{ data, meta: { page, limit, totalItems, totalPages } }`.
-- [ ] Actualizar `QuerySecurityEventDto` / tipos de respuesta si aplica.
-- [ ] Frontend: adaptar `SecurityEventsTab.tsx` (`data.data`, `meta.page/limit`) y `admin-security.types.ts`.
-- [ ] Actualizar tests de controller, servicio y componente.
-- [ ] Ciclos de calidad backend y frontend.
+- [x] Backend: refactor `SecurityEventService.findAll` para devolver `{ data, meta: { page, limit, totalItems, totalPages } }`.
+- [x] Actualizar `SecurityEventListResponse` (interface interna del servicio).
+- [x] Frontend: adaptar `SecurityEventsTab.tsx` (`data.data`, `meta.page/limit`) y `admin-security.types.ts`.
+- [x] Actualizar tests de controller, servicio y componente (incluyendo `useAdminSecurity.test.ts` y `admin-security-api.test.ts`).
+- [x] Crear `security-event.service.spec.ts` (nuevo — 13 tests cubriendo findAll, logSecurityEvent, detectSuspiciousActivity).
+- [x] Ciclos de calidad backend y frontend completos.
 
 #### 🎯 Criterios de Aceptación
 
-- [ ] El endpoint y el componente usan el contrato estándar del proyecto.
-- [ ] La pestaña "Eventos de Seguridad" pagina correctamente sin regresiones.
+- [x] El endpoint y el componente usan el contrato estándar del proyecto.
+- [x] La pestaña "Eventos de Seguridad" pagina correctamente sin regresiones.
 
 #### 📁 Archivos involucrados
 
-- `backend/tarot-app/src/modules/security/security-event.service.ts` + spec
-- `backend/tarot-app/src/modules/security/security-events.controller.ts` + spec
-- `frontend/src/components/features/admin/SecurityEventsTab.tsx` + test
-- `frontend/src/types/admin-security.types.ts`
+- `backend/tarot-app/src/modules/security/security-event.service.ts` (modificado)
+- `backend/tarot-app/src/modules/security/security-event.service.spec.ts` (nuevo)
+- `backend/tarot-app/src/modules/security/security-events.controller.spec.ts` (actualizado)
+- `frontend/src/components/features/admin/SecurityEventsTab.tsx` (modificado)
+- `frontend/src/components/features/admin/SecurityEventsTab.test.tsx` (nuevo)
+- `frontend/src/types/admin-security.types.ts` (modificado)
+- `frontend/src/hooks/api/useAdminSecurity.test.ts` (actualizado)
+- `frontend/src/lib/api/admin-security-api.test.ts` (actualizado)
 
 ---
 

--- a/frontend/src/components/features/admin/SecurityEventsTab.test.tsx
+++ b/frontend/src/components/features/admin/SecurityEventsTab.test.tsx
@@ -10,8 +10,10 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createElement } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
 import { SecurityEventsTab } from './SecurityEventsTab';
 import * as useAdminSecurity from '@/hooks/api/useAdminSecurity';
+import type { SecurityEventsResponse } from '@/types/admin-security.types';
 
 vi.mock('@/hooks/api/useAdminSecurity');
 
@@ -38,14 +40,44 @@ const mockEvent = {
   createdAt: '2026-01-01T10:00:00Z',
 };
 
+/** Helper para construir un mock tipado de UseQueryResult sin repetir boilerplate */
+function mockQueryResult(
+  overrides: Partial<UseQueryResult<SecurityEventsResponse, Error>>
+): UseQueryResult<SecurityEventsResponse, Error> {
+  return {
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    isSuccess: false,
+    isPending: false,
+    isFetching: false,
+    isFetched: false,
+    isFetchedAfterMount: false,
+    isLoadingError: false,
+    isRefetchError: false,
+    isPlaceholderData: false,
+    isStale: false,
+    isRefetching: false,
+    isInitialLoading: false,
+    status: 'pending',
+    fetchStatus: 'idle',
+    error: null,
+    errorUpdateCount: 0,
+    errorUpdatedAt: 0,
+    dataUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    refetch: vi.fn(),
+    promise: Promise.resolve({} as SecurityEventsResponse),
+    ...overrides,
+  } as UseQueryResult<SecurityEventsResponse, Error>;
+}
+
 describe('SecurityEventsTab', () => {
   it('should render loading state', () => {
-    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      isError: false,
-      refetch: vi.fn(),
-    } as never);
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue(
+      mockQueryResult({ data: undefined, isLoading: true, isError: false })
+    );
 
     render(<SecurityEventsTab />, { wrapper: createWrapper() });
 
@@ -54,12 +86,9 @@ describe('SecurityEventsTab', () => {
   });
 
   it('should render error state', () => {
-    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      isError: true,
-      refetch: vi.fn(),
-    } as never);
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue(
+      mockQueryResult({ data: undefined, isLoading: false, isError: true })
+    );
 
     render(<SecurityEventsTab />, { wrapper: createWrapper() });
 
@@ -67,20 +96,16 @@ describe('SecurityEventsTab', () => {
   });
 
   it('should render events from data.data (standard contract)', () => {
-    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
-      data: {
-        data: [mockEvent],
-        meta: {
-          page: 1,
-          limit: 10,
-          totalItems: 1,
-          totalPages: 1,
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue(
+      mockQueryResult({
+        data: {
+          data: [mockEvent],
+          meta: { page: 1, limit: 10, totalItems: 1, totalPages: 1 },
         },
-      },
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as never);
+        isLoading: false,
+        isError: false,
+      })
+    );
 
     render(<SecurityEventsTab />, { wrapper: createWrapper() });
 
@@ -89,20 +114,16 @@ describe('SecurityEventsTab', () => {
   });
 
   it('should render empty state when data.data is empty', () => {
-    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
-      data: {
-        data: [],
-        meta: {
-          page: 1,
-          limit: 10,
-          totalItems: 0,
-          totalPages: 0,
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue(
+      mockQueryResult({
+        data: {
+          data: [],
+          meta: { page: 1, limit: 10, totalItems: 0, totalPages: 0 },
         },
-      },
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as never);
+        isLoading: false,
+        isError: false,
+      })
+    );
 
     render(<SecurityEventsTab />, { wrapper: createWrapper() });
 
@@ -115,20 +136,16 @@ describe('SecurityEventsTab', () => {
       id: `event-${i}`,
     }));
 
-    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
-      data: {
-        data: mockEvents,
-        meta: {
-          page: 1,
-          limit: 10,
-          totalItems: 25,
-          totalPages: 3,
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue(
+      mockQueryResult({
+        data: {
+          data: mockEvents,
+          meta: { page: 1, limit: 10, totalItems: 25, totalPages: 3 },
         },
-      },
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as never);
+        isLoading: false,
+        isError: false,
+      })
+    );
 
     render(<SecurityEventsTab />, { wrapper: createWrapper() });
 
@@ -137,20 +154,16 @@ describe('SecurityEventsTab', () => {
   });
 
   it('should NOT render pagination buttons when totalPages <= 1', () => {
-    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
-      data: {
-        data: [mockEvent],
-        meta: {
-          page: 1,
-          limit: 10,
-          totalItems: 1,
-          totalPages: 1,
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue(
+      mockQueryResult({
+        data: {
+          data: [mockEvent],
+          meta: { page: 1, limit: 10, totalItems: 1, totalPages: 1 },
         },
-      },
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as never);
+        isLoading: false,
+        isError: false,
+      })
+    );
 
     render(<SecurityEventsTab />, { wrapper: createWrapper() });
 
@@ -160,15 +173,16 @@ describe('SecurityEventsTab', () => {
   it('should clear filters when Limpiar Filtros is clicked', async () => {
     const user = userEvent.setup();
 
-    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
-      data: {
-        data: [],
-        meta: { page: 1, limit: 10, totalItems: 0, totalPages: 0 },
-      },
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as never);
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue(
+      mockQueryResult({
+        data: {
+          data: [],
+          meta: { page: 1, limit: 10, totalItems: 0, totalPages: 0 },
+        },
+        isLoading: false,
+        isError: false,
+      })
+    );
 
     render(<SecurityEventsTab />, { wrapper: createWrapper() });
 
@@ -182,15 +196,16 @@ describe('SecurityEventsTab', () => {
   });
 
   it('should display severity badge with correct style', () => {
-    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
-      data: {
-        data: [{ ...mockEvent, severity: 'critical' as const }],
-        meta: { page: 1, limit: 10, totalItems: 1, totalPages: 1 },
-      },
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
-    } as never);
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue(
+      mockQueryResult({
+        data: {
+          data: [{ ...mockEvent, severity: 'critical' as const }],
+          meta: { page: 1, limit: 10, totalItems: 1, totalPages: 1 },
+        },
+        isLoading: false,
+        isError: false,
+      })
+    );
 
     render(<SecurityEventsTab />, { wrapper: createWrapper() });
 

--- a/frontend/src/components/features/admin/SecurityEventsTab.test.tsx
+++ b/frontend/src/components/features/admin/SecurityEventsTab.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Tests for SecurityEventsTab component
+ *
+ * Verifica que el componente consume el contrato estándar de paginación:
+ * { data: [...], meta: { page, limit, totalItems, totalPages } }
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SecurityEventsTab } from './SecurityEventsTab';
+import * as useAdminSecurity from '@/hooks/api/useAdminSecurity';
+
+vi.mock('@/hooks/api/useAdminSecurity');
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  Wrapper.displayName = 'QueryClientWrapper';
+  return Wrapper;
+};
+
+const mockEvent = {
+  id: 'abc-123',
+  eventType: 'failed_login' as const,
+  severity: 'medium' as const,
+  userId: 1,
+  ipAddress: '192.168.1.1',
+  details: 'Login failed',
+  createdAt: '2026-01-01T10:00:00Z',
+};
+
+describe('SecurityEventsTab', () => {
+  it('should render loading state', () => {
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      refetch: vi.fn(),
+    } as never);
+
+    render(<SecurityEventsTab />, { wrapper: createWrapper() });
+
+    // Skeletons visible
+    expect(document.querySelector('.animate-pulse')).toBeInTheDocument();
+  });
+
+  it('should render error state', () => {
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    } as never);
+
+    render(<SecurityEventsTab />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('Error al cargar eventos de seguridad')).toBeInTheDocument();
+  });
+
+  it('should render events from data.data (standard contract)', () => {
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
+      data: {
+        data: [mockEvent],
+        meta: {
+          page: 1,
+          limit: 10,
+          totalItems: 1,
+          totalPages: 1,
+        },
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as never);
+
+    render(<SecurityEventsTab />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('failed login')).toBeInTheDocument();
+    expect(screen.getByText('192.168.1.1')).toBeInTheDocument();
+  });
+
+  it('should render empty state when data.data is empty', () => {
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
+      data: {
+        data: [],
+        meta: {
+          page: 1,
+          limit: 10,
+          totalItems: 0,
+          totalPages: 0,
+        },
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as never);
+
+    render(<SecurityEventsTab />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('Sin eventos')).toBeInTheDocument();
+  });
+
+  it('should show pagination when totalPages > 1', () => {
+    const mockEvents = Array.from({ length: 10 }, (_, i) => ({
+      ...mockEvent,
+      id: `event-${i}`,
+    }));
+
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
+      data: {
+        data: mockEvents,
+        meta: {
+          page: 1,
+          limit: 10,
+          totalItems: 25,
+          totalPages: 3,
+        },
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as never);
+
+    render(<SecurityEventsTab />, { wrapper: createWrapper() });
+
+    // Pagination buttons should be visible (Anterior/Siguiente)
+    expect(screen.getByRole('button', { name: /anterior/i })).toBeInTheDocument();
+  });
+
+  it('should NOT render pagination buttons when totalPages <= 1', () => {
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
+      data: {
+        data: [mockEvent],
+        meta: {
+          page: 1,
+          limit: 10,
+          totalItems: 1,
+          totalPages: 1,
+        },
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as never);
+
+    render(<SecurityEventsTab />, { wrapper: createWrapper() });
+
+    expect(screen.queryByRole('button', { name: /anterior/i })).not.toBeInTheDocument();
+  });
+
+  it('should clear filters when Limpiar Filtros is clicked', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
+      data: {
+        data: [],
+        meta: { page: 1, limit: 10, totalItems: 0, totalPages: 0 },
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as never);
+
+    render(<SecurityEventsTab />, { wrapper: createWrapper() });
+
+    const clearButton = screen.getByRole('button', { name: /limpiar filtros/i });
+    await user.click(clearButton);
+
+    // After clearing, hook should be called with default filters
+    expect(useAdminSecurity.useSecurityEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1, limit: 10 })
+    );
+  });
+
+  it('should display severity badge with correct style', () => {
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
+      data: {
+        data: [{ ...mockEvent, severity: 'critical' as const }],
+        meta: { page: 1, limit: 10, totalItems: 1, totalPages: 1 },
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as never);
+
+    render(<SecurityEventsTab />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('CRITICAL')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/admin/SecurityEventsTab.tsx
+++ b/frontend/src/components/features/admin/SecurityEventsTab.tsx
@@ -88,7 +88,7 @@ export function SecurityEventsTab() {
     );
   }
 
-  const events = data?.events ?? [];
+  const events = data?.data ?? [];
   const meta = data?.meta;
 
   return (
@@ -240,10 +240,10 @@ export function SecurityEventsTab() {
               {meta && meta.totalPages > 1 && (
                 <div className="mt-6">
                   <Pagination
-                    currentPage={meta.currentPage}
+                    currentPage={meta.page}
                     totalPages={meta.totalPages}
                     totalItems={meta.totalItems}
-                    limit={meta.itemsPerPage}
+                    limit={meta.limit}
                     onPageChange={handlePageChange}
                   />
                 </div>

--- a/frontend/src/hooks/api/useAdminSecurity.test.ts
+++ b/frontend/src/hooks/api/useAdminSecurity.test.ts
@@ -76,7 +76,7 @@ describe('useAdminSecurity hooks', () => {
       };
 
       const mockData = {
-        events: [
+        data: [
           {
             id: 'uuid-123',
             eventType: 'failed_login' as const,
@@ -88,8 +88,8 @@ describe('useAdminSecurity hooks', () => {
           },
         ],
         meta: {
-          currentPage: 1,
-          itemsPerPage: 10,
+          page: 1,
+          limit: 10,
           totalItems: 1,
           totalPages: 1,
         },
@@ -102,8 +102,8 @@ describe('useAdminSecurity hooks', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
       expect(result.current.data).toEqual(mockData);
-      expect(result.current.data?.events).toHaveLength(1);
-      expect(result.current.data?.events[0].ipAddress).toBe('192.168.1.50');
+      expect(result.current.data?.data).toHaveLength(1);
+      expect(result.current.data?.data[0].ipAddress).toBe('192.168.1.50');
       expect(securityApi.fetchSecurityEvents).toHaveBeenCalledWith(filters);
     });
   });

--- a/frontend/src/lib/api/admin-security-api.test.ts
+++ b/frontend/src/lib/api/admin-security-api.test.ts
@@ -69,7 +69,7 @@ describe('admin-security-api', () => {
       };
 
       const mockData: SecurityEventsResponse = {
-        events: [
+        data: [
           {
             id: 'uuid-123',
             eventType: 'failed_login',
@@ -81,8 +81,8 @@ describe('admin-security-api', () => {
           },
         ],
         meta: {
-          currentPage: 1,
-          itemsPerPage: 10,
+          page: 1,
+          limit: 10,
           totalItems: 1,
           totalPages: 1,
         },
@@ -96,16 +96,16 @@ describe('admin-security-api', () => {
         params: filters,
       });
       expect(result).toEqual(mockData);
-      expect(result.events).toHaveLength(1);
+      expect(result.data).toHaveLength(1);
       expect(result.meta.totalItems).toBe(1);
     });
 
     it('should fetch security events without filters', async () => {
       const mockData: SecurityEventsResponse = {
-        events: [],
+        data: [],
         meta: {
-          currentPage: 1,
-          itemsPerPage: 10,
+          page: 1,
+          limit: 10,
           totalItems: 0,
           totalPages: 0,
         },
@@ -118,7 +118,7 @@ describe('admin-security-api', () => {
       expect(apiClient.get).toHaveBeenCalledWith('/admin/security/events', {
         params: {},
       });
-      expect(result.events).toHaveLength(0);
+      expect(result.data).toHaveLength(0);
     });
   });
 });

--- a/frontend/src/lib/api/admin-security-api.test.ts
+++ b/frontend/src/lib/api/admin-security-api.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { apiClient } from './axios-config';
 import { fetchRateLimitData, fetchSecurityEvents } from './admin-security-api';
+import { API_ENDPOINTS } from './endpoints';
 import type { RateLimitResponse, SecurityEventsResponse } from '@/types/admin-security.types';
 
 vi.mock('./axios-config');
@@ -92,7 +93,7 @@ describe('admin-security-api', () => {
 
       const result = await fetchSecurityEvents(filters);
 
-      expect(apiClient.get).toHaveBeenCalledWith('/admin/security/events', {
+      expect(apiClient.get).toHaveBeenCalledWith(API_ENDPOINTS.ADMIN.SECURITY_EVENTS, {
         params: filters,
       });
       expect(result).toEqual(mockData);
@@ -115,7 +116,7 @@ describe('admin-security-api', () => {
 
       const result = await fetchSecurityEvents();
 
-      expect(apiClient.get).toHaveBeenCalledWith('/admin/security/events', {
+      expect(apiClient.get).toHaveBeenCalledWith(API_ENDPOINTS.ADMIN.SECURITY_EVENTS, {
         params: {},
       });
       expect(result.data).toHaveLength(0);

--- a/frontend/src/types/admin-security.types.ts
+++ b/frontend/src/types/admin-security.types.ts
@@ -83,12 +83,15 @@ export interface SecurityEventFilters {
 
 /**
  * Respuesta paginada de eventos de seguridad
+ *
+ * Contrato estándar del proyecto: { data, meta: { page, limit, totalItems, totalPages } }
+ * (Alineado con AuditLogsContent y el resto de tablas paginadas)
  */
 export interface SecurityEventsResponse {
-  events: SecurityEvent[];
+  data: SecurityEvent[];
   meta: {
-    currentPage: number;
-    itemsPerPage: number;
+    page: number;
+    limit: number;
     totalItems: number;
     totalPages: number;
   };


### PR DESCRIPTION
## T-ADM-004: Estandarizar Paginación de Security Events

Cubre hallazgo **ADM-004** del backlog `BACKLOG_ADMIN_AUDIT_2026_05.md`.

## Problema

`GET /admin/security/events` retornaba `{ events: [...], meta: { currentPage, itemsPerPage, ... } }`, incumpliendo el contrato estándar del proyecto.

## Solución

### Backend
- Cambia `SecurityEventListResponse` de `{events, meta.currentPage/itemsPerPage}` → `{data, meta.page/limit}`
- Nuevo `security-event.service.spec.ts` con 13 tests (findAll, logSecurityEvent, detectSuspiciousActivity)
- Actualiza `security-events.controller.spec.ts` con nuevo contrato

### Frontend
- Actualiza `SecurityEventsResponse` en `admin-security.types.ts`
- Adapta `SecurityEventsTab.tsx`: lee `data.data` y `meta.page/limit`
- Nuevo `SecurityEventsTab.test.tsx` con 8 tests
- Actualiza `useAdminSecurity.test.ts` y `admin-security-api.test.ts`

## Validaciones ✅

- [x] Tests backend: 19 tests pasan (service + controller)
- [x] Tests frontend: 13 tests pasan (tab + hook + api)
- [x] `npm run lint` sin errores
- [x] `npm run build` exitoso (backend y frontend)
- [x] `node scripts/validate-architecture.js` pasa (backend y frontend)
- [x] Módulo security: 81.81% statements, 80.64% lines (≥ 80%)
- [x] Backlog actualizado con estado ✅ COMPLETADA