### PR TITLE
feat(ai): DeepSeek como IA principal (salvo horóscopos) + fix Node>=22

### DIFF
--- a/backend/tarot-app/package.json
+++ b/backend/tarot-app/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "postinstall": "patch-package",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
@@ -139,6 +140,7 @@
     "eslint-plugin-prettier": "^5.2.2",
     "globals": "^16.0.0",
     "jest": "^29.7.0",
+    "patch-package": "^8.0.1",
     "prettier": "^3.4.2",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",

--- a/backend/tarot-app/patches/buffer-equal-constant-time+1.0.1.patch
+++ b/backend/tarot-app/patches/buffer-equal-constant-time+1.0.1.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/buffer-equal-constant-time/index.js b/node_modules/buffer-equal-constant-time/index.js
+index 5462c1f..fc2c79c 100644
+--- a/node_modules/buffer-equal-constant-time/index.js
++++ b/node_modules/buffer-equal-constant-time/index.js
+@@ -1,7 +1,9 @@
+ /*jshint node:true */
+ 'use strict';
+ var Buffer = require('buffer').Buffer; // browserify
+-var SlowBuffer = require('buffer').SlowBuffer;
++// SlowBuffer was removed in Node >=22. Fall back to Buffer so this module loads
++// (jwa only uses the default constant-time compare; install/restore are unused).
++var SlowBuffer = require('buffer').SlowBuffer || Buffer;
+
+ module.exports = bufferEq;
+

--- a/backend/tarot-app/src/config/env.validation.spec.ts
+++ b/backend/tarot-app/src/config/env.validation.spec.ts
@@ -329,7 +329,7 @@ describe('EnvironmentVariables', () => {
           DEEPSEEK_API_KEY: 'sk-deepseek-1234',
         });
 
-        expect(envConfig.DEEPSEEK_MODEL).toBe('deepseek-chat');
+        expect(envConfig.DEEPSEEK_MODEL).toBe('deepseek-v4-flash');
       });
     });
 

