### PR TITLE
T-BUG-016-A: Diferenciar estados del widget de horóscopo (400/404/5xx) + reparar suite heredada

### DIFF
--- a/docs/BACKLOG_BUGFIXES_2026_05_PARTE2.md
+++ b/docs/BACKLOG_BUGFIXES_2026_05_PARTE2.md
@@ -292,7 +292,7 @@ Páginas que usan hoy el widget pobre: `/carta-del-dia`, `/horoscopo`, `/horosco
 **Estimación:** 2 puntos
 **Dependencias:** ninguna
 **Cubre BUG:** BUG-016
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ Completada
 
 #### 📋 Descripción
 
@@ -300,14 +300,14 @@ Que el `HoroscopeWidget` deje de mostrar "Configura tu fecha de nacimiento" cuan
 
 #### ✅ Tareas específicas
 
-- [ ] En `useMySignHoroscope` (o un wrapper), mapear el error a un estado tipado: `'no-birthdate'` (400) / `'not-generated'` (404) / `'error'` (resto).
-- [ ] Ajustar `retry`: no reintentar en 400/404; permitir 1-2 reintentos para 5xx.
-- [ ] En `HoroscopeWidget.tsx` reemplazar el bloque único `if (error || !horoscope)` por ramas:
+- [x] En `useMySignHoroscope` (o un wrapper), mapear el error a un estado tipado: `'no-birthdate'` (400) / `'not-generated'` (404) / `'error'` (resto).
+- [x] Ajustar `retry`: no reintentar en 400/404; permitir 1-2 reintentos para 5xx.
+- [x] En `HoroscopeWidget.tsx` reemplazar el bloque único `if (error || !horoscope)` por ramas:
   - 400 → CTA "Configura tu fecha de nacimiento" (actual).
   - 404 → mensaje "Tu horóscopo de hoy se está preparando, volvé en un rato".
   - 5xx/desconocido → estado de error genérico con opción de reintentar.
-- [ ] Tests del widget por estado (success / 400 / 404 / 5xx).
-- [ ] Coverage ≥ 80%.
+- [x] Tests del widget por estado (success / 400 / 404 / 5xx).
+- [x] Coverage ≥ 80%.
 
 #### 🎯 Criterios de Aceptación
 

--- a/frontend/src/app/admin/seguridad/page.test.tsx
+++ b/frontend/src/app/admin/seguridad/page.test.tsx
@@ -2,7 +2,7 @@
  * Tests for Admin Seguridad Page
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createElement } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -25,6 +25,15 @@ const createWrapper = () => {
 };
 
 describe('AdminSeguridadPage', () => {
+  beforeEach(() => {
+    // RateLimitingTab (renderizado por la página) desestructura { mutate, isPending }
+    // de useUnblockIP. Sin este default el auto-mock devuelve undefined y rompe el render.
+    vi.mocked(useAdminSecurity.useUnblockIP).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as never);
+  });
+
   it('should render page title and description', () => {
     vi.mocked(useAdminSecurity.useRateLimitData).mockReturnValue({
       data: {

--- a/frontend/src/app/ritual/preguntas/page.test.tsx
+++ b/frontend/src/app/ritual/preguntas/page.test.tsx
@@ -39,6 +39,10 @@ vi.mock('@/hooks/useAuth', () => ({
 vi.mock('@/hooks/api/useSubscription', () => ({
   useCreatePreapproval: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
 }));
+// usePublicPlans (useQuery) lo usa UpgradeModal para mostrar el precio Premium.
+vi.mock('@/hooks/api/usePublicPlans', () => ({
+  usePublicPlans: vi.fn().mockReturnValue({ data: [{ planType: 'premium', price: 9.99 }] }),
+}));
 
 // Mock data
 const mockCategory = {

--- a/frontend/src/app/tarot/preguntas/page.test.tsx
+++ b/frontend/src/app/tarot/preguntas/page.test.tsx
@@ -39,6 +39,10 @@ vi.mock('@/hooks/useAuth', () => ({
 vi.mock('@/hooks/api/useSubscription', () => ({
   useCreatePreapproval: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
 }));
+// usePublicPlans (useQuery) lo usa UpgradeModal para mostrar el precio Premium.
+vi.mock('@/hooks/api/usePublicPlans', () => ({
+  usePublicPlans: vi.fn().mockReturnValue({ data: [{ planType: 'premium', price: 9.99 }] }),
+}));
 
 // Mock data
 const mockCategory = {

--- a/frontend/src/components/features/admin/RateLimitingTab.test.tsx
+++ b/frontend/src/components/features/admin/RateLimitingTab.test.tsx
@@ -2,7 +2,7 @@
  * Tests for RateLimitingTab component
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createElement } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -25,6 +25,15 @@ const createWrapper = () => {
 };
 
 describe('RateLimitingTab', () => {
+  beforeEach(() => {
+    // El componente desestructura { mutate, isPending } de useUnblockIP (mutación
+    // para desbloquear IPs). Sin este default el auto-mock devuelve undefined.
+    vi.mocked(useAdminSecurity.useUnblockIP).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as never);
+  });
+
   it('should render stats cards when data is loaded', () => {
     vi.mocked(useAdminSecurity.useRateLimitData).mockReturnValue({
       data: {

--- a/frontend/src/components/features/chinese-horoscope/AnimalCalculator.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalCalculator.test.tsx
@@ -295,7 +295,17 @@ describe('AnimalCalculator', () => {
 
     it('should persist birthDate in sessionStorage when viewing horoscope', async () => {
       const user = userEvent.setup();
-      const mockSetItem = vi.spyOn(Storage.prototype, 'setItem');
+
+      // En jsdom 27 `sessionStorage` es un objeto exótico cuyo `setItem` no se puede
+      // interceptar con vi.spyOn (ni vía Storage.prototype ni vía la instancia).
+      // Reemplazamos la instancia por un mock para poder verificar la persistencia.
+      const setItemMock = vi.fn();
+      const originalSessionStorage = window.sessionStorage;
+      Object.defineProperty(window, 'sessionStorage', {
+        value: { getItem: vi.fn(), setItem: setItemMock, removeItem: vi.fn(), clear: vi.fn() },
+        writable: true,
+        configurable: true,
+      });
 
       mockUseCalculateAnimal.mockReturnValue({
         data: createMockCalculateResponse(),
@@ -314,8 +324,13 @@ describe('AnimalCalculator', () => {
       const viewButton = screen.getByTestId('animal-calculator-view-button');
       await user.click(viewButton);
 
-      expect(mockSetItem).toHaveBeenCalledWith('anonymousBirthDate', '1988-03-15');
-      mockSetItem.mockRestore();
+      expect(setItemMock).toHaveBeenCalledWith('anonymousBirthDate', '1988-03-15');
+
+      Object.defineProperty(window, 'sessionStorage', {
+        value: originalSessionStorage,
+        writable: true,
+        configurable: true,
+      });
     });
   });
 

--- a/frontend/src/components/features/contact/ContactForm.test.tsx
+++ b/frontend/src/components/features/contact/ContactForm.test.tsx
@@ -1,24 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { toast } from '@/hooks/utils/useToast';
+import { toast } from 'sonner';
 import { ContactForm } from './ContactForm';
 
-vi.mock('@/hooks/utils/useToast', () => ({
+// ContactForm muestra el feedback usando `toast` de sonner (ver ContactForm.tsx),
+// por lo que el mock debe apuntar a 'sonner' y no al wrapper interno useToast.
+vi.mock('sonner', () => ({
   toast: {
     success: vi.fn(),
     error: vi.fn(),
     info: vi.fn(),
     dismiss: vi.fn(),
   },
-  useToast: () => ({
-    toast: {
-      success: vi.fn(),
-      error: vi.fn(),
-      info: vi.fn(),
-      dismiss: vi.fn(),
-    },
-  }),
 }));
 
 describe('ContactForm', () => {

--- a/frontend/src/components/features/dashboard/UserDashboard.test.tsx
+++ b/frontend/src/components/features/dashboard/UserDashboard.test.tsx
@@ -15,7 +15,6 @@ import type {
   AuthUser,
   UserProfile,
   UserCapabilities,
-  DailyHoroscope,
   ChineseHoroscope,
   SacredEvent,
 } from '@/types';

--- a/frontend/src/components/features/dashboard/UserDashboard.test.tsx
+++ b/frontend/src/components/features/dashboard/UserDashboard.test.tsx
@@ -66,8 +66,9 @@ describe('UserDashboard', () => {
       data: undefined,
       isLoading: false,
       error: null,
+      errorState: null,
       refetch: vi.fn(),
-    } as unknown as UseQueryResult<DailyHoroscope, Error>);
+    } as unknown as ReturnType<typeof useHoroscopeModule.useMySignHoroscope>);
 
     // Default mock for useMyAnimalHoroscope (Chinese horoscope widget)
     vi.spyOn(useChineseHoroscopeModule, 'useMyAnimalHoroscope').mockReturnValue({
@@ -514,8 +515,9 @@ describe('UserDashboard', () => {
       },
       isLoading: false,
       error: null,
+      errorState: null,
       refetch: vi.fn(),
-    } as unknown as UseQueryResult<DailyHoroscope, Error>);
+    } as unknown as ReturnType<typeof useHoroscopeModule.useMySignHoroscope>);
 
     render(<UserDashboard />);
 
@@ -601,8 +603,9 @@ describe('UserDashboard', () => {
       },
       isLoading: false,
       error: null,
+      errorState: null,
       refetch: vi.fn(),
-    } as unknown as UseQueryResult<DailyHoroscope, Error>);
+    } as unknown as ReturnType<typeof useHoroscopeModule.useMySignHoroscope>);
 
     render(<UserDashboard />);
 

--- a/frontend/src/components/features/horoscope/HoroscopeWidget.test.tsx
+++ b/frontend/src/components/features/horoscope/HoroscopeWidget.test.tsx
@@ -79,9 +79,7 @@ describe('HoroscopeWidget', () => {
 
       expect(screen.getByTestId('horoscope-widget')).toBeInTheDocument();
       expect(screen.getByText('Aries')).toBeInTheDocument();
-      expect(
-        screen.getByText('Hoy es un día propicio para nuevos comienzos.')
-      ).toBeInTheDocument();
+      expect(screen.getByText('Hoy es un día propicio para nuevos comienzos.')).toBeInTheDocument();
       expect(screen.getByRole('link', { name: /ver más/i })).toHaveAttribute(
         'href',
         '/horoscopo/aries'
@@ -100,13 +98,8 @@ describe('HoroscopeWidget', () => {
       render(<HoroscopeWidget />);
 
       expect(screen.getByTestId('horoscope-widget-no-birthdate')).toBeInTheDocument();
-      expect(
-        screen.getByText(/configura tu fecha de nacimiento/i)
-      ).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: /configurar/i })).toHaveAttribute(
-        'href',
-        '/perfil'
-      );
+      expect(screen.getByText(/configura tu fecha de nacimiento/i)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /configurar/i })).toHaveAttribute('href', '/perfil');
     });
 
     it('should NOT show the "not-generated" message', () => {
@@ -133,13 +126,9 @@ describe('HoroscopeWidget', () => {
       render(<HoroscopeWidget />);
 
       expect(screen.getByTestId('horoscope-widget-not-generated')).toBeInTheDocument();
-      expect(
-        screen.getByText(/tu horóscopo de hoy se está preparando/i)
-      ).toBeInTheDocument();
+      expect(screen.getByText(/tu horóscopo de hoy se está preparando/i)).toBeInTheDocument();
       // Crítico: NO debe pedir configurar fecha
-      expect(
-        screen.queryByText(/configura tu fecha de nacimiento/i)
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/configura tu fecha de nacimiento/i)).not.toBeInTheDocument();
       expect(screen.queryByRole('link', { name: /configurar/i })).not.toBeInTheDocument();
     });
   });
@@ -157,9 +146,7 @@ describe('HoroscopeWidget', () => {
       expect(screen.getByTestId('horoscope-widget-error')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /reintentar/i })).toBeInTheDocument();
       // No debe mostrar el CTA de fecha de nacimiento
-      expect(
-        screen.queryByText(/configura tu fecha de nacimiento/i)
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/configura tu fecha de nacimiento/i)).not.toBeInTheDocument();
     });
 
     it('should call refetch when retry button is clicked', async () => {
@@ -179,4 +166,3 @@ describe('HoroscopeWidget', () => {
     });
   });
 });
-

--- a/frontend/src/components/features/horoscope/HoroscopeWidget.test.tsx
+++ b/frontend/src/components/features/horoscope/HoroscopeWidget.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Tests for HoroscopeWidget Component
+ *
+ * Cubre los distintos estados del widget según la respuesta del backend:
+ * - Loading
+ * - Success (horóscopo del día disponible)
+ * - 400: usuario sin fecha de nacimiento → CTA "Configurar"
+ * - 404: horóscopo aún no generado → mensaje "se está preparando"
+ * - 5xx / error genérico → mensaje de error + botón "Reintentar"
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { HoroscopeWidget } from './HoroscopeWidget';
+import * as useHoroscopeModule from '@/hooks/api/useHoroscope';
+import { ZodiacSign, type DailyHoroscope } from '@/types/horoscope.types';
+
+vi.mock('@/hooks/api/useHoroscope', async () => {
+  const actual = await vi.importActual<typeof useHoroscopeModule>('@/hooks/api/useHoroscope');
+  return {
+    ...actual,
+    useMySignHoroscope: vi.fn(),
+  };
+});
+
+const mockHoroscope: DailyHoroscope = {
+  id: 1,
+  zodiacSign: ZodiacSign.ARIES,
+  horoscopeDate: '2026-05-29',
+  generalContent: 'Hoy es un día propicio para nuevos comienzos.',
+  areas: {
+    love: { content: 'Amor en el aire', score: 8 },
+    wellness: { content: 'Energía alta', score: 9 },
+    money: { content: 'Cuidado con gastos', score: 6 },
+  },
+  luckyNumber: 7,
+  luckyColor: 'Rojo',
+  luckyTime: 'Mañana',
+};
+
+type HookReturn = ReturnType<typeof useHoroscopeModule.useMySignHoroscope>;
+
+function mockHook(overrides: Partial<HookReturn>): void {
+  vi.mocked(useHoroscopeModule.useMySignHoroscope).mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    isSuccess: false,
+    error: null,
+    errorState: null,
+    isRefetching: false,
+    refetch: vi.fn(),
+    ...overrides,
+  } as unknown as HookReturn);
+}
+
+describe('HoroscopeWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Loading state', () => {
+    it('should render skeleton while loading', () => {
+      mockHook({ isLoading: true });
+
+      render(<HoroscopeWidget />);
+
+      expect(screen.getByTestId('horoscope-widget-loading')).toBeInTheDocument();
+    });
+  });
+
+  describe('Success state', () => {
+    it('should render horoscope content when data is available', () => {
+      mockHook({ data: mockHoroscope, isSuccess: true });
+
+      render(<HoroscopeWidget />);
+
+      expect(screen.getByTestId('horoscope-widget')).toBeInTheDocument();
+      expect(screen.getByText('Aries')).toBeInTheDocument();
+      expect(
+        screen.getByText('Hoy es un día propicio para nuevos comienzos.')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /ver más/i })).toHaveAttribute(
+        'href',
+        '/horoscopo/aries'
+      );
+    });
+  });
+
+  describe('Error state: no-birthdate (400)', () => {
+    it('should show CTA to configure birth date', () => {
+      mockHook({
+        isError: true,
+        errorState: 'no-birthdate',
+        error: new Error('birthDate required'),
+      });
+
+      render(<HoroscopeWidget />);
+
+      expect(screen.getByTestId('horoscope-widget-no-birthdate')).toBeInTheDocument();
+      expect(
+        screen.getByText(/configura tu fecha de nacimiento/i)
+      ).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /configurar/i })).toHaveAttribute(
+        'href',
+        '/perfil'
+      );
+    });
+
+    it('should NOT show the "not-generated" message', () => {
+      mockHook({
+        isError: true,
+        errorState: 'no-birthdate',
+        error: new Error('birthDate required'),
+      });
+
+      render(<HoroscopeWidget />);
+
+      expect(screen.queryByText(/se está preparando/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Error state: not-generated (404)', () => {
+    it('should show "preparing" message, NOT the birth date CTA', () => {
+      mockHook({
+        isError: true,
+        errorState: 'not-generated',
+        error: new Error('Horoscope not found'),
+      });
+
+      render(<HoroscopeWidget />);
+
+      expect(screen.getByTestId('horoscope-widget-not-generated')).toBeInTheDocument();
+      expect(
+        screen.getByText(/tu horóscopo de hoy se está preparando/i)
+      ).toBeInTheDocument();
+      // Crítico: NO debe pedir configurar fecha
+      expect(
+        screen.queryByText(/configura tu fecha de nacimiento/i)
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /configurar/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Error state: generic error (5xx / network)', () => {
+    it('should show generic error message with retry button', () => {
+      mockHook({
+        isError: true,
+        errorState: 'error',
+        error: new Error('Internal Server Error'),
+      });
+
+      render(<HoroscopeWidget />);
+
+      expect(screen.getByTestId('horoscope-widget-error')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /reintentar/i })).toBeInTheDocument();
+      // No debe mostrar el CTA de fecha de nacimiento
+      expect(
+        screen.queryByText(/configura tu fecha de nacimiento/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it('should call refetch when retry button is clicked', async () => {
+      const refetch = vi.fn();
+      mockHook({
+        isError: true,
+        errorState: 'error',
+        error: new Error('Internal Server Error'),
+        refetch,
+      });
+
+      render(<HoroscopeWidget />);
+
+      await userEvent.click(screen.getByRole('button', { name: /reintentar/i }));
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+

--- a/frontend/src/components/features/horoscope/HoroscopeWidget.tsx
+++ b/frontend/src/components/features/horoscope/HoroscopeWidget.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import Link from 'next/link';
-import { ArrowRight, Settings } from 'lucide-react';
+import { AlertCircle, ArrowRight, Clock, RefreshCw, Settings } from 'lucide-react';
 
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -16,17 +16,12 @@ import { ZODIAC_SIGNS_INFO } from '@/lib/utils/zodiac';
  * Dashboard widget showing user's daily horoscope.
  * Displays personalized content based on user's birth date.
  *
- * States:
- * - No birthDate: Shows CTA to configure profile
- * - Loading: Shows skeleton
- * - Error/No data: Shows error message
- * - Success: Shows horoscope summary with link to full view
- *
- * Features:
- * - Automatic sign detection from birthDate
- * - Compact view with 3-line clamped content
- * - Area scores display
- * - Link to full horoscope page
+ * Estados (diferenciados según la respuesta del backend):
+ * - **Loading**: skeleton.
+ * - **Success**: muestra el horóscopo del día.
+ * - **400 / `no-birthdate`**: el usuario no tiene fecha de nacimiento → CTA a `/perfil`.
+ * - **404 / `not-generated`**: el horóscopo del día aún no se generó → mensaje "se está preparando".
+ * - **5xx / `error`**: error transitorio → mensaje genérico + botón "Reintentar".
  *
  * @example
  * ```tsx
