### PR TITLE
fix(horoscope): robustecer generación diaria de horóscopos occidentales (T-BUG-016-B)

### DIFF
--- a/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.config.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.config.ts
@@ -44,6 +44,32 @@ export const GENERATION_SCHEDULE = '0 0 6 * * *';
 export const CLEANUP_SCHEDULE = '0 0 0 * * 0';
 
 /**
+ * T-BUG-016-B: Expresión cron para verificar la completitud de la generación diaria
+ *
+ * Formato: "segundo minuto hora díaMes mes díaSemana"
+ * Valor: "0 0 9 * * *"
+ * Significado: Todos los días a las 09:00 UTC (3 horas después de la generación)
+ * Razón: Detectar y regenerar signos faltantes si la generación de las 06:00 quedó incompleta
+ */
+export const VERIFICATION_SCHEDULE = '0 0 9 * * *';
+
+/**
+ * T-BUG-016-B: Cantidad máxima de reintentos por signo ante fallo transitorio
+ *
+ * Valor: 3 reintentos (4 intentos totales por signo)
+ * Razón: Tolerar errores transitorios (5xx / rate limit / timeout) de los proveedores de IA
+ */
+export const MAX_RETRIES_PER_SIGN = 3;
+
+/**
+ * T-BUG-016-B: Delays (ms) de backoff exponencial antes de cada reintento
+ *
+ * Valor: [6000, 12000, 24000]
+ * Razón: Backoff creciente respetando rate limits sin bloquear el lote completo
+ */
+export const RETRY_DELAYS_MS = [6000, 12000, 24000];
+
+/**
  * Configuración completa del cron de horóscopos
  *
  * Objeto agregado para facilitar importación y modificación centralizada
@@ -53,4 +79,7 @@ export const HOROSCOPE_CRON_CONFIG = {
   RETENTION_DAYS,
   GENERATION_SCHEDULE,
   CLEANUP_SCHEDULE,
+  VERIFICATION_SCHEDULE,
+  MAX_RETRIES_PER_SIGN,
+  RETRY_DELAYS_MS,
 } as const;

--- a/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.spec.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.spec.ts
@@ -34,6 +34,7 @@ describe('HoroscopeCronService', () => {
   const mockHoroscopeGenerationService = {
     generateForSign: jest.fn(),
     cleanupOldHoroscopes: jest.fn(),
+    findMissingSignsForDate: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -125,12 +126,13 @@ describe('HoroscopeCronService', () => {
       await service.generateDailyHoroscopes();
 
       // Assert
-      // Debe haber intentado generar los 12 signos a pesar del error
+      // T-BUG-016-B: 11 signos exitosos (1 llamada cada uno) + Cáncer reintentado
+      // 4 veces (1 intento + 3 reintentos) = 15 llamadas totales
       expect(
         mockHoroscopeGenerationService.generateForSign,
-      ).toHaveBeenCalledTimes(12);
+      ).toHaveBeenCalledTimes(15);
 
-      // Verificar que se logueo el error de Cancer
+      // Verificar que se logueo el error de Cancer tras agotar reintentos
       expect(Logger.prototype.error).toHaveBeenCalledWith(
         expect.stringContaining('Cáncer: Cancer generation failed'),
       );
@@ -241,6 +243,170 @@ describe('HoroscopeCronService', () => {
       expect(Logger.prototype.warn).toHaveBeenCalledWith(
         'Generación manual iniciada...',
       );
+    });
+  });
+
+  describe('retry behavior (T-BUG-016-B)', () => {
+    it('should retry a transient failure and succeed without leaving a gap', async () => {
+      // Arrange: Leo falla 2 veces y luego tiene éxito
+      let leoAttempts = 0;
+      mockHoroscopeGenerationService.generateForSign.mockImplementation(
+        (sign: ZodiacSign) => {
+          if (sign === ZodiacSign.LEO) {
+            leoAttempts++;
+            if (leoAttempts <= 2) {
+              return Promise.reject(new Error('Transient 5xx'));
+            }
+          }
+          return Promise.resolve(createMockHoroscope(sign));
+        },
+      );
+
+      // Act
+      await service.generateDailyHoroscopes();
+
+      // Assert: 11 signos OK (1 llamada) + Leo (3 llamadas) = 14 llamadas
+      expect(
+        mockHoroscopeGenerationService.generateForSign,
+      ).toHaveBeenCalledTimes(14);
+
+      // No debe haber error definitivo, los 12 fueron exitosos
+      expect(Logger.prototype.log).toHaveBeenCalledWith(
+        expect.stringContaining('12/12 exitosos'),
+      );
+    });
+
+    it('should give up after exhausting retries for a sign', async () => {
+      // Arrange: Virgo siempre falla
+      mockHoroscopeGenerationService.generateForSign.mockImplementation(
+        (sign: ZodiacSign) => {
+          if (sign === ZodiacSign.VIRGO) {
+            return Promise.reject(new Error('Persistent failure'));
+          }
+          return Promise.resolve(createMockHoroscope(sign));
+        },
+      );
+
+      // Act
+      await service.generateDailyHoroscopes();
+
+      // Assert: Virgo intentado 4 veces (1 + 3 reintentos)
+      const virgoCalls =
+        mockHoroscopeGenerationService.generateForSign.mock.calls.filter(
+          (call) => call[0] === ZodiacSign.VIRGO,
+        );
+      expect(virgoCalls).toHaveLength(4);
+
+      expect(Logger.prototype.error).toHaveBeenCalledWith(
+        expect.stringContaining('sin más reintentos'),
+      );
+    });
+  });
+
+  describe('verifyAndCompleteDailyHoroscopes (T-BUG-016-B)', () => {
+    it('should not generate anything when all 12 signs exist', async () => {
+      // Arrange
+      mockHoroscopeGenerationService.findMissingSignsForDate.mockResolvedValue(
+        [],
+      );
+
+      // Act
+      await service.verifyAndCompleteDailyHoroscopes();
+
+      // Assert
+      expect(
+        mockHoroscopeGenerationService.findMissingSignsForDate,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockHoroscopeGenerationService.generateForSign,
+      ).not.toHaveBeenCalled();
+      expect(Logger.prototype.log).toHaveBeenCalledWith(
+        expect.stringContaining('los 12 horóscopos del día existen'),
+      );
+    });
+
+    it('should generate only the missing signs', async () => {
+      // Arrange: faltan 2 signos
+      mockHoroscopeGenerationService.findMissingSignsForDate.mockResolvedValue([
+        ZodiacSign.ARIES,
+        ZodiacSign.PISCES,
+      ]);
+      mockHoroscopeGenerationService.generateForSign.mockImplementation(
+        (sign: ZodiacSign) => Promise.resolve(createMockHoroscope(sign)),
+      );
+
+      // Act
+      await service.verifyAndCompleteDailyHoroscopes();
+
+      // Assert: solo se generan los 2 faltantes
+      expect(
+        mockHoroscopeGenerationService.generateForSign,
+      ).toHaveBeenCalledTimes(2);
+      expect(
+        mockHoroscopeGenerationService.generateForSign,
+      ).toHaveBeenCalledWith(ZodiacSign.ARIES, expect.any(Date));
+      expect(
+        mockHoroscopeGenerationService.generateForSign,
+      ).toHaveBeenCalledWith(ZodiacSign.PISCES, expect.any(Date));
+    });
+
+    it('should handle errors gracefully', async () => {
+      // Arrange
+      mockHoroscopeGenerationService.findMissingSignsForDate.mockRejectedValue(
+        new Error('DB down'),
+      );
+
+      // Act
+      await service.verifyAndCompleteDailyHoroscopes();
+
+      // Assert
+      expect(Logger.prototype.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error en verificación de horóscopos'),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('generateMissingHoroscopes (T-BUG-016-B)', () => {
+    it('should return summary with missing, successful and failed counts', async () => {
+      // Arrange: faltan 3, uno falla
+      mockHoroscopeGenerationService.findMissingSignsForDate.mockResolvedValue([
+        ZodiacSign.GEMINI,
+        ZodiacSign.CANCER,
+        ZodiacSign.LEO,
+      ]);
+      mockHoroscopeGenerationService.generateForSign.mockImplementation(
+        (sign: ZodiacSign) => {
+          if (sign === ZodiacSign.CANCER) {
+            return Promise.reject(new Error('fail'));
+          }
+          return Promise.resolve(createMockHoroscope(sign));
+        },
+      );
+
+      // Act
+      const result = await service.generateMissingHoroscopes(new Date());
+
+      // Assert
+      expect(result.missing).toBe(3);
+      expect(result.successful).toBe(2);
+      expect(result.failed).toBe(1);
+    });
+
+    it('should return zeros when nothing is missing', async () => {
+      // Arrange
+      mockHoroscopeGenerationService.findMissingSignsForDate.mockResolvedValue(
+        [],
+      );
+
+      // Act
+      const result = await service.generateMissingHoroscopes(new Date());
+
+      // Assert
+      expect(result).toEqual({ missing: 0, successful: 0, failed: 0 });
+      expect(
+        mockHoroscopeGenerationService.generateForSign,
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.ts
@@ -10,6 +10,9 @@ import {
   RETENTION_DAYS,
   GENERATION_SCHEDULE,
   CLEANUP_SCHEDULE,
+  VERIFICATION_SCHEDULE,
+  MAX_RETRIES_PER_SIGN,
+  RETRY_DELAYS_MS,
 } from './horoscope-cron.config';
 
 /**
@@ -140,6 +143,11 @@ export class HoroscopeCronService {
   /**
    * Genera un horóscopo individual para un signo
    *
+   * T-BUG-016-B: Reintenta hasta MAX_RETRIES_PER_SIGN veces con backoff
+   * exponencial ante fallos transitorios (5xx / rate limit / timeout) antes
+   * de marcar el signo como definitivamente fallido. Esto evita que un error
+   * puntual deje un hueco permanente en la generación diaria.
+   *
    * @param sign - Signo zodiacal
    * @param date - Fecha del horóscopo
    * @param index - Índice en el orden de generación (1-12)
@@ -152,35 +160,51 @@ export class HoroscopeCronService {
     index: number,
   ): Promise<GenerationResult> {
     const signInfo = getZodiacSignInfo(sign);
+    let lastError = '';
 
-    try {
-      this.logger.log(`[${index}/12] Generando ${signInfo.nameEs}...`);
+    for (let attempt = 1; attempt <= MAX_RETRIES_PER_SIGN + 1; attempt++) {
+      try {
+        this.logger.log(`[${index}/12] Generando ${signInfo.nameEs}...`);
 
-      const startTime = Date.now();
-      const horoscope = await this.horoscopeService.generateForSign(sign, date);
-      const duration = Date.now() - startTime;
+        const startTime = Date.now();
+        const horoscope = await this.horoscopeService.generateForSign(
+          sign,
+          date,
+        );
+        const duration = Date.now() - startTime;
 
-      this.logger.log(
-        `[${index}/12] ✓ ${signInfo.nameEs} (${duration}ms, ${horoscope.aiProvider})`,
-      );
+        this.logger.log(
+          `[${index}/12] ✓ ${signInfo.nameEs} (${duration}ms, ${horoscope.aiProvider})`,
+        );
 
-      return {
-        sign,
-        success: true,
-        duration,
-        provider: horoscope.aiProvider || undefined,
-      };
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      this.logger.error(`[${index}/12] ✗ ${signInfo.nameEs}: ${errorMessage}`);
+        return {
+          sign,
+          success: true,
+          duration,
+          provider: horoscope.aiProvider || undefined,
+        };
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
 
-      return {
-        sign,
-        success: false,
-        error: errorMessage,
-      };
+        if (attempt <= MAX_RETRIES_PER_SIGN) {
+          const retryDelay = RETRY_DELAYS_MS[attempt - 1];
+          this.logger.warn(
+            `[${index}/12] Reintento ${attempt}/${MAX_RETRIES_PER_SIGN} para ${signInfo.nameEs} en ${retryDelay / 1000}s: ${lastError}`,
+          );
+          await this.delay(retryDelay);
+        }
+      }
     }
+
+    this.logger.error(
+      `[${index}/12] ✗ ${signInfo.nameEs}: ${lastError} (sin más reintentos)`,
+    );
+
+    return {
+      sign,
+      success: false,
+      error: lastError,
+    };
   }
 
   /**
@@ -216,6 +240,89 @@ export class HoroscopeCronService {
   async generateNow(): Promise<void> {
     this.logger.warn('Generación manual iniciada...');
     await this.generateDailyHoroscopes();
+  }
+
+  /**
+   * T-BUG-016-B: Verifica la completitud de la generación diaria - 09:00 UTC
+   *
+   * Se ejecuta unas horas después de la generación de las 06:00 para detectar
+   * signos que hayan quedado sin horóscopo (por fallos transitorios persistentes)
+   * y regenerar únicamente los faltantes, sin tocar los ya generados.
+   *
+   * Cron expression: "0 0 9 * * *" (todos los días a las 09:00 UTC)
+   */
+  @Cron(VERIFICATION_SCHEDULE, {
+    name: 'verify-daily-horoscope-completeness',
+    timeZone: 'UTC',
+  })
+  async verifyAndCompleteDailyHoroscopes(): Promise<void> {
+    const today = new Date();
+    const dateStr = today.toISOString().split('T')[0];
+
+    this.logger.log(
+      `=== VERIFICACIÓN: Comprobando completitud de horóscopos para ${dateStr} ===`,
+    );
+
+    try {
+      await this.generateMissingHoroscopes(today);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const errorStack = error instanceof Error ? (error.stack ?? '') : '';
+      this.logger.error(
+        `Error en verificación de horóscopos para ${dateStr}: ${errorMessage}`,
+        errorStack,
+      );
+    }
+  }
+
+  /**
+   * T-BUG-016-B: Genera únicamente los horóscopos faltantes de una fecha.
+   *
+   * Identifica los signos sin horóscopo para la fecha dada y genera solo esos,
+   * con reintentos por signo. No regenera los que ya existen.
+   *
+   * @param date - Fecha objetivo (default: hoy)
+   * @returns Resumen de generación (faltantes detectados, exitosos, fallidos)
+   */
+  async generateMissingHoroscopes(date: Date = new Date()): Promise<{
+    missing: number;
+    successful: number;
+    failed: number;
+  }> {
+    const missingSigns =
+      await this.horoscopeService.findMissingSignsForDate(date);
+
+    if (missingSigns.length === 0) {
+      this.logger.log('Verificación OK: los 12 horóscopos del día existen.');
+      return { missing: 0, successful: 0, failed: 0 };
+    }
+
+    this.logger.warn(
+      `Se encontraron ${missingSigns.length} horóscopos faltantes. Iniciando regeneración...`,
+    );
+
+    const results: GenerationResult[] = [];
+    for (let i = 0; i < missingSigns.length; i++) {
+      const sign = missingSigns[i];
+
+      // Delay ANTES de generar (excepto para el primer faltante)
+      if (i > 0) {
+        await this.delay(this.DELAY_BETWEEN_SIGNS_MS);
+      }
+
+      const result = await this.generateSingleHoroscope(sign, date, i + 1);
+      results.push(result);
+    }
+
+    const successful = results.filter((r) => r.success).length;
+    const failed = results.filter((r) => !r.success).length;
+
+    this.logger.log(
+      `Regeneración de faltantes completada: ${successful} exitosos, ${failed} fallidos`,
+    );
+
+    return { missing: missingSigns.length, successful, failed };
   }
 
   /**

--- a/backend/tarot-app/src/modules/horoscope/application/services/horoscope-generation.service.spec.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/horoscope-generation.service.spec.ts
@@ -385,6 +385,54 @@ describe('HoroscopeGenerationService', () => {
     });
   });
 
+  describe('findMissingSignsForDate (T-BUG-016-B)', () => {
+    it('should return all 12 signs when none exist for the date', async () => {
+      const date = new Date('2026-01-17');
+
+      const queryBuilder = repository.createQueryBuilder();
+      queryBuilder.getMany = jest.fn().mockResolvedValue([]);
+
+      const result = await service.findMissingSignsForDate(date);
+
+      expect(result).toHaveLength(12);
+      expect(result).toContain(ZodiacSign.ARIES);
+      expect(result).toContain(ZodiacSign.PISCES);
+    });
+
+    it('should return only the signs that are missing', async () => {
+      const date = new Date('2026-01-17');
+
+      const queryBuilder = repository.createQueryBuilder();
+      queryBuilder.getMany = jest.fn().mockResolvedValue([
+        { ...mockDailyHoroscope, zodiacSign: ZodiacSign.ARIES },
+        { ...mockDailyHoroscope, zodiacSign: ZodiacSign.TAURUS },
+      ]);
+
+      const result = await service.findMissingSignsForDate(date);
+
+      expect(result).toHaveLength(10);
+      expect(result).not.toContain(ZodiacSign.ARIES);
+      expect(result).not.toContain(ZodiacSign.TAURUS);
+      expect(result).toContain(ZodiacSign.GEMINI);
+    });
+
+    it('should return empty array when all 12 signs exist', async () => {
+      const date = new Date('2026-01-17');
+
+      const allSigns = Object.values(ZodiacSign).map((sign) => ({
+        ...mockDailyHoroscope,
+        zodiacSign: sign,
+      }));
+
+      const queryBuilder = repository.createQueryBuilder();
+      queryBuilder.getMany = jest.fn().mockResolvedValue(allSigns);
+
+      const result = await service.findMissingSignsForDate(date);
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('incrementViewCount', () => {
     it('should increment view count for a horoscope', async () => {
       const id = 1;

--- a/backend/tarot-app/src/modules/horoscope/application/services/horoscope-generation.service.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/horoscope-generation.service.ts
@@ -184,6 +184,24 @@ export class HoroscopeGenerationService {
   }
 
   /**
+   * T-BUG-016-B: Identifica los signos zodiacales sin horóscopo para una fecha.
+   *
+   * Compara los 12 signos esperados contra los horóscopos existentes en la BD
+   * para la fecha dada y retorna los signos faltantes.
+   *
+   * @param date - Fecha a verificar (default: hoy)
+   * @returns Array de signos zodiacales sin horóscopo para esa fecha
+   */
+  async findMissingSignsForDate(
+    date: Date = new Date(),
+  ): Promise<ZodiacSign[]> {
+    const existing = await this.findAllByDate(date);
+    const existingSigns = new Set(existing.map((h) => h.zodiacSign));
+
+    return Object.values(ZodiacSign).filter((sign) => !existingSigns.has(sign));
+  }
+
+  /**
    * Incrementa el contador de visualizaciones de un horóscopo
    *
    * Operación atómica usando query builder para evitar race conditions.

--- a/docs/BACKLOG_BUGFIXES_2026_05_PARTE2.md
+++ b/docs/BACKLOG_BUGFIXES_2026_05_PARTE2.md
@@ -329,7 +329,7 @@ Que el `HoroscopeWidget` deje de mostrar "Configura tu fecha de nacimiento" cuan
 **Estimación:** 3 puntos
 **Dependencias:** ninguna (puede ir en paralelo con T-BUG-016-A)
 **Cubre BUG:** BUG-016 (causa subyacente)
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ Completada
 
 #### 📋 Descripción
 
@@ -337,11 +337,11 @@ Confirmar que los 12 horóscopos occidentales se generan completos cada día y a
 
 #### ✅ Tareas específicas
 
-- [ ] Auditar `horoscope-cron.service.ts` y `horoscope-generation.service.ts`: confirmar que se generan los 12 signos por día y qué pasa ante fallo individual.
-- [ ] Si un signo falla, reintentar con backoff sin abortar el resto del lote.
-- [ ] (Opcional) Endpoint admin de status del día (`generados / 12`) + "generar faltantes del día" reutilizando el patrón de T-BUG-001-A.
-- [ ] Tests unitarios de la lógica de generación/reintento.
-- [ ] Coverage ≥ 80%.
+- [x] Auditar `horoscope-cron.service.ts` y `horoscope-generation.service.ts`: confirmar que se generan los 12 signos por día y qué pasa ante fallo individual.
+- [x] Si un signo falla, reintentar con backoff sin abortar el resto del lote.
+- [x] Verificación diaria (cron a las 09:00 UTC) que detecta y regenera solo los signos faltantes del día (`generateMissingHoroscopes` + `findMissingSignsForDate`).
+- [x] Tests unitarios de la lógica de generación/reintento.
+- [x] Coverage ≥ 80%.
 
 #### 🎯 Criterios de Aceptación
 


### PR DESCRIPTION
## Resumen

Aborda la causa subyacente de **BUG-016**: el widget de horóscopo mostraba "Configura tu fecha de nacimiento" cuando en realidad el horóscopo diario del signo no había sido generado (404). Esta tarea robustece la generación diaria de horóscopos occidentales (analogía con T-BUG-001-A de horóscopos chinos).

## Cambios

- **Reintentos con backoff exponencial por signo** (\`6s / 12s / 24s\`, 4 intentos) en la generación diaria: un fallo transitorio (5xx / rate limit / timeout) ya no deja un hueco permanente ni aborta el lote.
- **Nuevo cron de verificación** \`verify-daily-horoscope-completeness\` a las **09:00 UTC** (3h después de la generación de las 06:00) que detecta y **regenera solo los signos faltantes** del día.
- \`HoroscopeGenerationService.findMissingSignsForDate(date)\`: identifica los signos sin horóscopo para una fecha.
- \`HoroscopeCronService.generateMissingHoroscopes(date)\`: genera únicamente los faltantes con reintentos.
- Constantes centralizadas en \`horoscope-cron.config.ts\` (\`VERIFICATION_SCHEDULE\`, \`MAX_RETRIES_PER_SIGN\`, \`RETRY_DELAYS_MS\`).

## Criterios de aceptación

- ✅ En un día normal \`GET /horoscope/my-sign\` no devuelve 404 por falta de generación para ninguno de los 12 signos.
- ✅ Un fallo transitorio en un signo no deja hueco permanente (reintento + verificación de faltantes).

## Validaciones

- ✅ \`npm run format\` / \`npm run lint\`
- ✅ \`npm run test:cov\` — 56 tests, cron 97.89% / generation 96.1% / config 100% (≥80%)
- ✅ \`npm run build\`
- ✅ \`node scripts/validate-architecture.js\`

Ref: T-BUG-016-B (\`docs/BACKLOG_BUGFIXES_2026_05_PARTE2.md\`)