### PR TITLE
feat(seguridad): agregar pestaña IP Whitelist en panel admin (T-ADM-006)

### DIFF
--- a/docs/BACKLOG_ADMIN_AUDIT_2026_05.md
+++ b/docs/BACKLOG_ADMIN_AUDIT_2026_05.md
@@ -535,17 +535,18 @@ El backend expone un CRUD de IP whitelist (`GET/POST/DELETE /admin/ip-whitelist`
 **Estimación:** 3 puntos
 **Dependencias:** confirmar que la whitelist debe gestionarse por UI (y no solo por infra/seed)
 **Cubre hallazgo:** ADM-006
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] Crear `lib/api/admin-ip-whitelist-api.ts` + entradas en `API_ENDPOINTS` (`/admin/ip-whitelist`).
-- [ ] Crear `hooks/api/useAdminIpWhitelist.ts` (list/add/remove).
-- [ ] Agregar pestaña "IP Whitelist" en `SecurityManagementContent.tsx` con tabla + alta/baja.
-- [ ] Tests + ciclo de calidad.
+- [x] Crear `lib/api/admin-ip-whitelist-api.ts` + entradas en `API_ENDPOINTS` (`/admin/ip-whitelist`).
+- [x] Crear `hooks/api/useAdminIpWhitelist.ts` (list/add/remove).
+- [x] Agregar pestaña "IP Whitelist" en `SecurityManagementContent.tsx` con tabla + alta/baja.
+- [x] Tests + ciclo de calidad (27 tests nuevos pasando; format, lint:fix, type-check, build, validate-architecture ✅).
 
 #### 🎯 Criterios de Aceptación
 
-- [ ] El admin puede listar, agregar y quitar IPs permitidas desde `/admin/seguridad`.
+- [x] El admin puede listar, agregar y quitar IPs permitidas desde `/admin/seguridad`.
 
 #### 📁 Archivos involucrados
 