@@ -34,7 +29,7 @@ import { ZODIAC_SIGNS_INFO } from '@/lib/utils/zodiac';
  * ```
  */
 export function HoroscopeWidget() {
-  const { data: horoscope, isLoading, error } = useMySignHoroscope();
+  const { data: horoscope, isLoading, errorState, refetch, isRefetching } = useMySignHoroscope();
 
   // Loading state
   if (isLoading) {
@@ -47,10 +42,10 @@ export function HoroscopeWidget() {
     );
   }
 
-  // Error or no data (includes no birthDate case from API)
-  if (error || !horoscope) {
+  // 400: el usuario no tiene fecha de nacimiento cargada
+  if (errorState === 'no-birthdate') {
     return (
-      <Card className="p-6" data-testid="horoscope-widget-no-data">
+      <Card className="p-6" data-testid="horoscope-widget-no-birthdate">
         <h2 className="mb-2 font-serif text-xl">Tu Horóscopo</h2>
         <p className="text-muted-foreground mb-4 text-sm">
           Configura tu fecha de nacimiento para ver tu horóscopo personalizado
@@ -60,6 +55,36 @@ export function HoroscopeWidget() {
             <Settings className="mr-2 h-4 w-4" />
             Configurar
           </Link>
+        </Button>
+      </Card>
+    );
+  }
+
+  // 404: el horóscopo del día todavía no fue generado para el signo del usuario
+  if (errorState === 'not-generated') {
+    return (
+      <Card className="p-6" data-testid="horoscope-widget-not-generated">
+        <h2 className="mb-2 font-serif text-xl">Tu Horóscopo</h2>
+        <p className="text-muted-foreground mb-4 flex items-start gap-2 text-sm">
+          <Clock className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>Tu horóscopo de hoy se está preparando, volvé en un rato.</span>
+        </p>
+      </Card>
+    );
+  }
+
+  // 5xx / error genérico / sin datos por razones inesperadas
+  if (errorState === 'error' || !horoscope) {
+    return (
+      <Card className="p-6" data-testid="horoscope-widget-error">
+        <h2 className="mb-2 font-serif text-xl">Tu Horóscopo</h2>
+        <p className="text-muted-foreground mb-4 flex items-start gap-2 text-sm">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>No pudimos cargar tu horóscopo. Intentá nuevamente en unos segundos.</span>
+        </p>
+        <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isRefetching}>
+          <RefreshCw className={`mr-2 h-4 w-4 ${isRefetching ? 'animate-spin' : ''}`} />
+          Reintentar
         </Button>
       </Card>
     );

--- a/frontend/src/components/features/readings/QuestionSelector.test.tsx
+++ b/frontend/src/components/features/readings/QuestionSelector.test.tsx
@@ -22,6 +22,10 @@ vi.mock('@/hooks/useAuth', () => ({
 vi.mock('@/hooks/api/useSubscription', () => ({
   useCreatePreapproval: vi.fn().mockReturnValue({ mutate: vi.fn(), isPending: false }),
 }));
+// usePublicPlans (useQuery) lo usa UpgradeModal para mostrar el precio Premium.
+vi.mock('@/hooks/api/usePublicPlans', () => ({
+  usePublicPlans: vi.fn().mockReturnValue({ data: [{ planType: 'premium', price: 9.99 }] }),
+}));
 
 const mockPush = vi.fn();
 const mockRefetch = vi.fn();

--- a/frontend/src/hooks/api/useHoroscope.test.tsx
+++ b/frontend/src/hooks/api/useHoroscope.test.tsx
@@ -167,6 +167,30 @@ describe('horoscope hooks', () => {
   });
 
   describe('useMySignHoroscope', () => {
+    // Helper para crear errores tipo Axios con status específico
+    function makeAxiosError(status: number, message = 'Request failed'): Error {
+      const error = new Error(message) as Error & {
+        response?: { status: number; data?: unknown };
+        isAxiosError?: boolean;
+      };
+      error.response = { status };
+      error.isAxiosError = true;
+      return error;
+    }
+
+    beforeEach(() => {
+      // Override queryClient para permitir que el hook controle su política de retry,
+      // pero con retryDelay=0 para que los tests sean rápidos
+      queryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            gcTime: 0,
+            retryDelay: 0,
+          },
+        },
+      });
+    });
+
     it('should fetch user horoscope successfully', async () => {
       vi.mocked(horoscopeApi.getMySignHoroscope).mockResolvedValueOnce(mockHoroscope);
 
@@ -179,12 +203,13 @@ describe('horoscope hooks', () => {
       });
 
       expect(result.current.data).toEqual(mockHoroscope);
+      expect(result.current.errorState).toBeNull();
       expect(horoscopeApi.getMySignHoroscope).toHaveBeenCalledOnce();
     });
 
-    it('should not retry on failure', async () => {
-      const mockError = new Error('User birthDate not configured');
-      vi.mocked(horoscopeApi.getMySignHoroscope).mockRejectedValueOnce(mockError);
+    it('should expose errorState="no-birthdate" on 400 and NOT retry', async () => {
+      const error400 = makeAxiosError(400, 'birthDate is required');
+      vi.mocked(horoscopeApi.getMySignHoroscope).mockRejectedValue(error400);
 
       const { result } = renderHook(() => useMySignHoroscope(), { wrapper });
 
@@ -192,9 +217,55 @@ describe('horoscope hooks', () => {
         expect(result.current.isError).toBe(true);
       });
 
-      expect(result.current.error).toEqual(mockError);
-      // Should only be called once (no retry)
+      expect(result.current.errorState).toBe('no-birthdate');
       expect(horoscopeApi.getMySignHoroscope).toHaveBeenCalledTimes(1);
     });
+
+    it('should expose errorState="not-generated" on 404 and NOT retry', async () => {
+      const error404 = makeAxiosError(404, 'Horoscope not found');
+      vi.mocked(horoscopeApi.getMySignHoroscope).mockRejectedValue(error404);
+
+      const { result } = renderHook(() => useMySignHoroscope(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.errorState).toBe('not-generated');
+      expect(horoscopeApi.getMySignHoroscope).toHaveBeenCalledTimes(1);
+    });
+
+    it('should expose errorState="error" on 500 and retry up to 2 times', async () => {
+      const error500 = makeAxiosError(500, 'Internal Server Error');
+      vi.mocked(horoscopeApi.getMySignHoroscope).mockRejectedValue(error500);
+
+      const { result } = renderHook(() => useMySignHoroscope(), { wrapper });
+
+      await waitFor(
+        () => {
+          expect(result.current.isError).toBe(true);
+        },
+        { timeout: 5000 }
+      );
+
+      expect(result.current.errorState).toBe('error');
+      // 1 intento original + 2 reintentos = 3 llamadas
+      expect(horoscopeApi.getMySignHoroscope).toHaveBeenCalledTimes(3);
+    }, 10000);
+
+    it('should treat unknown errors (without status) as generic "error"', async () => {
+      vi.mocked(horoscopeApi.getMySignHoroscope).mockRejectedValue(new Error('Network down'));
+
+      const { result } = renderHook(() => useMySignHoroscope(), { wrapper });
+
+      await waitFor(
+        () => {
+          expect(result.current.isError).toBe(true);
+        },
+        { timeout: 5000 }
+      );
+
+      expect(result.current.errorState).toBe('error');
+    }, 10000);
   });
 });

--- a/frontend/src/hooks/api/useHoroscope.ts
+++ b/frontend/src/hooks/api/useHoroscope.ts
@@ -15,6 +15,35 @@ import {
 import type { ZodiacSign } from '@/types/horoscope.types';
 
 /**
+ * Estados de error tipados para `useMySignHoroscope`.
+ *
+ * - `no-birthdate`: el backend respondió 400 porque el usuario no tiene
+ *   fecha de nacimiento configurada → mostrar CTA a `/perfil`.
+ * - `not-generated`: el backend respondió 404 porque el horóscopo del día
+ *   para el signo del usuario todavía no fue generado → mostrar mensaje
+ *   "se está preparando".
+ * - `error`: cualquier otro error (5xx, red, desconocido) → mostrar
+ *   mensaje de error genérico con opción de reintentar.
+ */
+export type MySignHoroscopeErrorState = 'no-birthdate' | 'not-generated' | 'error';
+
+/**
+ * Extrae el HTTP status code de un error (tipo AxiosError) si existe.
+ */
+function getHttpStatus(error: unknown): number | undefined {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const response = (error as { response?: unknown }).response;
+    if (response && typeof response === 'object' && 'status' in response) {
+      const status = (response as { status?: unknown }).status;
+      if (typeof status === 'number') {
+        return status;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
  * Query keys para horóscopos
  * Organizados jerárquicamente para facilitar invalidaciones
  */
@@ -78,28 +107,58 @@ export function useTodayHoroscope(sign: ZodiacSign) {
 
 /**
  * Hook para obtener el horóscopo del usuario autenticado
- * basado en su fecha de nacimiento
+ * basado en su fecha de nacimiento.
  *
- * IMPORTANTE: Este hook puede fallar si el usuario no tiene configurada
- * su fecha de nacimiento. Por eso retry está deshabilitado.
+ * Retorna además `errorState` que diferencia los distintos motivos de
+ * fallo (ver {@link MySignHoroscopeErrorState}) para que los componentes
+ * no confundan "fecha no configurada" con "horóscopo no generado" o
+ * con un error transitorio.
+ *
+ * Política de reintentos:
+ * - 400 / 404 (cualquier 4xx) → NO reintenta (es un error legítimo).
+ * - 5xx, red u otros → reintenta hasta 2 veces.
  *
  * @example
  * ```tsx
  * function MyHoroscope() {
- *   const { data, isLoading, error } = useMySignHoroscope();
+ *   const { data, isLoading, errorState, refetch } = useMySignHoroscope();
  *
  *   if (isLoading) return <Spinner />;
- *   if (error) return <ConfigureBirthDate />;
+ *   if (errorState === 'no-birthdate') return <ConfigureBirthDate />;
+ *   if (errorState === 'not-generated') return <PreparingMessage />;
+ *   if (errorState === 'error') return <ErrorWithRetry onRetry={refetch} />;
  *
- *   return <HoroscopeCard horoscope={data} />;
+ *   return <HoroscopeCard horoscope={data!} />;
  * }
  * ```
  */
 export function useMySignHoroscope() {
-  return useQuery({
+  const query = useQuery({
     queryKey: horoscopeQueryKeys.mySign(),
     queryFn: getMySignHoroscope,
     staleTime: 1000 * 60 * 60, // 1 hora
-    retry: false, // No reintentar si falla (probablemente por falta de birthDate)
+    retry: (failureCount, error) => {
+      const status = getHttpStatus(error);
+      // 4xx (400 sin birthDate, 404 sin generar, etc.) → no reintentar
+      if (status !== undefined && status >= 400 && status < 500) {
+        return false;
+      }
+      // 5xx / red / desconocido → hasta 2 reintentos
+      return failureCount < 2;
+    },
   });
+
+  let errorState: MySignHoroscopeErrorState | null = null;
+  if (query.error) {
+    const status = getHttpStatus(query.error);
+    if (status === 400) {
+      errorState = 'no-birthdate';
+    } else if (status === 404) {
+      errorState = 'not-generated';
+    } else {
+      errorState = 'error';
+    }
+  }
+
+  return { ...query, errorState };
 }

--- a/frontend/src/lib/api/admin-ip-whitelist-api.test.ts
+++ b/frontend/src/lib/api/admin-ip-whitelist-api.test.ts
@@ -52,10 +52,9 @@ describe('admin-ip-whitelist-api', () => {
 
       const result = await addIpToWhitelist({ ip: '203.0.113.45' });
 
-      expect(apiClient.post).toHaveBeenCalledWith(
-        API_ENDPOINTS.ADMIN.IP_WHITELIST,
-        { ip: '203.0.113.45' },
-      );
+      expect(apiClient.post).toHaveBeenCalledWith(API_ENDPOINTS.ADMIN.IP_WHITELIST, {
+        ip: '203.0.113.45',
+      });
       expect(result).toEqual(mockResponse);
     });
 
@@ -76,10 +75,9 @@ describe('admin-ip-whitelist-api', () => {
 
       const result = await removeIpFromWhitelist({ ip: '203.0.113.45' });
 
-      expect(apiClient.delete).toHaveBeenCalledWith(
-        API_ENDPOINTS.ADMIN.IP_WHITELIST,
-        { data: { ip: '203.0.113.45' } },
-      );
+      expect(apiClient.delete).toHaveBeenCalledWith(API_ENDPOINTS.ADMIN.IP_WHITELIST, {
+        data: { ip: '203.0.113.45' },
+      });
       expect(result).toEqual(mockResponse);
     });
 


### PR DESCRIPTION
## Resumen

Cierra **T-BUG-016-A** (estados diferenciados del `HoroscopeWidget`) y repara la suite de tests heredada de `develop` que estaba en rojo.

### T-BUG-016-A — Estados del widget de horóscopo
- `useMySignHoroscope` mapea el error a un estado tipado: `'no-birthdate'` (400) / `'not-generated'` (404) / `'error'` (resto), con política de `retry` que no reintenta en 4xx y reintenta hasta 2 veces en 5xx/red.
- `HoroscopeWidget` muestra el copy correcto por estado:
  - **400** → CTA "Configura tu fecha de nacimiento".
  - **404** → "Tu horóscopo de hoy se está preparando, volvé en un rato" (ya **no** muestra el CTA de fecha).
  - **5xx/desconocido** → error genérico con botón "Reintentar".
- Tests por estado (success / 400 / 404 / 5xx).

### Reparación de la suite heredada (no era la versión de Node)
Verificado con `fnm exec --using=20`: los 7 archivos fallaban **igual en Node 20 (CI) y Node 26 (local)**. La causa real eran tests desactualizados frente a cambios de componentes ya mergeados en `develop`:

| Archivo | Causa | Fix |
|---|---|---|
| `ContactForm.test` | Componente migró a `toast` de `sonner`; el test mockeaba `@/hooks/utils/useToast` → timeout | Mockear `sonner` |
| `QuestionSelector`, `tarot/preguntas`, `ritual/preguntas` | `UpgradeModal` usa `usePublicPlans` (useQuery) sin mockear → "No QueryClient set" | Mock de `usePublicPlans` |
| `RateLimitingTab`, `admin/seguridad` | `RateLimitingTab` añadió `useUnblockIP`; auto-mock devolvía undefined | Default en `beforeEach` |
| `AnimalCalculator` | jsdom 27 cambió `sessionStorage`; `vi.spyOn` ya no intercepta `setItem` | Reemplazar instancia por mock |

También se limpió el import sin uso `DailyHoroscope` en `UserDashboard.test`.

## Verificación (ciclo de calidad frontend completo)
- ✅ **Tests:** 391 archivos / 4768 pasan (7 skipped) — antes: 7 archivos y 92 tests fallando
- ✅ **Lint:** 0 errores
- ✅ **Type-check**, **Build**, **validate-architecture** OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)