--- a/backend/tarot-app/src/config/env.validation.ts
+++ b/backend/tarot-app/src/config/env.validation.ts
@@ -133,8 +133,8 @@ export class EnvironmentVariables {
 
   @IsString()
   @IsOptional()
-  @Transform(({ value }) => (value ? String(value) : 'deepseek-chat'))
-  DEEPSEEK_MODEL: string = 'deepseek-chat';
+  @Transform(({ value }) => (value ? String(value) : 'deepseek-v4-flash'))
+  DEEPSEEK_MODEL: string = 'deepseek-v4-flash';
 
   // OpenAI (Fallback/Premium - Optional)
   @IsString()

--- a/backend/tarot-app/src/modules/ai/application/services/ai-provider.service.spec.ts
+++ b/backend/tarot-app/src/modules/ai/application/services/ai-provider.service.spec.ts
@@ -7,6 +7,7 @@ import { GeminiProvider } from '../../infrastructure/providers/gemini.provider';
 import { OpenAIProvider } from '../../infrastructure/providers/openai.provider';
 import { AIUsageService } from '../../../ai-usage/ai-usage.service';
 import { AIQuotaService } from '../../../ai-usage/ai-quota.service';
+import { AIProvider } from '../../../ai-usage/entities/ai-usage-log.entity';
 import {
   AIProviderType,
   AIMessage,
@@ -52,6 +53,7 @@ describe('AIProviderService', () => {
       generateCompletion: jest.fn(),
       getProviderType: jest.fn().mockReturnValue(AIProviderType.GROQ),
       isAvailable: jest.fn().mockResolvedValue(true),
+      isConfigured: jest.fn().mockReturnValue(true),
     };
     groqProvider = groqProviderMock as unknown as jest.Mocked<GroqProvider>;
 
@@ -59,6 +61,7 @@ describe('AIProviderService', () => {
       generateCompletion: jest.fn(),
       getProviderType: jest.fn().mockReturnValue(AIProviderType.DEEPSEEK),
       isAvailable: jest.fn().mockResolvedValue(true),
+      isConfigured: jest.fn().mockReturnValue(true),
     };
     deepseekProvider =
       deepseekProviderMock as unknown as jest.Mocked<DeepSeekProvider>;
@@ -67,6 +70,7 @@ describe('AIProviderService', () => {
       generateCompletion: jest.fn(),
       getProviderType: jest.fn().mockReturnValue(AIProviderType.GEMINI),
       isAvailable: jest.fn().mockResolvedValue(true),
+      isConfigured: jest.fn().mockReturnValue(true),
     };
     geminiProvider =
       geminiProviderMock as unknown as jest.Mocked<GeminiProvider>;
@@ -75,6 +79,7 @@ describe('AIProviderService', () => {
       generateCompletion: jest.fn(),
       getProviderType: jest.fn().mockReturnValue(AIProviderType.OPENAI),
       isAvailable: jest.fn().mockResolvedValue(true),
+      isConfigured: jest.fn().mockReturnValue(true),
     };
     openaiProvider =
       openaiProviderMock as unknown as jest.Mocked<OpenAIProvider>;
@@ -214,6 +219,34 @@ describe('AIProviderService', () => {
       expect(result.provider).toBe(AIProviderType.GROQ);
       expect(groqProvider.generateCompletion).toHaveBeenCalledTimes(1);
       expect(deepseekProvider.generateCompletion).not.toHaveBeenCalled();
+    });
+
+    it('should skip providers that are not configured (no API key) without logging errors', async () => {
+      // OpenAI y Gemini sin key -> no se intentan ni se loguean como error
+      openaiProvider.isConfigured.mockReturnValue(false);
+      geminiProvider.isConfigured.mockReturnValue(false);
+      deepseekProvider.generateCompletion.mockRejectedValue(
+        new Error('DeepSeek down'),
+      );
+      groqProvider.generateCompletion.mockResolvedValue(mockSuccessResponse);
+
+      const result = await service.generateCompletion(
+        mockMessages,
+        1,
+        1,
+        undefined,
+        AIProviderType.DEEPSEEK,
+      );
+
+      expect(result.provider).toBe(AIProviderType.GROQ);
+      expect(openaiProvider.generateCompletion).not.toHaveBeenCalled();
+      expect(geminiProvider.generateCompletion).not.toHaveBeenCalled();
+      // Solo se loguea el intento fallido de DeepSeek, no de OpenAI/Gemini
+      const loggedProviders = aiUsageService.createLog.mock.calls.map(
+        (call) => call[0].provider,
+      );
+      expect(loggedProviders).not.toContain(AIProvider.OPENAI);
+      expect(loggedProviders).not.toContain(AIProvider.GEMINI);
     });
 
     it('should fallback to default order when primaryProvider is unknown', async () => {

--- a/backend/tarot-app/src/modules/ai/application/services/ai-provider.service.spec.ts
+++ b/backend/tarot-app/src/modules/ai/application/services/ai-provider.service.spec.ts
@@ -155,6 +155,82 @@ describe('AIProviderService', () => {
       );
     });
 
+    it('should try the preferred primaryProvider first (DeepSeek) without using Groq', async () => {
+      deepseekProvider.generateCompletion.mockResolvedValue({
+        ...mockSuccessResponse,
+        provider: AIProviderType.DEEPSEEK,
+      });
+
+      const result = await service.generateCompletion(
+        mockMessages,
+        1,
+        1,
+        undefined,
+        AIProviderType.DEEPSEEK,
+      );
+
+      expect(result.provider).toBe(AIProviderType.DEEPSEEK);
+      expect(deepseekProvider.generateCompletion).toHaveBeenCalledTimes(1);
+      expect(groqProvider.generateCompletion).not.toHaveBeenCalled();
+      expect(geminiProvider.generateCompletion).not.toHaveBeenCalled();
+      expect(aiUsageService.createLog).toHaveBeenCalledWith(
+        expect.objectContaining({ fallbackUsed: false }),
+      );
+    });
+
+    it('should keep the rest of providers as fallback when primaryProvider fails', async () => {
+      deepseekProvider.generateCompletion.mockRejectedValue(
+        new Error('DeepSeek down'),
+      );
+      groqProvider.generateCompletion.mockResolvedValue(mockSuccessResponse);
+
+      const result = await service.generateCompletion(
+        mockMessages,
+        1,
+        1,
+        undefined,
+        AIProviderType.DEEPSEEK,
+      );
+
+      expect(result.provider).toBe(AIProviderType.GROQ);
+      expect(deepseekProvider.generateCompletion).toHaveBeenCalled();
+      expect(groqProvider.generateCompletion).toHaveBeenCalled();
+      expect(aiUsageService.createLog).toHaveBeenCalledWith(
+        expect.objectContaining({ fallbackUsed: true }),
+      );
+    });
+
+    it('should use the default order (Groq first) when primaryProvider is Groq', async () => {
+      groqProvider.generateCompletion.mockResolvedValue(mockSuccessResponse);
+
+      const result = await service.generateCompletion(
+        mockMessages,
+        null,
+        null,
+        undefined,
+        AIProviderType.GROQ,
+      );
+
+      expect(result.provider).toBe(AIProviderType.GROQ);
+      expect(groqProvider.generateCompletion).toHaveBeenCalledTimes(1);
+      expect(deepseekProvider.generateCompletion).not.toHaveBeenCalled();
+    });
+
+    it('should fallback to default order when primaryProvider is unknown', async () => {
+      groqProvider.generateCompletion.mockResolvedValue(mockSuccessResponse);
+
+      const result = await service.generateCompletion(
+        mockMessages,
+        1,
+        1,
+        undefined,
+        'unknown' as unknown as AIProviderType,
+      );
+
+      expect(result.provider).toBe(AIProviderType.GROQ);
+      expect(groqProvider.generateCompletion).toHaveBeenCalledTimes(1);
+    });
+
     it('should fallback to Gemini when Groq fails with 429 error', async () => {
       const rateLimitError = Object.assign(new Error('Rate limit exceeded'), {
         status: 429,

--- a/backend/tarot-app/src/modules/ai/application/services/ai-provider.service.spec.ts
+++ b/backend/tarot-app/src/modules/ai/application/services/ai-provider.service.spec.ts
@@ -332,6 +332,21 @@ describe('AIProviderService', () => {
       expect(openaiProvider.generateCompletion).toHaveBeenCalled();
     });
 
+    it('should throw a clear error when NO provider is configured', async () => {
+      groqProvider.isConfigured.mockReturnValue(false);
+      deepseekProvider.isConfigured.mockReturnValue(false);
+      geminiProvider.isConfigured.mockReturnValue(false);
+      openaiProvider.isConfigured.mockReturnValue(false);
+
+      await expect(
+        service.generateCompletion(mockMessages, 1, 1),
+      ).rejects.toThrow(/No hay ningún proveedor de IA configurado/);
+
+      // No se intenta ningún provider ni se loguea error vacío
+      expect(groqProvider.generateCompletion).not.toHaveBeenCalled();
+      expect(aiUsageService.createLog).not.toHaveBeenCalled();
+    });
+
     it('should log all provider failures', async () => {
       const error = new Error('Service unavailable');
 

--- a/backend/tarot-app/src/modules/ai/application/services/ai-provider.service.ts
+++ b/backend/tarot-app/src/modules/ai/application/services/ai-provider.service.ts
@@ -111,7 +111,18 @@ export class AIProviderService {
     let fallbackUsed = false;
     let providerIndex = 0;
 
-    for (const provider of this.getOrderedProviders(primaryProvider)) {
+    const orderedProviders = this.getOrderedProviders(primaryProvider);
+
+    // Si ningún proveedor tiene API key configurada, el bucle no correría y se
+    // lanzaría "All AI providers failed:" con resumen vacío (confuso). Avisar claro.
+    if (orderedProviders.length === 0) {
+      throw new Error(
+        'No hay ningún proveedor de IA configurado (falta API key). ' +
+          'Configurá al menos GROQ_API_KEY o DEEPSEEK_API_KEY.',
+      );
+    }
+
+    for (const provider of orderedProviders) {
       const providerType = provider.getProviderType();
       const circuitBreaker = this.circuitBreakers.get(providerType);
 

--- a/backend/tarot-app/src/modules/ai/application/services/ai-provider.service.ts
+++ b/backend/tarot-app/src/modules/ai/application/services/ai-provider.service.ts
@@ -257,23 +257,31 @@ export class AIProviderService {
    * Returns the provider list to iterate, placing `primaryProvider` first when
    * provided and keeping the rest in their default priority order as fallback.
    * If the preferred provider is unknown, falls back to the default order.
+   *
+   * Providers without an API key configured are excluded entirely, so they are
+   * never attempted nor logged as errors (evita ensuciar las métricas con
+   * proveedores que no están en uso, ej. OpenAI/Gemini sin key).
    */
   private getOrderedProviders(primaryProvider?: AIProviderType): IAIProvider[] {
+    const configured = this.providers.filter((provider) =>
+      provider.isConfigured(),
+    );
+
     if (!primaryProvider) {
-      return this.providers;
+      return configured;
     }
 
-    const preferred = this.providers.find(
+    const preferred = configured.find(
       (provider) => provider.getProviderType() === primaryProvider,
     );
 
     if (!preferred) {
-      return this.providers;
+      return configured;
     }
 
     return [
       preferred,
-      ...this.providers.filter(
+      ...configured.filter(
         (provider) => provider.getProviderType() !== primaryProvider,
       ),
     ];

--- a/backend/tarot-app/src/modules/ai/application/services/ai-provider.service.ts
+++ b/backend/tarot-app/src/modules/ai/application/services/ai-provider.service.ts
@@ -95,18 +95,23 @@ export class AIProviderService {
    * Generate completion with automatic fallback, retry, and circuit breaker
    * Tries providers in priority order until one succeeds
    * @param config Optional AI config (temperature, maxTokens, topP) from tarotista settings
+   * @param primaryProvider Optional preferred provider to try first. The remaining
+   *   providers stay as fallback in their default priority order. Allows each feature
+   *   to pick its main provider (ej: DeepSeek para tarot/numerología/carta astral,
+   *   Groq para horóscopos) sin perder el fallback automático.
    */
   async generateCompletion(
     messages: AIMessage[],
     userId?: number | null,
     readingId?: number | null,
     config?: Partial<AIProviderConfig>,
+    primaryProvider?: AIProviderType,
   ): Promise<AIResponse> {
     const errors: Array<{ provider: string; error: string }> = [];
     let fallbackUsed = false;
     let providerIndex = 0;
 
-    for (const provider of this.providers) {
+    for (const provider of this.getOrderedProviders(primaryProvider)) {
       const providerType = provider.getProviderType();
       const circuitBreaker = this.circuitBreakers.get(providerType);
 
@@ -246,6 +251,32 @@ export class AIProviderService {
       .map((e) => `${e.provider}: ${e.error}`)
       .join('; ');
     throw new Error(`All AI providers failed: ${errorSummary}`);
+  }
+
+  /**
+   * Returns the provider list to iterate, placing `primaryProvider` first when
+   * provided and keeping the rest in their default priority order as fallback.
+   * If the preferred provider is unknown, falls back to the default order.
+   */
+  private getOrderedProviders(primaryProvider?: AIProviderType): IAIProvider[] {
+    if (!primaryProvider) {
+      return this.providers;
+    }
+
+    const preferred = this.providers.find(
+      (provider) => provider.getProviderType() === primaryProvider,
+    );
+
+    if (!preferred) {
+      return this.providers;
+    }
+
+    return [
+      preferred,
+      ...this.providers.filter(
+        (provider) => provider.getProviderType() !== primaryProvider,
+      ),
+    ];
   }
 
   private mapProviderToEnum(providerType: AIProviderType | string): AIProvider {

--- a/backend/tarot-app/src/modules/ai/domain/interfaces/ai-provider.interface.ts
+++ b/backend/tarot-app/src/modules/ai/domain/interfaces/ai-provider.interface.ts
@@ -44,5 +44,12 @@ export interface IAIProvider {
 
   isAvailable(): Promise<boolean>;
 
+  /**
+   * Synchronous check: whether the provider has an API key configured.
+   * Used to skip unconfigured providers in the fallback chain without
+   * attempting a call (and without polluting usage metrics with errors).
+   */
+  isConfigured(): boolean;
+
   getProviderType(): AIProviderType;
 }

--- a/backend/tarot-app/src/modules/ai/infrastructure/providers/deepseek.provider.ts
+++ b/backend/tarot-app/src/modules/ai/infrastructure/providers/deepseek.provider.ts
@@ -243,6 +243,10 @@ export class DeepSeekProvider implements IAIProvider {
     return AIProviderType.DEEPSEEK;
   }
 
+  isConfigured(): boolean {
+    return this.client !== null;
+  }
+
   /**
    * Calculate appropriate max_tokens based on card count
    * DeepSeek is economical - moderate limits

--- a/backend/tarot-app/src/modules/ai/infrastructure/providers/deepseek.provider.ts
+++ b/backend/tarot-app/src/modules/ai/infrastructure/providers/deepseek.provider.ts
@@ -13,7 +13,7 @@ import { AIProviderException, AIErrorType } from '../errors/ai-error.types';
 @Injectable()
 export class DeepSeekProvider implements IAIProvider {
   private client: OpenAI | null = null;
-  private readonly DEFAULT_MODEL = 'deepseek-chat';
+  private readonly DEFAULT_MODEL = 'deepseek-v4-flash';
   private readonly DEFAULT_TEMPERATURE = 0.6; // Similar to Llama
   private readonly TIMEOUT = 15000; // 15s
   private readonly BASE_URL = 'https://api.deepseek.com';

--- a/backend/tarot-app/src/modules/ai/infrastructure/providers/gemini.provider.ts
+++ b/backend/tarot-app/src/modules/ai/infrastructure/providers/gemini.provider.ts
@@ -224,6 +224,10 @@ export class GeminiProvider implements IAIProvider {
     return AIProviderType.GEMINI;
   }
 
+  isConfigured(): boolean {
+    return this.client !== null;
+  }
+
   /**
    * Convert OpenAI-style messages to Gemini Content format
    * Gemini uses 'user' and 'model' roles instead of 'user' and 'assistant'

--- a/backend/tarot-app/src/modules/ai/infrastructure/providers/groq.provider.ts
+++ b/backend/tarot-app/src/modules/ai/infrastructure/providers/groq.provider.ts
@@ -225,6 +225,10 @@ export class GroqProvider implements IAIProvider {
     return AIProviderType.GROQ;
   }
 
+  isConfigured(): boolean {
+    return this.client !== null;
+  }
+
   /**
    * Calculate appropriate max_tokens based on card count
    * Groq is free, so we can be more generous

--- a/backend/tarot-app/src/modules/ai/infrastructure/providers/openai.provider.ts
+++ b/backend/tarot-app/src/modules/ai/infrastructure/providers/openai.provider.ts
@@ -220,6 +220,10 @@ export class OpenAIProvider implements IAIProvider {
     return AIProviderType.OPENAI;
   }
 
+  isConfigured(): boolean {
+    return this.client !== null;
+  }
+
   /**
    * Calculate appropriate max_tokens based on card count
    * OpenAI is costly, so we're more restrictive

--- a/backend/tarot-app/src/modules/birth-chart/application/services/chart-ai-synthesis.service.spec.ts
+++ b/backend/tarot-app/src/modules/birth-chart/application/services/chart-ai-synthesis.service.spec.ts
@@ -185,6 +185,7 @@ Los aspectos en tu carta sugieren una tensión creativa que te impulsa constante
           maxTokens: expect.any(Number),
           temperature: expect.any(Number),
         }),
+        AIProviderType.DEEPSEEK, // IA principal de carta astral
       );
     });
 

--- a/backend/tarot-app/src/modules/birth-chart/application/services/chart-ai-synthesis.service.ts
+++ b/backend/tarot-app/src/modules/birth-chart/application/services/chart-ai-synthesis.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AIProviderService } from '../../../ai/application/services/ai-provider.service';
-import { AIMessage } from '../../../ai/domain/interfaces/ai-provider.interface';
+import {
+  AIMessage,
+  AIProviderType,
+} from '../../../ai/domain/interfaces/ai-provider.interface';
 import { ChartData } from '../../entities/birth-chart.entity';
 import {
   ZodiacSign,
@@ -81,6 +84,7 @@ export class ChartAISynthesisService {
           maxTokens: this.MAX_TOKENS,
           temperature: this.TEMPERATURE,
         },
+        AIProviderType.DEEPSEEK, // IA principal de carta astral (fallback automático)
       );
 
       const durationMs = Date.now() - startTime;

--- a/backend/tarot-app/src/modules/health/ai-health.service.spec.ts
+++ b/backend/tarot-app/src/modules/health/ai-health.service.spec.ts
@@ -189,7 +189,7 @@ describe('AIHealthService', () => {
     it('should detect valid DeepSeek API key', async () => {
       mockConfigService.get.mockImplementation((key: string) => {
         if (key === 'DEEPSEEK_API_KEY') return 'sk-deepseek123';
-        if (key === 'DEEPSEEK_MODEL') return 'deepseek-chat';
+        if (key === 'DEEPSEEK_MODEL') return 'deepseek-v4-flash';
         return undefined;
       });
 
@@ -197,7 +197,7 @@ describe('AIHealthService', () => {
 
       expect(result.provider).toBe('deepseek');
       expect(result.configured).toBe(true);
-      expect(result.model).toBe('deepseek-chat');
+      expect(result.model).toBe('deepseek-v4-flash');
     });
   });
 

--- a/backend/tarot-app/src/modules/health/ai-health.service.ts
+++ b/backend/tarot-app/src/modules/health/ai-health.service.ts
@@ -261,7 +261,8 @@ export class AIHealthService {
       deepseek.chat.completions.create({
         messages: [{ role: 'user', content: 'test' }],
         model:
-          this.configService.get<string>('DEEPSEEK_MODEL') || 'deepseek-chat',
+          this.configService.get<string>('DEEPSEEK_MODEL') ||
+          'deepseek-v4-flash',
         max_tokens: 1,
       }),
       this.timeout(this.DEEPSEEK_TIMEOUT),

--- a/backend/tarot-app/src/modules/horoscope/application/services/chinese-horoscope.service.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/chinese-horoscope.service.ts
@@ -7,7 +7,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ChineseHoroscope } from '../../entities/chinese-horoscope.entity';
 import { AIProviderService } from '../../../ai/application/services/ai-provider.service';
-import { AIMessage } from '../../../ai/domain/interfaces/ai-provider.interface';
+import {
+  AIMessage,
+  AIProviderType,
+} from '../../../ai/domain/interfaces/ai-provider.interface';
 import {
   ChineseZodiacAnimal,
   ChineseElement,
@@ -155,6 +158,7 @@ export class ChineseHoroscopeService {
         temperature: 0.7, // Balance entre creatividad y consistencia
         maxTokens: 1500, // Suficiente para las 4 áreas + elementos lucky
       },
+      AIProviderType.GROQ, // Los horóscopos usan Groq (fallback automático al resto)
     );
 
     // 5. Parsear respuesta de la IA

--- a/backend/tarot-app/src/modules/horoscope/application/services/horoscope-generation.service.spec.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/horoscope-generation.service.spec.ts
@@ -154,6 +154,7 @@ describe('HoroscopeGenerationService', () => {
           temperature: 0.8,
           maxTokens: 1000,
         },
+        AIProviderType.GROQ, // Los horóscopos usan Groq
       );
       expect(repository.create).toHaveBeenCalled();
       expect(repository.save).toHaveBeenCalled();

--- a/backend/tarot-app/src/modules/horoscope/application/services/horoscope-generation.service.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/horoscope-generation.service.ts
@@ -7,7 +7,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan } from 'typeorm';
 import { DailyHoroscope } from '../../entities/daily-horoscope.entity';
 import { AIProviderService } from '../../../ai/application/services/ai-provider.service';
-import { AIMessage } from '../../../ai/domain/interfaces/ai-provider.interface';
+import {
+  AIMessage,
+  AIProviderType,
+} from '../../../ai/domain/interfaces/ai-provider.interface';
 import {
   getZodiacSignInfo,
   ZodiacSign,
@@ -97,6 +100,7 @@ export class HoroscopeGenerationService {
         temperature: 0.8, // Mayor variedad en las generaciones
         maxTokens: 1000, // Suficiente para los 3 areas + elementos lucky
       },
+      AIProviderType.GROQ, // Los horóscopos usan Groq (fallback automático al resto)
     );
 
     // 5. Parsear respuesta de la IA

--- a/backend/tarot-app/src/modules/numerology/numerology.service.ts
+++ b/backend/tarot-app/src/modules/numerology/numerology.service.ts
@@ -17,6 +17,7 @@ import {
 } from './dto/numerology-response.dto';
 import { NumerologyInterpretation } from './entities/numerology-interpretation.entity';
 import { AIProviderService } from '../ai/application/services/ai-provider.service';
+import { AIProviderType } from '../ai/domain/interfaces/ai-provider.interface';
 import {
   NUMEROLOGY_SYSTEM_PROMPT,
   buildNumerologyUserPrompt,
@@ -149,6 +150,7 @@ export class NumerologyService {
       user.id,
       null,
       { temperature: 0.7, maxTokens: 1500 },
+      AIProviderType.DEEPSEEK, // IA principal (fallback automático al resto)
     );
 
     const generationTimeMs = Date.now() - startTime;

--- a/backend/tarot-app/src/modules/tarot/interpretations/interpretations.service.ts
+++ b/backend/tarot-app/src/modules/tarot/interpretations/interpretations.service.ts
@@ -17,6 +17,7 @@ import { TarotSpread } from '../spreads/entities/tarot-spread.entity';
 import { TarotReading } from '../readings/entities/tarot-reading.entity';
 import { Tarotista } from '../../tarotistas/entities/tarotista.entity';
 import { AIProviderService } from '../../ai/application/services/ai-provider.service';
+import { AIProviderType } from '../../ai/domain/interfaces/ai-provider.interface';
 import { InterpretationCacheService } from '../../cache/application/services/interpretation-cache.service';
 import { PromptBuilderService } from '../../ai/application/services/prompt-builder.service';
 import { TarotPrompts } from '../../ai/application/prompts/tarot-prompts';
@@ -219,6 +220,7 @@ export class InterpretationsService {
         userId,
         readingId,
         aiConfig, // Pass maxTokens from DB config (default: 4000)
+        AIProviderType.DEEPSEEK, // IA principal del tarot (fallback automático al resto)
       );
 
       // Sanitize AI response before using it (TASK-048-a: Output Sanitization)
@@ -437,11 +439,17 @@ export class InterpretationsService {
         `Generating daily card interpretation for card: ${card.name} (${isReversed ? 'reversed' : 'upright'})`,
       );
 
-      // Generar interpretación con IA
-      const response = await this.aiProviderService.generateCompletion([
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userPrompt },
-      ]);
+      // Generar interpretación con IA (DeepSeek principal, fallback automático)
+      const response = await this.aiProviderService.generateCompletion(
+        [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userPrompt },
+        ],
+        undefined,
+        undefined,
+        undefined,
+        AIProviderType.DEEPSEEK,
+      );
 
       // Sanitizar output
       const sanitized = this.outputSanitizer.sanitizeAiResponse(

--- a/backend/tarot-app/src/modules/tarot/interpretations/interpretations.service.ts
+++ b/backend/tarot-app/src/modules/tarot/interpretations/interpretations.service.ts
@@ -445,9 +445,9 @@ export class InterpretationsService {
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt },
         ],
-        undefined,
-        undefined,
-        undefined,
+        null, // userId: no aplica para carta del día
+        null, // readingId: no aplica
+        undefined, // config: usar defaults del provider
         AIProviderType.DEEPSEEK,
       );
 

--- a/docs/BACKLOG_BUGFIXES_2026_05_PARTE2.md
+++ b/docs/BACKLOG_BUGFIXES_2026_05_PARTE2.md
@@ -1,0 +1,468 @@
+# BACKLOG: CORRECCIÓN DE BUGS REPORTADOS — Mayo 2026 (Ronda 2)
+
+## PARTE A: REPORTE DE BUGS
+
+**Proyecto:** Auguria - Plataforma de Servicios Místicos
+**Tipo:** Corrección de defectos en módulos existentes
+**Versión:** 1.0
+**Fecha:** 29 de mayo de 2026
+**Preparado por:** Ariel (Product Owner) + Claude (Asistente IA)
+**Continuación de:** `BACKLOG_BUGFIXES_2026_05.md` (la numeración de BUGs y tareas continúa desde donde terminó ese archivo: BUG-016 / T-BUG-016).
+
+---
+
+## CONTEXTO
+
+Durante una segunda verificación visual sobre **https://staging.auguriatarot.com** Ariel reportó cuatro problemas adicionales, todos en el frontend público:
+
+1. **Widget de horóscopo occidental no reconoce la fecha de nacimiento**: aunque el usuario tiene su fecha de nacimiento cargada en el perfil, el widget del dashboard no muestra su signo y muestra el CTA "Configura tu fecha de nacimiento".
+2. **La Guía del Tarot no aparece en `/enciclopedia/guias`**: siendo la guía más importante de la página, solo se puede llegar a ella desde los widgets de "Tirada de Tarot" o "Tarot del Día", pero no figura en el listado de Guías.
+3. **Símbolos del horóscopo occidental se ven multicolor (emoji) en vez de lila**: los 12 símbolos zodiacales del selector se renderizan como emoji multicolor del sistema. Lo deseado es que sean del **color lila/primary de la página** (monocromáticos), coherentes con la identidad visual.
+4. **Tarjeta informativa de cada servicio mucho más pobre que la de Numerología**: la página de Numerología muestra una tarjeta rica y estructurada (`NumerologyIntro`: intro + dos columnas con bullets explicativos + nota + botón a la enciclopedia). El resto de los servicios usan el genérico `EncyclopediaInfoWidget`, que solo muestra una frase. La diferencia es abismal: todos los servicios deben mostrar tanta información y con el mismo nivel de riqueza visual que Numerología.
+
+---
+
+## ÍNDICE DE BUGS
+
+| ID      | Bug                                                                          | Severidad  | Módulo afectado                |
+| ------- | ---------------------------------------------------------------------------- | ---------- | ------------------------------ |
+| BUG-016 | Widget de horóscopo pide configurar fecha aunque ya está cargada             | 🟠 Alta    | Frontend — Horoscope Widget    |
+| BUG-017 | La Guía del Tarot no figura en `/enciclopedia/guias`                         | 🔴 Crítica | Frontend — Encyclopedia        |
+| BUG-018 | Símbolos zodiacales se ven multicolor (emoji) en vez de lila                 | 🟡 Media   | Frontend — Horoscope UI        |
+| BUG-019 | Tarjeta informativa por servicio mucho más pobre que la de Numerología       | 🟠 Alta    | Frontend — Encyclopedia/Servicios |
+
+---
+
+## DETALLE DE BUGS
+
+### BUG-016: Widget de Horóscopo Pide Configurar Fecha Aunque Ya Está Cargada
+
+**Severidad:** 🟠 Alta
+**Módulo:** `frontend/src/components/features/horoscope/HoroscopeWidget.tsx`
+**Reportado por:** Ariel — dashboard con fecha de nacimiento ya cargada (29/05/2026)
+
+#### Descripción del Problema
+
+En el dashboard (`UserDashboard.tsx:71`), el `HoroscopeWidget` debería mostrar el signo del usuario y un resumen del horóscopo del día. Pese a tener la fecha de nacimiento cargada en el perfil, el widget muestra el estado "sin datos": el título "Tu Horóscopo" + el texto **"Configura tu fecha de nacimiento para ver tu horóscopo personalizado"** + botón "Configurar". El usuario interpreta (erróneamente) que su fecha no está guardada.
+
+#### Causa Raíz Identificada
+
+El problema es una **conflación de errores en el frontend**. En [HoroscopeWidget.tsx:51-66](frontend/src/components/features/horoscope/HoroscopeWidget.tsx#L51-L66):
+
+```tsx
+// Error or no data (includes no birthDate case from API)
+if (error || !horoscope) {
+  return (
+    <Card ...>
+      <h2>Tu Horóscopo</h2>
+      <p>Configura tu fecha de nacimiento para ver tu horóscopo personalizado</p>
+      <Button asChild ...><Link href="/perfil">Configurar</Link></Button>
+    </Card>
+  );
+}
+```
+
+El widget trata **cualquier** error igual que "el usuario no tiene fecha de nacimiento". Pero el endpoint backend `GET /horoscope/my-sign` ([horoscope.controller.ts:170-204](backend/tarot-app/src/modules/horoscope/infrastructure/controllers/horoscope.controller.ts#L170-L204)) puede fallar por dos motivos muy distintos:
+
+- **400 Bad Request** → `if (!user.birthDate)` → "Configura tu fecha de nacimiento…" (este sí es el caso real de fecha faltante).
+- **404 Not Found** → `if (!horoscope)` → "Horóscopo de {sign} no disponible" — es decir, **la fecha SÍ está cargada y el signo se calculó bien**, pero el horóscopo diario para ese signo todavía no fue generado para la fecha de hoy.
+
+Además, el hook [useHoroscope.ts:98-105](frontend/src/hooks/api/useHoroscope.ts#L98-L105) tiene `retry: false`, por lo que un fallo transitorio (5xx / timeout) tampoco se reintenta y cae también al mismo CTA engañoso.
+
+**Resultado**: si el horóscopo del día para el signo del usuario no fue generado (404) o hubo un error de red/5xx, el usuario con fecha cargada ve "Configura tu fecha de nacimiento", lo cual es incorrecto y confuso.
+
+> ⚠️ **Causa subyacente probable (a verificar):** que el horóscopo diario del signo del usuario no esté generado para hoy apunta a un hueco en la generación diaria de horóscopos occidentales, análogo a BUG-001 (horóscopos chinos faltantes). Conviene auditar `horoscope-cron.service.ts` / `horoscope-generation.service.ts` para confirmar que los 12 signos se generan completos cada día y que existe reintento ante fallos parciales.
+
+#### Criterios de Aceptación
+
+1. **Dado** que tengo la fecha de nacimiento cargada y el horóscopo del día de mi signo existe
+   **Cuando** abro el dashboard
+   **Entonces** el widget muestra mi símbolo, nombre del signo y el resumen (comportamiento exitoso actual).
+
+2. **Dado** que NO tengo fecha de nacimiento cargada (backend responde **400**)
+   **Cuando** abro el dashboard
+   **Entonces** veo el CTA "Configura tu fecha de nacimiento" con botón a `/perfil`.
+
+3. **Dado** que tengo fecha cargada pero el horóscopo del día de mi signo aún no existe (backend responde **404**)
+   **Cuando** abro el dashboard
+   **Entonces** veo un mensaje distinto y honesto (ej: "Tu horóscopo de hoy se está preparando, volvé en un rato"), NO el CTA de configurar fecha.
+
+4. **Dado** que el endpoint falla por error transitorio (5xx / red)
+   **Cuando** abro el dashboard
+   **Entonces** se reintenta razonablemente y, si persiste, se muestra un estado de error genérico (no el CTA de fecha).
+
+5. **(Subyacente)** **Dado** que es un día cualquiera
+   **Cuando** se consulta `/horoscope/my-sign` para cualquier signo
+   **Entonces** el horóscopo del día existe para los 12 signos (generación diaria completa y con reintento).
+
+#### Notas Técnicas
+
+- El cliente Axios expone `error.response?.status`. Diferenciar `400` (fecha faltante) vs `404` (horóscopo no generado) vs resto.
+- Considerar exponer un campo/estado tipado desde el hook (ej. mapear el error a `'no-birthdate' | 'not-generated' | 'error'`) para que el widget no inspeccione el status crudo.
+- Reevaluar `retry: false` en `useMySignHoroscope`: mantener "no reintentar" solo para 400; permitir 1-2 reintentos para 5xx.
+- El mismo patrón de mensaje empático ya se aplicó en horóscopo chino (T-BUG-001-C, `AnimalHoroscopePage.tsx`) — reutilizar criterio/copys.
+- Auditar la generación diaria de horóscopos occidentales (cron) por la causa subyacente del 404.
+
+---
+
+### BUG-017: La Guía del Tarot No Figura en `/enciclopedia/guias`
+
+**Severidad:** 🔴 Crítica (la guía más importante del sitio no es navegable desde el índice de guías)
+**Módulo:** `frontend/src/components/features/encyclopedia/GuiasContent.tsx`
+**Reportado por:** Ariel — navegación a `/enciclopedia/guias` (29/05/2026)
+
+#### Descripción del Problema
+
+En `https://staging.auguriatarot.com/enciclopedia/guias` se listan las guías de Numerología, Péndulo, Carta Astral, Rituales, Horóscopo y Horóscopo Chino, pero **NO aparece la Guía del Tarot**, que es la más importante de la plataforma. Hoy solo se puede acceder a ella desde el `EncyclopediaInfoWidget` de las páginas "Tirada de Tarot" (`/tarot`) y "Tarot del Día" (`/carta-del-dia`), que enlazan a `/enciclopedia/guias/guia-tarot`. El artículo existe, pero el índice de guías no lo muestra.
+
+#### Causa Raíz Identificada
+
+En [GuiasContent.tsx:12-19](frontend/src/components/features/encyclopedia/GuiasContent.tsx#L12-L19) el array de categorías recorridas **omite `GUIDE_TAROT`**:
+
+```ts
+const GUIDE_CATEGORIES: ArticleCategory[] = [
+  ArticleCategory.GUIDE_NUMEROLOGY,
+  ArticleCategory.GUIDE_PENDULUM,
+  ArticleCategory.GUIDE_BIRTH_CHART,
+  ArticleCategory.GUIDE_RITUAL,
+  ArticleCategory.GUIDE_HOROSCOPE,
+  ArticleCategory.GUIDE_CHINESE,
+  // ❌ falta ArticleCategory.GUIDE_TAROT
+];
+```
+
+La categoría existe en el enum ([encyclopedia-article.types.ts:23](frontend/src/types/encyclopedia-article.types.ts#L23): `GUIDE_TAROT = 'guide_tarot'`) y el artículo está sembrado en el backend con slug `guia-tarot` ([activity-guides.data.ts:15-18](backend/tarot-app/src/modules/encyclopedia/data/activity-guides.data.ts#L15-L18)). El componente renderiza una `CategorySection` por cada entrada del array (un fetch por categoría), por lo que al faltar la entrada, la Guía del Tarot simplemente nunca se solicita ni se muestra.
+
+#### Criterios de Aceptación
+
+1. **Dado** que entro a `/enciclopedia/guias`
+   **Cuando** carga la lista
+   **Entonces** la **Guía del Tarot** aparece en el listado, idealmente **primera** por ser la más importante.
+
+2. **Dado** que clickeo la Guía del Tarot desde el índice
+   **Cuando** navego
+   **Entonces** llego a `/enciclopedia/guias/guia-tarot` con el artículo completo.
+
+3. **Dado** que ya existían las otras 6 guías
+   **Cuando** se agrega la del Tarot
+   **Entonces** las demás siguen mostrándose sin regresiones.
+
+#### Notas Técnicas
+
+- Fix mínimo: agregar `ArticleCategory.GUIDE_TAROT` al array `GUIDE_CATEGORIES`. Para dejarla primera, ubicarla al inicio del array.
+- Verificar que la BD de staging tenga el artículo `guia-tarot` sembrado (el seed lo incluye; si falta, re-seed de encyclopedia).
+- Actualizar el test `GuiasContent` / `guias/page.test.tsx` para esperar 7 categorías (incluida Tarot).
+- Revisar si el comentario "6 guías" en `guias/page.tsx:6` y el JSDoc de `GuiasContent` deben pasar a "7 guías".
+
+---
+
+### BUG-018: Símbolos Zodiacales Se Ven Multicolor (Emoji) en Vez de Lila
+
+**Severidad:** 🟡 Media (estético/identidad visual)
+**Módulo:** `frontend/src/components/features/horoscope/ZodiacSignCard.tsx` (+ todo lugar que renderice `signInfo.symbol`)
+**Reportado por:** Ariel — selector de signos del horóscopo occidental (29/05/2026)
+
+#### Descripción del Problema
+
+Los 12 símbolos del selector de signos (`ZodiacSignSelector` → `ZodiacSignCard`) se ven **multicolor** (como emoji del sistema operativo). El estado **deseado es que sean del color lila/primary de la página** (monocromáticos), coherentes con la identidad visual del sitio. **NO deben ser coloridos.**
+
+#### Causa Raíz Identificada
+
+En [ZodiacSignCard.tsx:89-91](frontend/src/components/features/horoscope/ZodiacSignCard.tsx#L89-L91) el símbolo se renderiza como carácter Unicode plano sin forzar presentación de texto ni color explícito:
+
+```tsx
+<span className="text-4xl" role="img" aria-label={signInfo.nameEs}>
+  {signInfo.symbol}
+</span>
+```
+
+Los símbolos en `ZODIAC_SIGNS_INFO` ([zodiac.ts](frontend/src/lib/utils/zodiac.ts)) son los glifos Unicode `♈ ♉ ♊ …` (U+2648–U+2653). Estos code points pertenecen al rango de **emoji** y muchos navegadores/SO (especialmente móviles) los renderizan por defecto como **emoji multicolor** en lugar de texto. Como no se fuerza la presentación de texto ni se aplica una clase de color, el glifo cae al render emoji del sistema → se ve multicolor y no toma el lila de la página.
+
+> Esto explica el reporte "estaban teñidos del lila… ahora son multicolor": un cambio de fuente/SO/navegador hizo que los glifos pasaran a renderizarse como emoji.
+
+#### Criterios de Aceptación
+
+1. **Dado** que veo el selector de signos en cualquier dispositivo/navegador
+   **Cuando** se renderizan los 12 símbolos
+   **Entonces** se muestran **monocromáticos en el color lila/primary** de la página (no como emoji multicolor).
+
+2. **Dado** un signo seleccionado o "Tu signo"
+   **Cuando** se aplica el color
+   **Entonces** los estados `ring`/`border` siguen visibles y legibles.
+
+3. **Dado** cualquier otro lugar que muestre el símbolo zodiacal (ej. `HoroscopeWidget`, detalle `[sign]`)
+   **Cuando** se renderiza
+   **Entonces** también se ve lila/monocromático (consistencia).
+
+#### Notas Técnicas
+
+- Forzar **presentación de texto** del glifo: agregar el selector de variación `︎` (U+FE0E, *text presentation selector*) al símbolo, y/o aplicar CSS `font-variant-emoji: text` en el `<span>`.
+- Aplicar explícitamente el color lila con `text-primary` (o el token correspondiente) al `<span>` del símbolo.
+- Alternativa más robusta y multiplataforma: reemplazar los glifos Unicode por **íconos SVG** (set propio o librería) teñidos con `text-primary` vía `currentColor` — evita depender del soporte de `font-variant-emoji`.
+- Aplicar el mismo tratamiento en todos los lugares que rendericen `signInfo.symbol` (`HoroscopeWidget.tsx:74`, detalle `[sign]`, etc.).
+- Tests de `ZodiacSignCard` verificando la clase de color / presencia del selector de variación.
+
+---
+
+### BUG-019: Tarjeta Informativa por Servicio Mucho Más Pobre que la de Numerología
+
+**Severidad:** 🟠 Alta
+**Módulo:** `frontend/src/components/features/encyclopedia/EncyclopediaInfoWidget.tsx` vs `frontend/src/components/features/numerology/NumerologyIntro.tsx`
+**Reportado por:** Ariel — comparación visual entre Numerología y el resto de los servicios (29/05/2026)
+
+#### Descripción del Problema
+
+La página de **Numerología** muestra una tarjeta informativa rica y estructurada: título "¿Qué es la Numerología?", párrafo introductorio, **dos columnas** ("📅 Desde tu Fecha de Nacimiento" / "✍️ Desde tu Nombre Completo") con bullets explicativos (Camino de Vida, Número de Cumpleaños, Año Personal, Mes Personal, Número de Expresión, Número del Alma, Personalidad), una **nota** destacada (números maestros 11/22/33) y el botón "Ver más en la Enciclopedia".
+
+El resto de los servicios (Tarot, Horóscopo Occidental, Horóscopo Chino, Péndulo, Carta Astral, Rituales, Carta del Día) muestran apenas **una frase** + el botón. La diferencia es **abismal**. Se pide que todos los servicios muestren tanta información y con la misma riqueza visual que Numerología; el resumen actual es "simple, aburrido y feo".
+
+#### Causa Raíz Identificada
+
+Son **dos componentes distintos**, no el mismo con datos diferentes:
+
+- **Numerología** usa un componente dedicado y hecho a medida: [NumerologyIntro.tsx](frontend/src/components/features/numerology/NumerologyIntro.tsx) — layout estructurado (intro + grid de 2 columnas con `<ul>` de bullets + nota + botón). Todo el contenido está escrito a mano en el componente.
+- **Todos los demás servicios** usan el genérico [EncyclopediaInfoWidget.tsx:91-93](frontend/src/components/features/encyclopedia/EncyclopediaInfoWidget.tsx#L91-L93), que solo renderiza `{article.snippet}` (una frase traída del seed):
+
+  ```tsx
+  <h2 ...>{displayTitle}</h2>
+  <p className="text-sm text-gray-700">{article.snippet}</p>
+  <Button asChild ...><Link href={linkHref}>Ver más en la Enciclopedia</Link></Button>
+  ```
+
+Páginas que usan hoy el widget pobre: `/carta-del-dia`, `/horoscopo`, `/horoscopo-chino`, `/ritual`, `/tarot`, Carta Astral (`BirthChartPageContent`), Péndulo (`PendulumConsultation`), Rituales (`RitualsPage`).
+
+**Resultado**: solo Numerología tiene la versión rica; el resto quedó con el widget mínimo.
+
+#### Criterios de Aceptación
+
+1. **Dado** que abro cualquier página de servicio
+   **Cuando** veo la tarjeta informativa de ese servicio
+   **Entonces** tiene un nivel de riqueza equivalente al de Numerología: intro + secciones/bullets explicativos + (si aplica) nota + botón "Ver más en la Enciclopedia".
+
+2. **Dado** que comparo las tarjetas entre todos los servicios
+   **Cuando** las leo
+   **Entonces** todas tienen estructura y profundidad homogéneas (ya no hay una "abismalmente" mejor que las otras).
+
+3. **Dado** que clickeo "Ver más en la Enciclopedia"
+   **Cuando** navego
+   **Entonces** llego al artículo completo (sin regresiones).
+
+4. **Dado** el contenido de cada tarjeta
+   **Cuando** se redacta
+   **Entonces** es específico y veraz por servicio (Tarot habla de arcanos/tiradas, Horóscopo de signos/elementos/modalidades, Péndulo de radiestesia, etc.).
+
+#### Notas Técnicas
+
+- Dos enfoques (decisión de arquitectura — recomendado el B por mantenibilidad):
+  - **A. Un componente rico por servicio:** crear `TarotIntro`, `HoroscopeIntro`, `ChineseHoroscopeIntro`, `PendulumIntro`, `BirthChartIntro`, `RitualIntro` espejando `NumerologyIntro`. Rápido de copiar pero genera mucha duplicación.
+  - **B. Generalizar `NumerologyIntro` en un componente data-driven:** crear `<ServiceIntro>` que reciba una estructura tipada (`title`, `intro`, `sections: { heading, icon, items: {term, description}[] }[]`, `note?`, `href`) y mover el contenido de cada servicio a un archivo de datos (`service-intros.data.ts`). `NumerologyIntro` pasa a ser una instancia de `<ServiceIntro>`. Menos duplicación, contenido centralizado.
+- Reemplazar el uso de `EncyclopediaInfoWidget` por el nuevo componente rico en las 8 ubicaciones listadas (o mantener `EncyclopediaInfoWidget` solo para casos secundarios).
+- Mantener el estilo visual de `NumerologyIntro` (card con gradiente lila/índigo, headings, bullets) como base del diseño.
+- Tests por servicio (render del título, secciones, bullets, botón) + actualizar tests de las páginas que cambian de widget.
+- Coordinar con `BACKLOG_CONSISTENCIA_UI.md` si existe tarea relacionada de consistencia.
+
+---
+
+---
+
+## PARTE B: TAREAS TÉCNICAS
+
+> **Convención de IDs:** continúa la numeración de `BACKLOG_BUGFIXES_2026_05.md`.
+> `-A` = backend, `-B` = frontend cuando aplica. Estimación en puntos de historia (1 punto ≈ 0.5 día).
+
+### Índice de Tareas Técnicas
+
+| ID          | Tarea                                                                          | Tipo        | Prioridad   | Estimación |
+| ----------- | ------------------------------------------------------------------------------ | ----------- | ----------- | ---------- |
+| T-BUG-016-A | Diferenciar estados del widget de horóscopo (400 vs 404 vs 5xx)                | Frontend    | 🟠 Alta     | 2 pts      |
+| T-BUG-016-B | (Subyacente) Auditar/robustecer generación diaria de horóscopos occidentales   | Backend     | 🟠 Alta     | 3 pts      |
+| T-BUG-017   | Agregar la Guía del Tarot al índice `/enciclopedia/guias`                       | Frontend    | 🔴 Crítica  | 0.5 pt     |
+| T-BUG-018   | Forzar render lila/monocromático de los símbolos zodiacales                    | Frontend    | 🟡 Media    | 1.5 pts    |
+| T-BUG-019   | Tarjetas informativas ricas por servicio (paridad con Numerología)             | Frontend    | 🟠 Alta     | 5-8 pts    |
+
+**Estimación total:** ~13–18 puntos.
+
+---
+
+## TAREAS DETALLADAS
+
+### T-BUG-016-A: Diferenciar Estados del Widget de Horóscopo (400 / 404 / 5xx)
+
+**Prioridad:** 🟠 Alta
+**Estimación:** 2 puntos
+**Dependencias:** ninguna
+**Cubre BUG:** BUG-016
+**Estado:** ⬜ Pendiente
+
+#### 📋 Descripción
+
+Que el `HoroscopeWidget` deje de mostrar "Configura tu fecha de nacimiento" cuando el problema NO es la falta de fecha. Mapear el error del endpoint a estados distintos y mostrar el copy correcto en cada uno.
+
+#### ✅ Tareas específicas
+
+- [ ] En `useMySignHoroscope` (o un wrapper), mapear el error a un estado tipado: `'no-birthdate'` (400) / `'not-generated'` (404) / `'error'` (resto).
+- [ ] Ajustar `retry`: no reintentar en 400/404; permitir 1-2 reintentos para 5xx.
+- [ ] En `HoroscopeWidget.tsx` reemplazar el bloque único `if (error || !horoscope)` por ramas:
+  - 400 → CTA "Configura tu fecha de nacimiento" (actual).
+  - 404 → mensaje "Tu horóscopo de hoy se está preparando, volvé en un rato".
+  - 5xx/desconocido → estado de error genérico con opción de reintentar.
+- [ ] Tests del widget por estado (success / 400 / 404 / 5xx).
+- [ ] Coverage ≥ 80%.
+
+#### 🎯 Criterios de Aceptación
+
+- Un usuario con fecha cargada y horóscopo no generado (404) ve el mensaje "en preparación", NO el CTA de fecha.
+- Solo el 400 muestra el CTA de configurar fecha.
+- Ciclo de calidad frontend completo pasa.
+
+#### 📁 Archivos involucrados
+
+- `frontend/src/components/features/horoscope/HoroscopeWidget.tsx`
+- `frontend/src/components/features/horoscope/HoroscopeWidget.test.tsx`
+- `frontend/src/hooks/api/useHoroscope.ts`
+
+---
+
+### T-BUG-016-B: Auditar/Robustecer Generación Diaria de Horóscopos Occidentales
+
+**Prioridad:** 🟠 Alta
+**Estimación:** 3 puntos
+**Dependencias:** ninguna (puede ir en paralelo con T-BUG-016-A)
+**Cubre BUG:** BUG-016 (causa subyacente)
+**Estado:** ⬜ Pendiente
+
+#### 📋 Descripción
+
+Confirmar que los 12 horóscopos occidentales se generan completos cada día y agregar reintento/visibilidad ante generación parcial (analogía directa con BUG-001 de horóscopos chinos).
+
+#### ✅ Tareas específicas
+
+- [ ] Auditar `horoscope-cron.service.ts` y `horoscope-generation.service.ts`: confirmar que se generan los 12 signos por día y qué pasa ante fallo individual.
+- [ ] Si un signo falla, reintentar con backoff sin abortar el resto del lote.
+- [ ] (Opcional) Endpoint admin de status del día (`generados / 12`) + "generar faltantes del día" reutilizando el patrón de T-BUG-001-A.
+- [ ] Tests unitarios de la lógica de generación/reintento.
+- [ ] Coverage ≥ 80%.
+
+#### 🎯 Criterios de Aceptación
+
+- En un día normal, `GET /horoscope/my-sign` nunca devuelve 404 por falta de generación para ninguno de los 12 signos.
+- Un fallo transitorio en un signo no deja hueco permanente.
+- `npm run test:cov && npm run build && node scripts/validate-architecture.js` pasan.
+
+#### 📁 Archivos involucrados
+
+- `backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.ts`
+- `backend/tarot-app/src/modules/horoscope/application/services/horoscope-generation.service.ts`
+- specs correspondientes.
+
+---
+
+### T-BUG-017: Agregar la Guía del Tarot al Índice `/enciclopedia/guias`
+
+**Prioridad:** 🔴 Crítica
+**Estimación:** 0.5 punto
+**Dependencias:** ninguna
+**Cubre BUG:** BUG-017
+**Estado:** ⬜ Pendiente
+
+#### ✅ Tareas específicas
+
+- [ ] Agregar `ArticleCategory.GUIDE_TAROT` al array `GUIDE_CATEGORIES` en `GuiasContent.tsx`, ubicándola **primera** (guía más importante).
+- [ ] Verificar que el artículo `guia-tarot` esté sembrado en staging/prod; re-seed de encyclopedia si falta.
+- [ ] Actualizar comentarios/JSDoc que mencionan "6 guías" → "7 guías" (`guias/page.tsx`, `GuiasContent`).
+- [ ] Actualizar tests (`GuiasContent` / `guias/page.test.tsx`) para esperar la Guía del Tarot.
+- [ ] Coverage ≥ 80%.
+
+#### 🎯 Criterios de Aceptación
+
+- La Guía del Tarot aparece (primera) en `/enciclopedia/guias` y enlaza a `/enciclopedia/guias/guia-tarot`.
+- Las otras 6 guías siguen listándose sin regresiones.
+- Ciclo de calidad frontend completo pasa.
+
+#### 📁 Archivos involucrados
+
+- `frontend/src/components/features/encyclopedia/GuiasContent.tsx`
+- `frontend/src/app/enciclopedia/guias/page.tsx` (comentario)
+- `frontend/src/app/enciclopedia/guias/page.test.tsx`
+
+---
+
+### T-BUG-018: Forzar Render Lila/Monocromático de los Símbolos Zodiacales
+
+**Prioridad:** 🟡 Media
+**Estimación:** 1.5 puntos
+**Dependencias:** ninguna
+**Cubre BUG:** BUG-018
+**Estado:** ⬜ Pendiente
+
+#### ✅ Tareas específicas
+
+- [ ] Forzar presentación de texto del glifo: agregar selector de variación U+FE0E al símbolo y/o `font-variant-emoji: text` en el `<span>` de `ZodiacSignCard.tsx`.
+- [ ] Aplicar color lila explícito (`text-primary` / token) al `<span>` del símbolo.
+- [ ] (Alternativa robusta) Evaluar reemplazo de glifos Unicode por SVG teñidos con `currentColor` si el soporte de `font-variant-emoji` es insuficiente en los navegadores objetivo.
+- [ ] Aplicar el mismo tratamiento en todos los lugares que rendericen `signInfo.symbol` (`HoroscopeWidget.tsx:74`, detalle `[sign]`).
+- [ ] Verificar en navegadores móviles (donde el render emoji es más frecuente) que se vean lila.
+- [ ] Tests de `ZodiacSignCard` (clase de color / selector de variación).
+- [ ] Coverage ≥ 80%.
+
+#### 🎯 Criterios de Aceptación
+
+- Los 12 símbolos se ven **lila/monocromáticos** (no emoji multicolor) en desktop y mobile.
+- Consistencia en todos los lugares que muestran símbolos zodiacales.
+- Ciclo de calidad frontend completo pasa.
+
+#### 📁 Archivos involucrados
+
+- `frontend/src/components/features/horoscope/ZodiacSignCard.tsx`
+- `frontend/src/components/features/horoscope/ZodiacSignCard.test.tsx`
+- (posibles) `frontend/src/lib/utils/zodiac.ts`, `HoroscopeWidget.tsx`, CSS global
+
+---
+
+### T-BUG-019: Tarjetas Informativas Ricas por Servicio (Paridad con Numerología)
+
+**Prioridad:** 🟠 Alta
+**Estimación:** 5-8 puntos (según enfoque A o B y cantidad de servicios)
+**Dependencias:** decisión de arquitectura (componente por servicio vs `<ServiceIntro>` data-driven)
+**Cubre BUG:** BUG-019
+**Estado:** ⬜ Pendiente
+
+#### 📋 Descripción
+
+Llevar la tarjeta informativa de cada servicio al mismo nivel de riqueza visual y de contenido que `NumerologyIntro` (intro + secciones con bullets + nota + botón a la enciclopedia), reemplazando el `EncyclopediaInfoWidget` mínimo. Recomendado el **Enfoque B** (componente genérico `<ServiceIntro>` + datos centralizados) por mantenibilidad.
+
+#### ✅ Tareas específicas
+
+**Enfoque B (recomendado — data-driven):**
+
+- [ ] Crear componente genérico `ServiceIntro` que reciba `{ title, intro, sections: { heading, icon?, items: {term, description}[] }[], note?, href }`, replicando el diseño de `NumerologyIntro` (card gradiente lila/índigo, grid de columnas, bullets, nota).
+- [ ] Crear archivo de datos `service-intros.data.ts` con el contenido por servicio (Tarot, Horóscopo Occidental, Horóscopo Chino, Péndulo, Carta Astral, Rituales, Carta del Día) — contenido específico y veraz.
+- [ ] Refactor: `NumerologyIntro` pasa a ser una instancia de `<ServiceIntro>` con sus datos (sin regresión visual).
+- [ ] Reemplazar `EncyclopediaInfoWidget` por `<ServiceIntro>` en las 8 ubicaciones: `/carta-del-dia`, `/horoscopo`, `/horoscopo-chino`, `/ritual`, `/tarot`, `BirthChartPageContent`, `PendulumConsultation`, `RitualsPage`.
+- [ ] Tests del genérico + un test por servicio (título, secciones, bullets, botón). Actualizar tests de páginas que cambian de widget.
+- [ ] Coverage ≥ 80%.
+
+**Enfoque A (alternativo — un componente por servicio):**
+
+- [ ] Crear `TarotIntro`, `HoroscopeIntro`, `ChineseHoroscopeIntro`, `PendulumIntro`, `BirthChartIntro`, `RitualIntro`, `CartaDelDiaIntro` espejando `NumerologyIntro`.
+- [ ] Reemplazar `EncyclopediaInfoWidget` por cada uno en su página.
+- [ ] Tests por componente. Coverage ≥ 80%.
+
+#### 🎯 Criterios de Aceptación
+
+- Cada servicio muestra una tarjeta con riqueza equivalente a Numerología (intro + secciones/bullets + nota cuando aplique + botón).
+- El contenido es específico y veraz por servicio.
+- "Ver más en la Enciclopedia" sigue llevando al artículo completo.
+- Numerología no sufre regresión visual.
+- Ciclo de calidad frontend completo pasa.
+
+#### 📁 Archivos involucrados
+
+- `frontend/src/components/features/encyclopedia/` — nuevo `ServiceIntro` (Enfoque B)
+- `frontend/src/components/features/numerology/NumerologyIntro.tsx` — refactor a `<ServiceIntro>`
+- nuevo `service-intros.data.ts` (Enfoque B)
+- páginas: `frontend/src/app/{carta-del-dia,horoscopo,horoscopo-chino,ritual,tarot}/page.tsx`
+- `frontend/src/components/features/birth-chart/BirthChartPageContent/`, `.../pendulum/PendulumConsultation.tsx`, `.../rituals/RitualsPage.tsx`
+- tests correspondientes
+
+---

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "eslint-plugin-prettier": "^5.2.2",
         "globals": "^16.0.0",
         "jest": "^29.7.0",
+        "patch-package": "^8.0.1",
         "prettier": "^3.4.2",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
@@ -3238,19 +3239,6 @@
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
-    "backend/tarot-app/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "backend/tarot-app/node_modules/fs-monkey": {
       "version": "1.0.6",
       "dev": true,
@@ -4153,17 +4141,6 @@
       "version": "3.3.1",
       "dev": true,
       "license": "MIT"
-    },
-    "backend/tarot-app/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "backend/tarot-app/node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -5698,14 +5675,6 @@
     "backend/tarot-app/node_modules/undici-types": {
       "version": "6.20.0",
       "license": "MIT"
-    },
-    "backend/tarot-app/node_modules/universalify": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "backend/tarot-app/node_modules/utils-merge": {
       "version": "1.0.1",
@@ -13928,6 +13897,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abbrev": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
@@ -17825,6 +17801,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/fixpack": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fixpack/-/fixpack-4.0.0.tgz",
@@ -17999,6 +17985,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fsevents": {
@@ -18974,8 +18975,8 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -19312,8 +19313,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -19703,6 +19704,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -19721,6 +19742,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jstransformer": {
@@ -19787,6 +19831,16 @@
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kuler": {
@@ -22446,8 +22500,8 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
       "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -22705,6 +22759,53 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -22873,7 +22974,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -24588,6 +24688,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/slick": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
@@ -25264,6 +25374,16 @@
       "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/to-buffer": {
       "version": "1.2.2",
@@ -25979,6 +26099,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -26875,6 +27005,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
     },
     "backend/tarot-app": {
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",


### PR DESCRIPTION
## Resumen

Configura **DeepSeek** como IA principal para tarot (tiradas + carta del día), numerología y carta astral, manteniendo **Groq** para los horóscopos (occidental y chino). Incluye limpieza de proveedores y un fix de dependencia necesario para que la suite corra en Node ≥22.

## Cambios

### `feat(ai)` — DeepSeek como principal salvo horóscopos
- Nuevo parámetro opcional `primaryProvider` en `AIProviderService.generateCompletion`: prioriza un proveedor y deja el resto como fallback automático.
- Tarot, numerología y carta astral → DeepSeek. Horóscopos → Groq.

### `fix(ai)` — omitir proveedores sin API key
- `isConfigured()` en `IAIProvider` + los 4 providers. Los proveedores sin key (ej. OpenAI, Gemini deshabilitado) ya **no se intentan ni se loguean como error**, limpiando las métricas de `/admin/ai-usage`.

### `fix(ai)` — modelo default de DeepSeek
- `deepseek-chat` → `deepseek-v4-flash` (verificado contra la API: los modelos disponibles son `deepseek-v4-flash` y `deepseek-v4-pro`). Actualizado en provider, `env.validation` y health check.

### `fix(deps)` — patch para Node ≥22
- En Node 22+ se removió `buffer.SlowBuffer`; `buffer-equal-constant-time@1.0.1` (transitivo vía `jsonwebtoken`) crasheaba al importar, tumbando todas las suites que usan `@nestjs/jwt`. Se agrega `patch-package` + `postinstall`.

### `docs(backlog)`
- `BACKLOG_BUGFIXES_2026_05_PARTE2.md`: investigación y tareas de los bugs reportados (BUG-016 a BUG-019).

## Calidad (backend)
- ✅ `format`, `lint`, `build`, `validate-architecture`
- ✅ `test:cov`: **308/308 suites, 4456 tests**, coverage **84.7%** (≥80%)

## ⚠️ Nota operativa (no bloquea el merge)
La cuenta de DeepSeek devuelve **HTTP 402 "Insufficient Balance"** (los 5M tokens gratis no figuran activos: `granted_balance: 0.00`). Hasta activar el saldo, el tarot cae automáticamente en fallback a **Groq** (funciona, pero no es DeepSeek). El código queda correcto; es una acción de cuenta del lado de DeepSeek.

> Recordatorio: `DEEPSEEK_API_KEY`/`DEEPSEEK_MODEL` viven en `.env` (no versionado) — cargarlas en staging/prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)