@@ -554,6 +555,7 @@ El backend expone un CRUD de IP whitelist (`GET/POST/DELETE /admin/ip-whitelist`
 - `frontend/src/hooks/api/useAdminIpWhitelist.ts` (nuevo) + test
 - `frontend/src/lib/api/admin-ip-whitelist-api.ts` (nuevo) + test
 - `frontend/src/lib/api/endpoints.ts`
+- `frontend/src/types/admin-security.types.ts`
 
 ---
 

--- a/frontend/src/components/features/admin/IpWhitelistTab.test.tsx
+++ b/frontend/src/components/features/admin/IpWhitelistTab.test.tsx
@@ -79,11 +79,33 @@ describe('IpWhitelistTab', () => {
       expect(screen.getByTestId('whitelist-count')).toHaveTextContent('2');
     });
 
-    it('should render the add IP form', () => {
+    it('should render the add IP form with accessible label', () => {
       setupMocks();
       render(<IpWhitelistTab />);
       expect(screen.getByTestId('add-ip-input')).toBeInTheDocument();
       expect(screen.getByTestId('add-ip-button')).toBeInTheDocument();
+      // El input debe tener un label accesible asociado
+      const input = screen.getByLabelText(/dirección ip a agregar/i);
+      expect(input).toBeInTheDocument();
+    });
+  });
+
+  describe('system IPs (loopback)', () => {
+    it('should render system IPs with Sistema badge and no remove button', () => {
+      setupMocks({ ips: ['127.0.0.1', '::1', '::ffff:127.0.0.1', '10.0.0.1'], count: 4 });
+      render(<IpWhitelistTab />);
+
+      // Sistema badge visible para loopback IPs
+      const sistemaBadges = screen.getAllByText('Sistema');
+      expect(sistemaBadges).toHaveLength(3);
+
+      // No debe existir botón de eliminar para las IPs de sistema
+      expect(screen.queryByTestId('remove-ip-127.0.0.1')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('remove-ip-::1')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('remove-ip-::ffff:127.0.0.1')).not.toBeInTheDocument();
+
+      // Sí debe existir botón de eliminar para IPs no-sistema
+      expect(screen.getByTestId('remove-ip-10.0.0.1')).toBeInTheDocument();
     });
   });
 
@@ -121,6 +143,7 @@ describe('IpWhitelistTab', () => {
       render(<IpWhitelistTab />);
 
       const removeButton = screen.getByTestId('remove-ip-192.168.1.1');
+      expect(removeButton).toHaveAttribute('aria-label', 'Eliminar 192.168.1.1 de la whitelist');
       await userEvent.click(removeButton);
 
       expect(screen.getByRole('alertdialog')).toBeInTheDocument();

--- a/frontend/src/components/features/admin/IpWhitelistTab.test.tsx
+++ b/frontend/src/components/features/admin/IpWhitelistTab.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IpWhitelistTab } from './IpWhitelistTab';
+import * as useAdminIpWhitelistHooks from '@/hooks/api/useAdminIpWhitelist';
+import type { WhitelistResponse } from '@/types/admin-security.types';
+
+vi.mock('@/hooks/api/useAdminIpWhitelist');
+
+const mockUseIpWhitelist = vi.mocked(useAdminIpWhitelistHooks.useIpWhitelist);
+const mockUseAddIpToWhitelist = vi.mocked(useAdminIpWhitelistHooks.useAddIpToWhitelist);
+const mockUseRemoveIpFromWhitelist = vi.mocked(useAdminIpWhitelistHooks.useRemoveIpFromWhitelist);
+
+const mockMutate = vi.fn();
+
+function setupMocks(
+  whitelistData: Partial<WhitelistResponse> | null = { ips: ['192.168.1.1'], count: 1 },
+  options: { isLoading?: boolean; isError?: boolean } = {}
+) {
+  mockUseIpWhitelist.mockReturnValue({
+    data: whitelistData as WhitelistResponse,
+    isLoading: options.isLoading ?? false,
+    isError: options.isError ?? false,
+    refetch: vi.fn(),
+    isSuccess: !options.isLoading && !options.isError,
+  } as unknown as ReturnType<typeof useAdminIpWhitelistHooks.useIpWhitelist>);
+
+  mockUseAddIpToWhitelist.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof useAdminIpWhitelistHooks.useAddIpToWhitelist>);
+
+  mockUseRemoveIpFromWhitelist.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof useAdminIpWhitelistHooks.useRemoveIpFromWhitelist>);
+}
+
+describe('IpWhitelistTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('loading state', () => {
+    it('should render skeleton while loading', () => {
+      setupMocks(null, { isLoading: true });
+      render(<IpWhitelistTab />);
+      expect(screen.getByTestId('skeleton-whitelist')).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('should render error display when fetch fails', () => {
+      setupMocks(null, { isError: true });
+      render(<IpWhitelistTab />);
+      expect(screen.getByTestId('error-whitelist')).toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', () => {
+    it('should show empty message when no IPs are configured', () => {
+      setupMocks({ ips: [], count: 0 });
+      render(<IpWhitelistTab />);
+      expect(screen.getByTestId('empty-whitelist')).toBeInTheDocument();
+    });
+  });
+
+  describe('with data', () => {
+    it('should render the list of whitelisted IPs', () => {
+      setupMocks({ ips: ['192.168.1.1', '10.0.0.1'], count: 2 });
+      render(<IpWhitelistTab />);
+      expect(screen.getByText('192.168.1.1')).toBeInTheDocument();
+      expect(screen.getByText('10.0.0.1')).toBeInTheDocument();
+    });
+
+    it('should show the count of whitelisted IPs', () => {
+      setupMocks({ ips: ['192.168.1.1', '10.0.0.1'], count: 2 });
+      render(<IpWhitelistTab />);
+      expect(screen.getByTestId('whitelist-count')).toHaveTextContent('2');
+    });
+
+    it('should render the add IP form', () => {
+      setupMocks();
+      render(<IpWhitelistTab />);
+      expect(screen.getByTestId('add-ip-input')).toBeInTheDocument();
+      expect(screen.getByTestId('add-ip-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('add IP flow', () => {
+    it('should call addIp mutation when form is submitted with valid IP', async () => {
+      setupMocks();
+      render(<IpWhitelistTab />);
+
+      const input = screen.getByTestId('add-ip-input');
+      const button = screen.getByTestId('add-ip-button');
+
+      await userEvent.type(input, '203.0.113.45');
+      await userEvent.click(button);
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        { ip: '203.0.113.45' },
+        expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+      );
+    });
+
+    it('should not submit when IP input is empty', async () => {
+      setupMocks();
+      render(<IpWhitelistTab />);
+
+      const button = screen.getByTestId('add-ip-button');
+      await userEvent.click(button);
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove IP flow', () => {
+    it('should show confirm dialog when remove button is clicked', async () => {
+      setupMocks({ ips: ['192.168.1.1'], count: 1 });
+      render(<IpWhitelistTab />);
+
+      const removeButton = screen.getByTestId('remove-ip-192.168.1.1');
+      await userEvent.click(removeButton);
+
+      expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+      expect(screen.getByRole('alertdialog')).toHaveTextContent('192.168.1.1');
+    });
+
+    it('should call removeIp mutation when confirmed', async () => {
+      setupMocks({ ips: ['192.168.1.1'], count: 1 });
+      render(<IpWhitelistTab />);
+
+      const removeButton = screen.getByTestId('remove-ip-192.168.1.1');
+      await userEvent.click(removeButton);
+
+      const confirmButton = screen.getByRole('button', { name: /eliminar/i });
+      await userEvent.click(confirmButton);
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        { ip: '192.168.1.1' },
+        expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+      );
+    });
+
+    it('should close dialog when cancelled', async () => {
+      setupMocks({ ips: ['192.168.1.1'], count: 1 });
+      render(<IpWhitelistTab />);
+
+      const removeButton = screen.getByTestId('remove-ip-192.168.1.1');
+      await userEvent.click(removeButton);
+
+      const cancelButton = screen.getByRole('button', { name: /cancelar/i });
+      await userEvent.click(cancelButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/components/features/admin/IpWhitelistTab.tsx
+++ b/frontend/src/components/features/admin/IpWhitelistTab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Shield, Trash2, Plus } from 'lucide-react';
+import { Shield, Trash2, Plus, Lock } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   useIpWhitelist,
@@ -11,6 +11,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -31,7 +32,12 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { WhitelistActionResponse } from '@/types/admin-security.types';
+
+// IPs que el servicio siempre incluye como entradas de sistema (loopback).
+// No se permiten eliminar desde la UI para evitar romper la whitelist interna.
+const SYSTEM_IPS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
 
 export function IpWhitelistTab() {
   const [newIp, setNewIp] = useState('');
@@ -117,16 +123,22 @@ export function IpWhitelistTab() {
         </CardHeader>
         <CardContent>
           <div className="flex gap-2">
-            <Input
-              data-testid="add-ip-input"
-              placeholder="Ej: 203.0.113.45 o 2001:db8::1"
-              value={newIp}
-              onChange={(e) => setNewIp(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleAdd();
-              }}
-              disabled={isAdding}
-            />
+            <div className="flex flex-1 flex-col gap-1">
+              <Label htmlFor="add-ip-input" className="sr-only">
+                Dirección IP a agregar a la whitelist
+              </Label>
+              <Input
+                id="add-ip-input"
+                data-testid="add-ip-input"
+                placeholder="Ej: 203.0.113.45 o 2001:db8::1"
+                value={newIp}
+                onChange={(e) => setNewIp(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleAdd();
+                }}
+                disabled={isAdding}
+              />
+            </div>
             <Button
               data-testid="add-ip-button"
               onClick={handleAdd}
@@ -157,22 +169,51 @@ export function IpWhitelistTab() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {ips.map((ip) => (
-                <TableRow key={ip}>
-                  <TableCell className="font-mono">{ip}</TableCell>
-                  <TableCell className="text-right">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      data-testid={`remove-ip-${ip}`}
-                      onClick={() => setIpToRemove(ip)}
-                      disabled={isRemoving}
-                    >
-                      <Trash2 className="text-destructive h-4 w-4" />
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
+              {ips.map((ip) => {
+                const isSystemIp = SYSTEM_IPS.has(ip);
+                return (
+                  <TableRow key={ip}>
+                    <TableCell className="font-mono">
+                      <span className="flex items-center gap-2">
+                        {ip}
+                        {isSystemIp && (
+                          <Badge variant="outline" className="text-xs">
+                            Sistema
+                          </Badge>
+                        )}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {isSystemIp ? (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="inline-flex h-8 w-8 items-center justify-center">
+                                <Lock
+                                  className="text-muted-foreground h-4 w-4"
+                                  aria-label={`${ip} es una IP de sistema y no puede eliminarse`}
+                                />
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>IP de sistema — no se puede eliminar</TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          data-testid={`remove-ip-${ip}`}
+                          aria-label={`Eliminar ${ip} de la whitelist`}
+                          onClick={() => setIpToRemove(ip)}
+                          disabled={isRemoving}
+                        >
+                          <Trash2 className="text-destructive h-4 w-4" />
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </Card>

--- a/frontend/src/components/features/admin/IpWhitelistTab.tsx
+++ b/frontend/src/components/features/admin/IpWhitelistTab.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState } from 'react';
+import { Shield, Trash2, Plus } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  useIpWhitelist,
+  useAddIpToWhitelist,
+  useRemoveIpFromWhitelist,
+} from '@/hooks/api/useAdminIpWhitelist';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { WhitelistActionResponse } from '@/types/admin-security.types';
+
+export function IpWhitelistTab() {
+  const [newIp, setNewIp] = useState('');
+  const [ipToRemove, setIpToRemove] = useState<string | null>(null);
+
+  const { data, isLoading, isError, refetch } = useIpWhitelist();
+  const { mutate: addIp, isPending: isAdding } = useAddIpToWhitelist();
+  const { mutate: removeIp, isPending: isRemoving } = useRemoveIpFromWhitelist();
+
+  const handleAdd = () => {
+    const trimmed = newIp.trim();
+    if (!trimmed) return;
+
+    addIp(
+      { ip: trimmed },
+      {
+        onSuccess: (result: WhitelistActionResponse) => {
+          toast.success(result.message ?? `IP ${trimmed} agregada a la whitelist`);
+          setNewIp('');
+        },
+        onError: () => {
+          toast.error(`Error al agregar la IP ${trimmed} a la whitelist`);
+        },
+      }
+    );
+  };
+
+  const handleRemoveConfirm = () => {
+    if (!ipToRemove) return;
+
+    removeIp(
+      { ip: ipToRemove },
+      {
+        onSuccess: (result: WhitelistActionResponse) => {
+          toast.success(result.message ?? `IP ${ipToRemove} eliminada de la whitelist`);
+          setIpToRemove(null);
+        },
+        onError: () => {
+          toast.error(`Error al eliminar la IP ${ipToRemove} de la whitelist`);
+          setIpToRemove(null);
+        },
+      }
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4" data-testid="skeleton-whitelist">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="text-destructive" data-testid="error-whitelist">
+        <p>Error al cargar la IP whitelist.</p>
+        <Button variant="outline" size="sm" className="mt-2" onClick={() => void refetch()}>
+          Reintentar
+        </Button>
+      </div>
+    );
+  }
+
+  const ips = data?.ips ?? [];
+
+  return (
+    <div className="space-y-6" data-testid="ip-whitelist-tab">
+      {/* Header con conteo */}
+      <div className="flex items-center gap-2">
+        <Shield className="text-muted-foreground h-5 w-5" />
+        <h3 className="text-lg font-semibold">IPs en Whitelist</h3>
+        <Badge variant="secondary" data-testid="whitelist-count">
+          {data?.count ?? 0}
+        </Badge>
+      </div>
+
+      {/* Formulario para agregar IP */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Agregar IP</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-2">
+            <Input
+              data-testid="add-ip-input"
+              placeholder="Ej: 203.0.113.45 o 2001:db8::1"
+              value={newIp}
+              onChange={(e) => setNewIp(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleAdd();
+              }}
+              disabled={isAdding}
+            />
+            <Button
+              data-testid="add-ip-button"
+              onClick={handleAdd}
+              disabled={isAdding || !newIp.trim()}
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Agregar
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Tabla de IPs */}
+      {ips.length === 0 ? (
+        <div
+          className="text-muted-foreground rounded-lg border border-dashed p-8 text-center"
+          data-testid="empty-whitelist"
+        >
+          No hay IPs en la whitelist. Las IPs agregadas aquí no serán bloqueadas por rate limiting.
+        </div>
+      ) : (
+        <Card>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Dirección IP</TableHead>
+                <TableHead className="w-24 text-right">Acciones</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {ips.map((ip) => (
+                <TableRow key={ip}>
+                  <TableCell className="font-mono">{ip}</TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      data-testid={`remove-ip-${ip}`}
+                      onClick={() => setIpToRemove(ip)}
+                      disabled={isRemoving}
+                    >
+                      <Trash2 className="text-destructive h-4 w-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Card>
+      )}
+
+      {/* AlertDialog de confirmación para eliminar */}
+      <AlertDialog open={!!ipToRemove} onOpenChange={(open) => !open && setIpToRemove(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Eliminar IP de la whitelist?</AlertDialogTitle>
+            <AlertDialogDescription>
+              La IP <span className="font-mono font-semibold">{ipToRemove}</span> será removida de
+              la whitelist y quedará sujeta a las reglas de rate limiting.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleRemoveConfirm} disabled={isRemoving}>
+              Eliminar
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/frontend/src/components/features/admin/SecurityManagementContent.test.tsx
+++ b/frontend/src/components/features/admin/SecurityManagementContent.test.tsx
@@ -2,14 +2,17 @@
  * Tests for SecurityManagementContent component
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createElement } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SecurityManagementContent } from './SecurityManagementContent';
 import * as useAdminSecurity from '@/hooks/api/useAdminSecurity';
+import * as useAdminIpWhitelist from '@/hooks/api/useAdminIpWhitelist';
 
 vi.mock('@/hooks/api/useAdminSecurity');
+vi.mock('@/hooks/api/useAdminIpWhitelist');
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -25,7 +28,7 @@ const createWrapper = () => {
 };
 
 describe('SecurityManagementContent', () => {
-  it('should render tabs for Rate Limiting and Security Events', () => {
+  beforeEach(() => {
     vi.mocked(useAdminSecurity.useRateLimitData).mockReturnValue({
       data: {
         violations: [],
@@ -40,9 +43,51 @@ describe('SecurityManagementContent', () => {
       error: null,
     } as never);
 
+    vi.mocked(useAdminSecurity.useUnblockIP).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as never);
+
+    vi.mocked(useAdminSecurity.useSecurityEvents).mockReturnValue({
+      data: { data: [], meta: { page: 1, limit: 10, totalItems: 0, totalPages: 0 } },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as never);
+
+    vi.mocked(useAdminIpWhitelist.useIpWhitelist).mockReturnValue({
+      data: { ips: [], count: 0 },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+      isSuccess: true,
+    } as never);
+
+    vi.mocked(useAdminIpWhitelist.useAddIpToWhitelist).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as never);
+
+    vi.mocked(useAdminIpWhitelist.useRemoveIpFromWhitelist).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as never);
+  });
+
+  it('should render tabs for Rate Limiting, Security Events and IP Whitelist', () => {
     render(<SecurityManagementContent />, { wrapper: createWrapper() });
 
     expect(screen.getByText('Rate Limiting')).toBeInTheDocument();
     expect(screen.getByText('Eventos de Seguridad')).toBeInTheDocument();
+    expect(screen.getByText('IP Whitelist')).toBeInTheDocument();
+  });
+
+  it('should show IP Whitelist tab content when selected', async () => {
+    render(<SecurityManagementContent />, { wrapper: createWrapper() });
+
+    const tab = screen.getByRole('tab', { name: 'IP Whitelist' });
+    await userEvent.click(tab);
+
+    expect(screen.getByTestId('ip-whitelist-tab')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/features/admin/SecurityManagementContent.tsx
+++ b/frontend/src/components/features/admin/SecurityManagementContent.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { RateLimitingTab } from './RateLimitingTab';
 import { SecurityEventsTab } from './SecurityEventsTab';
+import { IpWhitelistTab } from './IpWhitelistTab';
 
 export function SecurityManagementContent() {
   const [activeTab, setActiveTab] = useState('rate-limiting');
@@ -20,6 +21,7 @@ export function SecurityManagementContent() {
       <TabsList>
         <TabsTrigger value="rate-limiting">Rate Limiting</TabsTrigger>
         <TabsTrigger value="security-events">Eventos de Seguridad</TabsTrigger>
+        <TabsTrigger value="ip-whitelist">IP Whitelist</TabsTrigger>
       </TabsList>
 
       <TabsContent value="rate-limiting" className="mt-6">
@@ -28,6 +30,10 @@ export function SecurityManagementContent() {
 
       <TabsContent value="security-events" className="mt-6">
         <SecurityEventsTab />
+      </TabsContent>
+
+      <TabsContent value="ip-whitelist" className="mt-6">
+        <IpWhitelistTab />
       </TabsContent>
     </Tabs>
   );

--- a/frontend/src/hooks/api/useAdminIpWhitelist.test.ts
+++ b/frontend/src/hooks/api/useAdminIpWhitelist.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests para useAdminIpWhitelist hooks (T-ADM-006)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import * as whitelistApi from '@/lib/api/admin-ip-whitelist-api';
+import {
+  useIpWhitelist,
+  useAddIpToWhitelist,
+  useRemoveIpFromWhitelist,
+} from './useAdminIpWhitelist';
+
+vi.mock('@/lib/api/admin-ip-whitelist-api');
+
+describe('useAdminIpWhitelist hooks', () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    vi.clearAllMocks();
+  });
+
+  describe('useIpWhitelist', () => {
+    it('should fetch whitelist and return ips and count', async () => {
+      const mockData = { ips: ['192.168.1.1', '10.0.0.1'], count: 2 };
+      vi.mocked(whitelistApi.getIpWhitelist).mockResolvedValue(mockData);
+
+      const { result } = renderHook(() => useIpWhitelist(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(mockData);
+      expect(whitelistApi.getIpWhitelist).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle empty whitelist', async () => {
+      vi.mocked(whitelistApi.getIpWhitelist).mockResolvedValue({ ips: [], count: 0 });
+
+      const { result } = renderHook(() => useIpWhitelist(), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data?.ips).toHaveLength(0);
+    });
+
+    it('should expose error state when fetch fails', async () => {
+      vi.mocked(whitelistApi.getIpWhitelist).mockRejectedValue(new Error('Forbidden'));
+
+      const { result } = renderHook(() => useIpWhitelist(), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+  });
+
+  describe('useAddIpToWhitelist', () => {
+    it('should call addIpToWhitelist with the dto and invalidate cache', async () => {
+      const mockResponse = { message: 'IP 203.0.113.45 added to whitelist', ip: '203.0.113.45' };
+      vi.mocked(whitelistApi.addIpToWhitelist).mockResolvedValue(mockResponse);
+
+      const { result } = renderHook(() => useAddIpToWhitelist(), { wrapper });
+
+      await act(async () => {
+        result.current.mutate({ ip: '203.0.113.45' });
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(whitelistApi.addIpToWhitelist).toHaveBeenCalledWith({ ip: '203.0.113.45' });
+    });
+
+    it('should expose error state when adding IP fails', async () => {
+      vi.mocked(whitelistApi.addIpToWhitelist).mockRejectedValue(new Error('Bad Request'));
+
+      const { result } = renderHook(() => useAddIpToWhitelist(), { wrapper });
+
+      await act(async () => {
+        result.current.mutate({ ip: 'invalid' });
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+  });
+
+  describe('useRemoveIpFromWhitelist', () => {
+    it('should call removeIpFromWhitelist with the dto and invalidate cache', async () => {
+      const mockResponse = { message: 'IP 192.168.1.1 removed from whitelist', ip: '192.168.1.1' };
+      vi.mocked(whitelistApi.removeIpFromWhitelist).mockResolvedValue(mockResponse);
+
+      const { result } = renderHook(() => useRemoveIpFromWhitelist(), { wrapper });
+
+      await act(async () => {
+        result.current.mutate({ ip: '192.168.1.1' });
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(whitelistApi.removeIpFromWhitelist).toHaveBeenCalledWith({ ip: '192.168.1.1' });
+    });
+
+    it('should expose error state when removing IP fails', async () => {
+      vi.mocked(whitelistApi.removeIpFromWhitelist).mockRejectedValue(new Error('Not Found'));
+
+      const { result } = renderHook(() => useRemoveIpFromWhitelist(), { wrapper });
+
+      await act(async () => {
+        result.current.mutate({ ip: '1.2.3.4' });
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+  });
+});

--- a/frontend/src/hooks/api/useAdminIpWhitelist.ts
+++ b/frontend/src/hooks/api/useAdminIpWhitelist.ts
@@ -1,0 +1,52 @@
+/**
+ * Hooks para la gestión de IP Whitelist desde el panel admin (T-ADM-006)
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getIpWhitelist,
+  addIpToWhitelist,
+  removeIpFromWhitelist,
+} from '@/lib/api/admin-ip-whitelist-api';
+import type { WhitelistIPDto } from '@/types/admin-security.types';
+
+const WHITELIST_QUERY_KEY = ['admin', 'security', 'ip-whitelist'] as const;
+
+/**
+ * Hook para obtener la lista de IPs en la whitelist
+ */
+export function useIpWhitelist() {
+  return useQuery({
+    queryKey: WHITELIST_QUERY_KEY,
+    queryFn: getIpWhitelist,
+    staleTime: 30 * 1000,
+  });
+}
+
+/**
+ * Hook para agregar una IP a la whitelist
+ * Invalida el cache al completarse
+ */
+export function useAddIpToWhitelist() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (dto: WhitelistIPDto) => addIpToWhitelist(dto),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: WHITELIST_QUERY_KEY });
+    },
+  });
+}
+
+/**
+ * Hook para eliminar una IP de la whitelist
+ * Invalida el cache al completarse
+ */
+export function useRemoveIpFromWhitelist() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (dto: WhitelistIPDto) => removeIpFromWhitelist(dto),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: WHITELIST_QUERY_KEY });
+    },
+  });
+}

--- a/frontend/src/lib/api/admin-ip-whitelist-api.test.ts
+++ b/frontend/src/lib/api/admin-ip-whitelist-api.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apiClient } from './axios-config';
+import { getIpWhitelist, addIpToWhitelist, removeIpFromWhitelist } from './admin-ip-whitelist-api';
+import { API_ENDPOINTS } from './endpoints';
+import type { WhitelistResponse, WhitelistActionResponse } from '@/types/admin-security.types';
+
+vi.mock('./axios-config');
+
+describe('admin-ip-whitelist-api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getIpWhitelist', () => {
+    it('should call GET /admin/ip-whitelist and return whitelist data', async () => {
+      const mockResponse: WhitelistResponse = {
+        ips: ['192.168.1.1', '10.0.0.1'],
+        count: 2,
+      };
+      vi.mocked(apiClient.get).mockResolvedValue({ data: mockResponse });
+
+      const result = await getIpWhitelist();
+
+      expect(apiClient.get).toHaveBeenCalledWith(API_ENDPOINTS.ADMIN.IP_WHITELIST);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should return empty whitelist when no IPs are configured', async () => {
+      const mockResponse: WhitelistResponse = { ips: [], count: 0 };
+      vi.mocked(apiClient.get).mockResolvedValue({ data: mockResponse });
+
+      const result = await getIpWhitelist();
+
+      expect(result.ips).toHaveLength(0);
+      expect(result.count).toBe(0);
+    });
+
+    it('should propagate errors from the API', async () => {
+      vi.mocked(apiClient.get).mockRejectedValue(new Error('Network error'));
+
+      await expect(getIpWhitelist()).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('addIpToWhitelist', () => {
+    it('should call POST /admin/ip-whitelist with the IP dto', async () => {
+      const mockResponse: WhitelistActionResponse = {
+        message: 'IP 203.0.113.45 added to whitelist',
+        ip: '203.0.113.45',
+      };
+      vi.mocked(apiClient.post).mockResolvedValue({ data: mockResponse });
+
+      const result = await addIpToWhitelist({ ip: '203.0.113.45' });
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        API_ENDPOINTS.ADMIN.IP_WHITELIST,
+        { ip: '203.0.113.45' },
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should propagate errors when adding IP fails', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('Bad Request'));
+
+      await expect(addIpToWhitelist({ ip: 'invalid-ip' })).rejects.toThrow('Bad Request');
+    });
+  });
+
+  describe('removeIpFromWhitelist', () => {
+    it('should call DELETE /admin/ip-whitelist with the IP in the body', async () => {
+      const mockResponse: WhitelistActionResponse = {
+        message: 'IP 203.0.113.45 removed from whitelist',
+        ip: '203.0.113.45',
+      };
+      vi.mocked(apiClient.delete).mockResolvedValue({ data: mockResponse });
+
+      const result = await removeIpFromWhitelist({ ip: '203.0.113.45' });
+
+      expect(apiClient.delete).toHaveBeenCalledWith(
+        API_ENDPOINTS.ADMIN.IP_WHITELIST,
+        { data: { ip: '203.0.113.45' } },
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should propagate errors when removing IP fails', async () => {
+      vi.mocked(apiClient.delete).mockRejectedValue(new Error('Not Found'));
+
+      await expect(removeIpFromWhitelist({ ip: '1.2.3.4' })).rejects.toThrow('Not Found');
+    });
+  });
+});

--- a/frontend/src/lib/api/admin-ip-whitelist-api.ts
+++ b/frontend/src/lib/api/admin-ip-whitelist-api.ts
@@ -1,0 +1,40 @@
+import { apiClient } from './axios-config';
+import { API_ENDPOINTS } from './endpoints';
+import type {
+  WhitelistResponse,
+  WhitelistIPDto,
+  WhitelistActionResponse,
+} from '@/types/admin-security.types';
+
+/**
+ * Obtiene la lista de IPs en la whitelist
+ * GET /admin/ip-whitelist
+ */
+export async function getIpWhitelist(): Promise<WhitelistResponse> {
+  const response = await apiClient.get<WhitelistResponse>(API_ENDPOINTS.ADMIN.IP_WHITELIST);
+  return response.data;
+}
+
+/**
+ * Agrega una IP a la whitelist
+ * POST /admin/ip-whitelist
+ */
+export async function addIpToWhitelist(dto: WhitelistIPDto): Promise<WhitelistActionResponse> {
+  const response = await apiClient.post<WhitelistActionResponse>(
+    API_ENDPOINTS.ADMIN.IP_WHITELIST,
+    dto
+  );
+  return response.data;
+}
+
+/**
+ * Elimina una IP de la whitelist
+ * DELETE /admin/ip-whitelist (IP en el body para soportar IPv6)
+ */
+export async function removeIpFromWhitelist(dto: WhitelistIPDto): Promise<WhitelistActionResponse> {
+  const response = await apiClient.delete<WhitelistActionResponse>(
+    API_ENDPOINTS.ADMIN.IP_WHITELIST,
+    { data: dto }
+  );
+  return response.data;
+}

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -251,6 +251,8 @@ export const API_ENDPOINTS = {
     RATE_LIMIT_DATA: '/admin/rate-limits/violations', // Retorna violations + blockedIps
     SECURITY_EVENTS: '/admin/security/events',
     UNBLOCK_IP: (ip: string) => `/admin/rate-limits/unblock-ip/${ip}`,
+    // IP Whitelist (T-ADM-006)
+    IP_WHITELIST: '/admin/ip-whitelist',
     // Readings Admin (T-ADM-001-B)
     READINGS: '/admin/readings',
     READING_SOFT_DELETE: (id: number) => `/admin/readings/${id}`,

--- a/frontend/src/types/admin-security.types.ts
+++ b/frontend/src/types/admin-security.types.ts
@@ -131,3 +131,26 @@ export interface IPActionResponse {
   message: string;
   ip: string;
 }
+
+/**
+ * Respuesta del endpoint GET /admin/ip-whitelist
+ */
+export interface WhitelistResponse {
+  ips: string[];
+  count: number;
+}
+
+/**
+ * DTO para agregar/eliminar IP de la whitelist
+ */
+export interface WhitelistIPDto {
+  ip: string;
+}
+
+/**
+ * Respuesta de acción sobre IP en la whitelist (agregar/eliminar)
+ */
+export interface WhitelistActionResponse {
+  message: string;
+  ip: string;
+}


### PR DESCRIPTION
## Descripción

Implementa la pestaña **IP Whitelist** en `/admin/seguridad`, consumiendo los endpoints backend existentes (`GET/POST/DELETE /admin/ip-whitelist`).

## Cambios

- **Nueva pestaña** "IP Whitelist" en `SecurityManagementContent.tsx` (3ª tab en Seguridad)
- **`IpWhitelistTab.tsx`**: tabla de IPs whitelisted + formulario para agregar + confirmación para eliminar
- **`useAdminIpWhitelist.ts`**: hooks React Query (list/add/remove)
- **`admin-ip-whitelist-api.ts`**: funciones API (GET/POST/DELETE con IP en body para soportar IPv6)
- **Tipos nuevos** en `admin-security.types.ts`: `WhitelistResponse`, `WhitelistIPDto`, `WhitelistActionResponse`
- **Endpoint centralizado**: `API_ENDPOINTS.ADMIN.IP_WHITELIST`

## Tests

27 tests nuevos pasando:
- 7 tests en `admin-ip-whitelist-api.test.ts`
- 7 tests en `useAdminIpWhitelist.test.ts`
- 11 tests en `IpWhitelistTab.test.tsx`
- 2 tests en `SecurityManagementContent.test.tsx` (actualizado)

## Ciclo de Calidad

- ✅ `npm run format`
- ✅ `npm run lint:fix` (0 errores)
- ✅ `npm run type-check`
- ✅ 27 tests nuevos pasando
- ✅ `npm run build`
- ✅ `node scripts/validate-architecture.js`

## Referencias

- Cubre hallazgo **ADM-006** del `BACKLOG_ADMIN_AUDIT_2026_05.md`
- Backend: `ip-whitelist-admin.controller.ts` (endpoints ya existentes)