### PR TITLE
fix(admin): resolver crashes de /usuarios, /tarotistas y /planes (ADM-007/008/009)

### DIFF
--- a/backend/tarot-app/src/modules/admin/admin-users.controller.spec.ts
+++ b/backend/tarot-app/src/modules/admin/admin-users.controller.spec.ts
@@ -78,10 +78,10 @@ describe('AdminUsersController', () => {
   describe('findAll', () => {
     it('should return paginated users with default parameters', async () => {
       const mockResponse = {
-        users: [mockUser],
+        data: [mockUser],
         meta: {
-          currentPage: 1,
-          itemsPerPage: 10,
+          page: 1,
+          limit: 10,
           totalItems: 1,
           totalPages: 1,
         },
@@ -105,10 +105,10 @@ describe('AdminUsersController', () => {
       };
 
       const mockResponse = {
-        users: [],
+        data: [],
         meta: {
-          currentPage: 2,
-          itemsPerPage: 20,
+          page: 2,
+          limit: 20,
           totalItems: 0,
           totalPages: 0,
         },

--- a/backend/tarot-app/src/modules/plan-config/entities/plan.entity.spec.ts
+++ b/backend/tarot-app/src/modules/plan-config/entities/plan.entity.spec.ts
@@ -1,3 +1,4 @@
+import { getMetadataArgsStorage } from 'typeorm';
 import { Plan } from './plan.entity';
 import { UserPlan } from '../../users/entities/user.entity';
 
@@ -44,6 +45,39 @@ describe('Plan Entity', () => {
       expect(plan.planType).toBe(UserPlan.ANONYMOUS);
       expect(plan.readingsLimit).toBe(3);
       expect(plan.aiQuotaMonthly).toBe(0);
+    });
+  });
+
+  describe('price column transformer', () => {
+    // El tipo decimal de Postgres se serializa como string vía TypeORM. El
+    // transformer `from` debe convertirlo a number para que el frontend pueda
+    // operar sobre él (p.ej. price.toFixed(2)) sin lanzar TypeError.
+    // Obtenemos el transformer real declarado en @Column sobre `price`.
+    const getPriceTransformer = (): {
+      to: (value: number) => unknown;
+      from: (value: string) => number;
+    } => {
+      const priceColumn = getMetadataArgsStorage().columns.find(
+        (c) => c.target === Plan && c.propertyName === 'price',
+      );
+      return priceColumn?.options?.transformer as {
+        to: (value: number) => unknown;
+        from: (value: string) => number;
+      };
+    };
+
+    it('should declare a transformer on the price column', () => {
+      const transformer = getPriceTransformer();
+      expect(transformer).toBeDefined();
+      expect(typeof transformer.from).toBe('function');
+    });
+
+    it('should parse a decimal string from the DB into a number', () => {
+      const { from } = getPriceTransformer();
+
+      expect(from('9.99')).toBe(9.99);
+      expect(from('0.00')).toBe(0);
+      expect(typeof from('15.50')).toBe('number');
     });
   });
 

--- a/backend/tarot-app/src/modules/plan-config/entities/plan.entity.ts
+++ b/backend/tarot-app/src/modules/plan-config/entities/plan.entity.ts
@@ -51,7 +51,16 @@ export class Plan {
     example: 0,
     description: 'Precio mensual en USD',
   })
-  @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 2,
+    default: 0,
+    transformer: {
+      to: (value: number) => value,
+      from: (value: string): number => parseFloat(value),
+    },
+  })
   price: number;
 
   @ApiProperty({

--- a/backend/tarot-app/src/modules/tarotistas/application/services/tarotistas-orchestrator.service.spec.ts
+++ b/backend/tarot-app/src/modules/tarotistas/application/services/tarotistas-orchestrator.service.spec.ts
@@ -136,10 +136,12 @@ describe('TarotistasOrchestratorService', () => {
 
       expect(result).toEqual({
         data: useCaseResult.data,
-        total: 25,
-        page: 1,
-        limit: 10,
-        totalPages: 3, // ceil(25/10)
+        meta: {
+          page: 1,
+          limit: 10,
+          totalItems: 25,
+          totalPages: 3, // ceil(25/10)
+        },
       });
     });
 

--- a/backend/tarot-app/src/modules/tarotistas/application/services/tarotistas-orchestrator.service.ts
+++ b/backend/tarot-app/src/modules/tarotistas/application/services/tarotistas-orchestrator.service.ts
@@ -70,10 +70,12 @@ export class TarotistasOrchestratorService {
 
   async getAllTarotistas(filterDto: GetTarotistasFilterDto): Promise<{
     data: Tarotista[];
-    total: number;
-    page: number;
-    limit: number;
-    totalPages: number;
+    meta: {
+      page: number;
+      limit: number;
+      totalItems: number;
+      totalPages: number;
+    };
   }> {
     const options = {
       page: filterDto.page || 1,
@@ -92,10 +94,12 @@ export class TarotistasOrchestratorService {
 
     return {
       data: result.data,
-      total: result.total,
-      page: options.page,
-      limit: options.limit,
-      totalPages,
+      meta: {
+        page: options.page,
+        limit: options.limit,
+        totalItems: result.total,
+        totalPages,
+      },
     };
   }
 
@@ -130,12 +134,24 @@ export class TarotistasOrchestratorService {
 
   async getAllApplications(filterDto: GetTarotistasFilterDto): Promise<{
     data: TarotistaApplication[];
-    total: number;
-    page: number;
-    limit: number;
-    totalPages: number;
+    meta: {
+      page: number;
+      limit: number;
+      totalItems: number;
+      totalPages: number;
+    };
   }> {
-    return await this.listApplicationsUseCase.execute(filterDto);
+    const result = await this.listApplicationsUseCase.execute(filterDto);
+
+    return {
+      data: result.data,
+      meta: {
+        page: result.page,
+        limit: result.limit,
+        totalItems: result.total,
+        totalPages: result.totalPages,
+      },
+    };
   }
 
   async bulkImportCustomMeanings(

--- a/backend/tarot-app/src/modules/tarotistas/infrastructure/controllers/tarotistas-admin.controller.spec.ts
+++ b/backend/tarot-app/src/modules/tarotistas/infrastructure/controllers/tarotistas-admin.controller.spec.ts
@@ -103,10 +103,12 @@ describe('TarotistasAdminController', () => {
             nombrePublico: 'Luna Mística',
           } as unknown as Tarotista,
         ],
-        total: 1,
-        page: 1,
-        limit: 20,
-        totalPages: 1,
+        meta: {
+          page: 1,
+          limit: 20,
+          totalItems: 1,
+          totalPages: 1,
+        },
       };
 
       mockOrchestrator.getAllTarotistas.mockResolvedValue(expectedResult);
@@ -131,10 +133,12 @@ describe('TarotistasAdminController', () => {
             nombrePublico: 'Luna Mística',
           } as unknown as Tarotista,
         ],
-        total: 1,
-        page: 1,
-        limit: 20,
-        totalPages: 1,
+        meta: {
+          page: 1,
+          limit: 20,
+          totalItems: 1,
+          totalPages: 1,
+        },
       };
 
       mockOrchestrator.getAllTarotistas.mockResolvedValue(expectedResult);
@@ -154,10 +158,12 @@ describe('TarotistasAdminController', () => {
 
       mockOrchestrator.getAllTarotistas.mockResolvedValue({
         data: [],
-        total: 0,
-        page: 1,
-        limit: 20,
-        totalPages: 0,
+        meta: {
+          page: 1,
+          limit: 20,
+          totalItems: 0,
+          totalPages: 0,
+        },
       });
 
       await controller.getAllTarotistas(filterDto);
@@ -392,10 +398,12 @@ describe('TarotistasAdminController', () => {
             status: ApplicationStatus.PENDING,
           } as unknown as TarotistaApplication,
         ],
-        total: 1,
-        page: 1,
-        limit: 20,
-        totalPages: 1,
+        meta: {
+          page: 1,
+          limit: 20,
+          totalItems: 1,
+          totalPages: 1,
+        },
       };
 
       mockOrchestrator.getAllApplications.mockResolvedValue(expectedResult);

--- a/backend/tarot-app/src/modules/users/application/dto/user-list-response.dto.ts
+++ b/backend/tarot-app/src/modules/users/application/dto/user-list-response.dto.ts
@@ -6,13 +6,13 @@ export class PaginationMetaDto {
     description: 'Número de página actual',
     example: 1,
   })
-  currentPage: number;
+  page: number;
 
   @ApiProperty({
     description: 'Cantidad de resultados por página',
     example: 10,
   })
-  itemsPerPage: number;
+  limit: number;
 
   @ApiProperty({
     description: 'Total de resultados',
@@ -32,7 +32,7 @@ export class UserListResponseDto {
     description: 'Lista de usuarios',
     type: [Object],
   })
-  users: UserWithoutPassword[];
+  data: UserWithoutPassword[];
 
   @ApiProperty({
     description: 'Metadatos de paginación',

--- a/backend/tarot-app/src/modules/users/infrastructure/repositories/typeorm-user.repository.spec.ts
+++ b/backend/tarot-app/src/modules/users/infrastructure/repositories/typeorm-user.repository.spec.ts
@@ -181,11 +181,11 @@ describe('TypeOrmUserRepository', () => {
 
       const result = await repository.findWithFilters(query);
 
-      expect(result.users).toHaveLength(2);
-      expect(result.users[0]).not.toHaveProperty('password');
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0]).not.toHaveProperty('password');
       expect(result.meta).toEqual({
-        currentPage: 1,
-        itemsPerPage: 10,
+        page: 1,
+        limit: 10,
         totalItems: 2,
         totalPages: 1,
       });

--- a/backend/tarot-app/src/modules/users/infrastructure/repositories/typeorm-user.repository.ts
+++ b/backend/tarot-app/src/modules/users/infrastructure/repositories/typeorm-user.repository.ts
@@ -149,10 +149,10 @@ export class TypeOrmUserRepository implements IUserRepository {
     const totalPages = Math.ceil(totalItems / limit);
 
     return {
-      users: usersWithoutPassword,
+      data: usersWithoutPassword,
       meta: {
-        currentPage: page,
-        itemsPerPage: limit,
+        page,
+        limit,
         totalItems,
         totalPages,
       },

--- a/backend/tarot-app/src/modules/users/users.service.spec.ts
+++ b/backend/tarot-app/src/modules/users/users.service.spec.ts
@@ -314,10 +314,10 @@ describe('UsersService', () => {
 
       const result = await service.findAllWithFilters({});
 
-      expect(result.users).toHaveLength(2);
-      expect(result.users[0]).not.toHaveProperty('password');
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0]).not.toHaveProperty('password');
       expect(result.meta.totalItems).toBe(2);
-      expect(result.meta.currentPage).toBe(1);
+      expect(result.meta.page).toBe(1);
     });
 
     it('should apply search filter', async () => {

--- a/backend/tarot-app/src/modules/users/users.service.ts
+++ b/backend/tarot-app/src/modules/users/users.service.ts
@@ -453,10 +453,10 @@ export class UsersService {
     const totalPages = Math.ceil(totalItems / limit);
 
     return {
-      users: usersWithoutPassword,
+      data: usersWithoutPassword,
       meta: {
-        currentPage: page,
-        itemsPerPage: limit,
+        page,
+        limit,
         totalItems,
         totalPages,
       },

--- a/backend/tarot-app/test/admin-tarotistas.e2e-spec.ts
+++ b/backend/tarot-app/test/admin-tarotistas.e2e-spec.ts
@@ -33,10 +33,12 @@ interface TarotistaResponse {
 
 interface TarotistaListResponse {
   data: TarotistaResponse[];
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
+  meta: {
+    page: number;
+    limit: number;
+    totalItems: number;
+    totalPages: number;
+  };
 }
 
 interface ApplicationResponse {
@@ -263,9 +265,9 @@ describe('Admin Tarotistas Management (e2e)', () => {
       expect(response.status).toBe(200);
       const body = response.body as TarotistaListResponse;
       expect(body.data).toBeInstanceOf(Array);
-      expect(body.total).toBeGreaterThanOrEqual(0);
-      expect(body.page).toBe(1);
-      expect(body.limit).toBe(20);
+      expect(body.meta.totalItems).toBeGreaterThanOrEqual(0);
+      expect(body.meta.page).toBe(1);
+      expect(body.meta.limit).toBe(20);
     });
 
     it('should filter by search term', async () => {
@@ -278,7 +280,7 @@ describe('Admin Tarotistas Management (e2e)', () => {
 
       expect(response.status).toBe(200);
       const body = response.body as TarotistaListResponse;
-      if (body.total > 0) {
+      if (body.meta.totalItems > 0) {
         expect(body.data[0].nombrePublico).toContain('Luna');
       }
     });
@@ -449,10 +451,10 @@ describe('Admin Tarotistas Management (e2e)', () => {
       expect(response.status).toBe(200);
       const body = response.body as {
         data: ApplicationResponse[];
-        total: number;
+        meta: { totalItems: number };
       };
       expect(body.data).toBeInstanceOf(Array);
-      expect(body.total).toBeGreaterThanOrEqual(0);
+      expect(body.meta.totalItems).toBeGreaterThanOrEqual(0);
     });
 
     it('should approve application and create tarotista', async () => {

--- a/backend/tarot-app/test/admin-user-edge-cases.e2e-spec.ts
+++ b/backend/tarot-app/test/admin-user-edge-cases.e2e-spec.ts
@@ -272,7 +272,7 @@ describe('Admin User Journey - Edge Cases E2E', () => {
         .set('Authorization', `Bearer ${newToken}`)
         .expect(200);
 
-      expect(userListWithNewToken.body).toHaveProperty('users');
+      expect(userListWithNewToken.body).toHaveProperty('data');
     }, 40000);
 
     it('✅ Remover rol ADMIN bloquea acceso incluso con token válido', async () => {

--- a/backend/tarot-app/test/admin-users.e2e-spec.ts
+++ b/backend/tarot-app/test/admin-users.e2e-spec.ts
@@ -23,7 +23,7 @@ interface LoginResponse {
 }
 
 interface UserListResponse {
-  users: Array<{
+  data: Array<{
     id: number;
     email: string;
     name: string;
@@ -33,8 +33,8 @@ interface UserListResponse {
     banReason: string | null;
   }>;
   meta: {
-    currentPage: number;
-    itemsPerPage: number;
+    page: number;
+    limit: number;
     totalItems: number;
     totalPages: number;
   };
@@ -208,13 +208,13 @@ describe('Admin Users Management (e2e)', () => {
 
       expect(response.status).toBe(200);
       const body = response.body as UserListResponse;
-      expect(body).toHaveProperty('users');
+      expect(body).toHaveProperty('data');
       expect(body).toHaveProperty('meta');
-      expect(body.meta).toHaveProperty('currentPage', 1);
-      expect(body.meta).toHaveProperty('itemsPerPage', 10);
+      expect(body.meta).toHaveProperty('page', 1);
+      expect(body.meta).toHaveProperty('limit', 10);
       expect(body.meta).toHaveProperty('totalItems');
       expect(body.meta).toHaveProperty('totalPages');
-      expect(Array.isArray(body.users)).toBe(true);
+      expect(Array.isArray(body.data)).toBe(true);
     });
 
     it('should filter by search term', async () => {
@@ -225,8 +225,8 @@ describe('Admin Users Management (e2e)', () => {
 
       expect(response.status).toBe(200);
       const body = response.body as UserListResponse;
-      expect(body.users.length).toBeGreaterThan(0);
-      const foundUser = body.users.find(
+      expect(body.data.length).toBeGreaterThan(0);
+      const foundUser = body.data.find(
         (u) => u.email === 'admin@test-admin-users.com',
       );
       expect(foundUser).toBeDefined();
@@ -240,8 +240,8 @@ describe('Admin Users Management (e2e)', () => {
 
       expect(response.status).toBe(200);
       const body = response.body as UserListResponse;
-      expect(body.users.length).toBeGreaterThan(0);
-      body.users.forEach((user) => {
+      expect(body.data.length).toBeGreaterThan(0);
+      body.data.forEach((user) => {
         expect(user.roles).toContain(UserRole.ADMIN);
       });
     });
@@ -254,8 +254,8 @@ describe('Admin Users Management (e2e)', () => {
 
       expect(response.status).toBe(200);
       const body = response.body as UserListResponse;
-      expect(body.meta.itemsPerPage).toBe(2);
-      expect(body.users.length).toBeLessThanOrEqual(2);
+      expect(body.meta.limit).toBe(2);
+      expect(body.data.length).toBeLessThanOrEqual(2);
     });
   });
 

--- a/backend/tarot-app/test/integration/admin.integration.spec.ts
+++ b/backend/tarot-app/test/integration/admin.integration.spec.ts
@@ -131,16 +131,16 @@ describe('Admin Operations Integration Tests', () => {
         .expect(200);
 
       // ASSERT
-      expect(response.body).toHaveProperty('users');
+      expect(response.body).toHaveProperty('data');
       expect(response.body).toHaveProperty('meta');
       expect(response.body.meta).toHaveProperty('totalItems');
-      expect(response.body.meta).toHaveProperty('currentPage');
-      expect(response.body.meta).toHaveProperty('itemsPerPage');
-      expect(Array.isArray(response.body.users)).toBe(true);
-      expect(response.body.users.length).toBeGreaterThan(0);
+      expect(response.body.meta).toHaveProperty('page');
+      expect(response.body.meta).toHaveProperty('limit');
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data.length).toBeGreaterThan(0);
 
       // Verificar que incluye nuestros usuarios de prueba
-      const emails = response.body.users.map(
+      const emails = response.body.data.map(
         (user: { email: string }) => user.email,
       );
       expect(emails).toContain(adminUser.email);

--- a/docs/BACKLOG_ADMIN_AUDIT_2026_05.md
+++ b/docs/BACKLOG_ADMIN_AUDIT_2026_05.md
@@ -566,3 +566,43 @@ El backend expone un CRUD de IP whitelist (`GET/POST/DELETE /admin/ip-whitelist`
 - **3 secciones con incompletitud/roturas menores**: Métricas (sesiones), Tarotistas (dead-links), Seguridad (contrato paginación).
 - **2 mejoras de baja prioridad**: tarjeta de ahorro de caché y UI de IP whitelist.
 - Prioridad sugerida: **ADM-001 → ADM-003 (Opción B) → ADM-004 → ADM-002 → ADM-005 → ADM-006**.
+
+---
+
+## PARTE C: HALLAZGOS POST-IMPLEMENTACIÓN (TESTING MANUAL — 27/05/2026)
+
+> Tras cerrar ADM-001…006, el testing manual del panel reveló que **tres secciones marcadas
+> "✅ Correcto" en la auditoría inicial en realidad crasheaban** ("Application error: a client-side
+> exception has occurred"). La auditoría se hizo leyendo código, no ejecutando contra el backend
+> real; los crashes solo aparecen con datos en vivo. Causa común: **el `<T>` de `apiClient.get<T>()`
+> es solo un cast de TS, no valida runtime**, así que un shape de backend distinto al tipado del
+> frontend revienta al renderizar. Misma clase que **ADM-004**.
+
+### ADM-007: `/admin/usuarios` crashea — paginación no estándar `{ users, meta: { currentPage } }`
+
+**Severidad:** 🔴 Crítica (página inutilizable) · **Estado:** ✅ COMPLETADA
+
+- **Backend** `/admin/users` devolvía `{ users, meta: { currentPage, itemsPerPage, totalItems, totalPages } }`.
+- **Frontend** `UsersManagementContent`/`UsersTable` esperan `{ data, meta: { page, limit, … } }` → `data.data` `undefined` → `UsersTable` `users.length` → **TypeError**.
+- **Fix:** se alineó `UserListResponseDto` + `UsersService.findAllWithFilters` + `TypeOrmUserRepository.findWithFilters` al contrato estándar `{ data, meta: { page, limit, totalItems, totalPages } }` (regla #3). Frontend sin cambios. Specs actualizados (58 tests). Verificado en vivo.
+
+### ADM-008: `/admin/tarotistas` crashea — shape plano sin `meta`
+
+**Severidad:** 🔴 Crítica · **Estado:** ✅ COMPLETADA
+
+- **Backend** `getAllTarotistas`/`getAllApplications` devolvían `{ data, total, page, limit, totalPages }` (plano, sin objeto `meta`).
+- **Frontend** lee `tarotistaData.meta.totalPages` → `meta` `undefined` → **TypeError**.
+- **Fix:** ambos métodos del orchestrator envuelven en `{ data, meta: { page, limit, totalItems, totalPages } }`. Frontend sin cambios. Specs actualizados (23 tests). Verificado en vivo.
+- **Sub-hallazgo (separado, NO crashea):** la pestaña "Aplicaciones Pendientes" envía `?status=pending`, pero `GetTarotistasFilterDto` no acepta `status` (`forbidNonWhitelisted`) → `400`. Además `ListApplicationsUseCase` es un **stub intencional** (siempre `[]`, MVP single-tarotista). Cae a EmptyState, no crashea. **Pendiente de decisión de producto** (¿implementar aplicaciones o quitar la pestaña?).
+
+### ADM-009: `/admin/planes` crashea — `price` serializado como string
+
+**Severidad:** 🔴 Crítica · **Estado:** ✅ COMPLETADA
+
+- **Backend** `/plan-config` devolvía `price` como **string** (`"0.00"`): Postgres `decimal` se serializa como string en TypeORM.
+- **Frontend** `PlanComparisonTable` hace `(value as number).toFixed(2)` → sobre string lanza **"toFixed is not a function"**.
+- **Fix:** transformer en `@Column` de `Plan.price` (`from: parseFloat`), mismo patrón que `holistic-service.entity`. Afecta a todos los consumidores, que ya tipan `price: number`. Test del transformer agregado (25 tests). Verificado en vivo.
+
+> **Nota de proceso:** estos tres confirman que las secciones "✅ Correcto" de la PARTE A no fueron
+> verificadas en runtime. Recomendación: en futuras auditorías, ejecutar cada pantalla contra el
+> backend real (o agregar validación de contrato runtime, p.ej. Zod, en la capa `api/`).


### PR DESCRIPTION
## Contexto

Testing manual del panel `/admin` (post ADM-001…006) reveló que **tres secciones marcadas "✅ Correcto" en la auditoría inicial crasheaban** con `Application error: a client-side exception has occurred`. La auditoría se hizo leyendo código, no ejecutando contra el backend real; los crashes solo aparecen con datos en vivo.

**Causa común:** `apiClient.get<T>()` es solo un cast de TS (no valida runtime), así que un shape de backend distinto al tipado del frontend revienta al renderizar. Misma clase de bug que ADM-004 (Security Events). Se opta por **estandarizar el backend al contrato del proyecto** (`CLAUDE.md` regla #3). El frontend ya esperaba los shapes correctos → **sin cambios de frontend**.

## Fixes

| # | Página | Causa | Fix |
|---|--------|-------|-----|
| ADM-007 | `/admin/usuarios` | `{ users, meta:{ currentPage, itemsPerPage } }` → `data.data` undefined → `UsersTable` `users.length` TypeError | `UserListResponseDto` + `UsersService.findAllWithFilters` + `TypeOrmUserRepository.findWithFilters` → `{ data, meta:{ page, limit, totalItems, totalPages } }` |
| ADM-008 | `/admin/tarotistas` | `{ data, total, page, limit, totalPages }` (sin `meta`) → `tarotistaData.meta.totalPages` TypeError | `getAllTarotistas`/`getAllApplications` envuelven en `{ data, meta:{…} }` |
| ADM-009 | `/admin/planes` | `price` serializado como string (`"0.00"`) → `(value as number).toFixed()` TypeError | transformer `parseFloat` en `@Column` de `Plan.price` (patrón de `holistic-service.entity`) |

## Verificación

- ✅ Shapes confirmados en vivo contra el backend (`/admin/users`, `/admin/tarotistas`, `/plan-config`).
- ✅ Backend: 157 tests de los specs tocados; specs actualizados al nuevo contrato + test del transformer de `price`.
- ✅ Frontend: 17 tests de las 3 páginas afectadas (sin cambios de código).
- ✅ `lint` + `build` + `validate-architecture` en cada commit.

## Fuera de alcance (documentado)

La pestaña "Aplicaciones Pendientes" de tarotistas envía `?status=pending` (rechazado por `GetTarotistasFilterDto` con 400) y `ListApplicationsUseCase` es un stub MVP que siempre devuelve `[]`. No crashea (cae a EmptyState). **Pendiente de decisión de producto.**

Detalle completo en `docs/BACKLOG_ADMIN_AUDIT_2026_05.md` → PARTE C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)