### PR TITLE
feat(encyclopedia): render editorial del Markdown de artículos (T-ENC-001)

### DIFF
--- a/.agents/skills/frontend-aesthetics/SKILL.md
+++ b/.agents/skills/frontend-aesthetics/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: frontend-aesthetics
+description: Design and build bold, memorable, production-grade frontend interfaces that avoid generic "AI-generated" looks. Use when creating or refining UI/web pages, choosing typography, color, motion, layout, and visual details, or when the user asks for striking, unique, non-cookie-cutter frontend design.
+---
+
+# Frontend Aesthetics
+
+When building frontend interfaces, follow these guidelines.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE?
+
+Choose a clear conceptual direction and execute it with precision.
+
+Implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+- **Typography**: Choose fonts that are beautiful and unique. Avoid Arial, Inter, Roboto. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables. Dominant colors with sharp accents.
+- **Motion**: Animations for micro-interactions. CSS-only for HTML. Staggered reveals on page load. Scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements.
+- **Backgrounds & Visual Details**: Gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders.
+
+NEVER use: Inter, Roboto, Arial, purple gradients on white, predictable layouts, or cookie-cutter patterns.
+
+Vary between light and dark themes. Every design should feel unique and context-specific.

--- a/docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md
+++ b/docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md
@@ -1,0 +1,555 @@
+# BACKLOG: REDISEÑO DE LA ENCICLOPEDIA MÍSTICA — Mayo 2026
+
+## PARTE A: REPORTE DE HALLAZGOS DE DISEÑO
+
+**Proyecto:** Auguria - Plataforma de Servicios Místicos
+**Tipo:** Rediseño de UX/UI y enriquecimiento editorial de un módulo existente
+**Versión:** 1.0
+**Fecha:** 31 de mayo de 2026
+**Preparado por:** Ariel (Product Owner) + Copilot (Asistente IA, skill `frontend-aesthetics`)
+**Documento de análisis fuente:** `FEEDBACK_ENCICLOPEDIA_DISENO.md`
+**Convención de IDs:** se inicia una nueva serie `ENC-XXX` / `T-ENC-XXX` propia de este backlog.
+
+---
+
+## CONTEXTO
+
+Durante una revisión de diseño sobre la **Enciclopedia Mística** (`/enciclopedia`, `/enciclopedia/guias`, `/enciclopedia/guias/[slug]` y artículos de detalle), Ariel reportó que la información de la enciclopedia se ve **aburrida**, con **texto difícil de leer**, **sin imágenes** que acompañen y **desconectada de la identidad visual** del resto de la página.
+
+El contenido editorial es de altísima calidad, pero la presentación lo desperdicia: se ve como un documento de texto plano sobre fondo blanco, sin jerarquía visual real ni atmósfera mística (celeste/dorado) que sí existe en el resto de la marca (`hero-bg.webp`, `tarot-cards.webp`, `birth-chart-promo.webp`).
+
+Además del problema estético, se detectó un **bug técnico raíz** que aplana toda la tipografía de los artículos (clases `prose` inertes por falta del plugin de typography). Resolverlo es el cambio de mayor impacto/esfuerzo.
+
+---
+
+## ÍNDICE DE HALLAZGOS
+
+| ID      | Hallazgo                                                                  | Severidad  | Módulo afectado                       |
+| ------- | ------------------------------------------------------------------------- | ---------- | ------------------------------------- |
+| ENC-001 | Tipografía de artículos plana: clases `prose` no aplican (sin jerarquía)  | 🔴 Crítica | Frontend — Encyclopedia ArticleDetail |
+| ENC-002 | "Cartas de Tarot Relacionadas" muestra IDs crudos (`#1 #2 … #10`)         | 🟠 Alta    | Frontend — Encyclopedia ArticleDetail |
+| ENC-003 | Artículos sin imágenes ni segmentación editorial (muro de texto)          | 🟠 Alta    | Frontend — Encyclopedia / Assets      |
+| ENC-004 | Hub `/enciclopedia` con emojis del sistema y tema plano sin identidad     | 🟡 Media   | Frontend — Encyclopedia Hub           |
+| ENC-005 | Listado `/enciclopedia/guias` con filas mínimas (sin imagen ni jerarquía) | 🟡 Media   | Frontend — Encyclopedia Guías         |
+
+---
+
+## DETALLE DE HALLAZGOS
+
+### ENC-001: Tipografía de Artículos Plana — Las Clases `prose` No Aplican
+
+**Severidad:** 🔴 Crítica (causa raíz del "texto difícil de leer")
+**Módulo:** `frontend/src/components/features/encyclopedia/ArticleDetailView.tsx`
+**Reportado por:** Ariel — lectura de `/enciclopedia/guias/guia-tarot` (31/05/2026)
+
+#### Descripción del Problema
+
+El contenido Markdown de cada artículo se renderiza con un muro de texto sin jerarquía: el título de la guía, los `H2` ("1. ¿Qué es el Tarot?"), los `H3` y los párrafos se ven **del mismo tamaño y peso**. No hay ritmo de lectura, lo que hace el contenido denso y aburrido.
+
+#### Causa Raíz Identificada
+
+En [ArticleDetailView.tsx](frontend/src/components/features/encyclopedia/ArticleDetailView.tsx) el contenido se envuelve en clases de typography:
+
+```tsx
+<div className="prose prose-neutral dark:prose-invert max-w-none">
+  <ReactMarkdown remarkPlugins={[remarkGfm]}>{article.content}</ReactMarkdown>
+</div>
+```
+
+Pero el proyecto **no tiene instalado `@tailwindcss/typography`** (verificado en [globals.css](frontend/src/app/globals.css) y `package.json`). En **Tailwind v4** esto significa que `prose`, `prose-neutral` y `dark:prose-invert` **no existen como utilidades** y se ignoran silenciosamente. Aunque `ReactMarkdown` genera correctamente `<h1>/<h2>/<h3>/<ul>/<strong>` (confirmado en el árbol de accesibilidad), ninguno recibe estilos → todo se ve como párrafo plano.
+
+> Esta es la causa #1 del problema reportado. Resolverla sola mejora ~60% de la experiencia de lectura.
+
+#### Criterios de Aceptación
+
+1. **Dado** que abro cualquier artículo de la enciclopedia
+   **Cuando** se renderiza el Markdown
+   **Entonces** los `H1/H2/H3` tienen tamaños, pesos y espaciado claramente diferenciados del cuerpo (jerarquía visual real).
+
+2. **Dado** el sistema de marca
+   **Cuando** se estilan los títulos
+   **Entonces** usan Cormorant Garamond (`font-serif`), el cuerpo usa Lato (`font-sans`), los enlaces el lila `#805ad5` y los acentos el dorado `#d69e2e`.
+
+3. **Dado** un párrafo largo
+   **Cuando** lo leo
+   **Entonces** el ancho de medida (~`max-w-[68ch]`), interlineado (`leading-relaxed`) y tamaño (`text-lg`) favorecen la legibilidad.
+
+#### Notas Técnicas
+
+- **Opción A:** instalar `@tailwindcss/typography` y configurar un preset `prose` con los tokens de Auguria.
+- **Opción B (recomendada):** mapear los nodos de `ReactMarkdown` a componentes propios (`components={{ h1, h2, h3, p, ul, ol, li, strong, em, blockquote, a, table }}`) con clases Tailwind. Permite además insertar callouts, separadores decorativos y drop-caps editoriales sin sumar dependencia.
+- Centralizar el mapeo en un componente reutilizable (ej. `MarkdownArticle`) para usarlo en todos los tipos de artículo (guías, signos, planetas, elementos).
+
+---
+
+### ENC-002: "Cartas de Tarot Relacionadas" Muestra IDs Crudos (`#1 #2 … #10`)
+
+**Severidad:** 🟠 Alta (confuso, se ve sin terminar)
+**Módulo:** `frontend/src/components/features/encyclopedia/ArticleDetailView.tsx`
+**Reportado por:** Ariel — guía de Tarot, sección inferior (31/05/2026)
+
+#### Descripción del Problema
+
+La sección "Cartas de Tarot Relacionadas" renderiza **chips con el ID numérico crudo** de cada carta (`#1`, `#2`, … `#10`) en vez de mostrar la carta. Es confuso para el usuario y transmite sensación de prototipo inacabado.
+
+#### Causa Raíz Identificada
+
+En [ArticleDetailView.tsx](frontend/src/components/features/encyclopedia/ArticleDetailView.tsx) la sección itera `article.relatedTarotCards` (un array de IDs) y renderiza el ID directamente:
+
+```tsx
+{
+  article.relatedTarotCards!.map((cardId) => (
+    <span key={cardId} className="...">
+      #{cardId}
+    </span>
+  ));
+}
+```
+
+No se resuelve el ID a la carta (nombre + miniatura), pese a que ya existen `CardThumbnail` y rutas `/enciclopedia/tarot/[slug]`.
+
+#### Criterios de Aceptación
+
+1. **Dado** un artículo con cartas relacionadas
+   **Cuando** se renderiza la sección
+   **Entonces** cada carta muestra **miniatura + nombre** (no el ID), enlazando a su detalle `/enciclopedia/tarot/[slug]`.
+
+2. **Dado** que no hay cartas relacionadas
+   **Cuando** se renderiza
+   **Entonces** la sección no aparece (comportamiento actual conservado).
+
+#### Notas Técnicas
+
+- Resolver los IDs a datos de carta (hook/endpoint existente de cartas) o, si el backend ya devuelve objetos, usar nombre/slug/imagen.
+- Reutilizar `CardThumbnail` / `CardListItem` y mantener el estilo de tarjeta de marca.
+- Tests del nuevo render (miniatura, nombre, href).
+
+---
+
+### ENC-003: Artículos Sin Imágenes ni Segmentación Editorial
+
+**Severidad:** 🟠 Alta
+**Módulo:** `frontend/src/components/features/encyclopedia/ArticleDetailView.tsx` (+ assets + datos de contenido)
+**Reportado por:** Ariel — "texto aburrido, difícil de leer, sin imágenes que acompañen" (31/05/2026)
+
+#### Descripción del Problema
+
+Los artículos no tienen **ninguna imagen** ni recursos visuales que segmenten y acompañen la lectura. No hay hero, ni imágenes de sección, ni callouts, ni separadores. La lectura es un muro continuo, sin descanso visual y sin la atmósfera mística de la marca.
+
+#### Causa Raíz Identificada
+
+El render actual es: breadcrumb + título + badge + snippet + bloque Markdown + secciones de relacionados. No existe una **plantilla editorial** (hero con imagen, TOC, imágenes por sección, callouts, CTA inmersivo). Tampoco hay assets de imagen para la enciclopedia (`public/images/` solo tiene los del marketing general).
+
+#### Criterios de Aceptación
+
+1. **Dado** que abro un artículo de guía
+   **Cuando** carga
+   **Entonces** veo un **hero** con imagen temática (banda oscura de marca), breadcrumb, categoría, título y lead.
+
+2. **Dado** el cuerpo del artículo
+   **Cuando** lo recorro
+   **Entonces** cada gran sección puede tener su **imagen/ilustración**, y existen recursos editoriales (callouts "Clave"/"Sabías que…", separadores dorados, blockquote, drop-cap en el primer párrafo).
+
+3. **Dado** las imágenes generadas
+   **Cuando** se integran
+   **Entonces** son coherentes con el canon visual (violeta/índigo + dorado, etéreo) y tienen `alt` descriptivo en español.
+
+#### Notas Técnicas
+
+- Crear componente `ArticleHero` (banda `bg-hero → bg-hero-mid`, imagen con overlay, breadcrumb, lead, meta tiempo de lectura / nº de secciones).
+- Sistema editorial: H2 numerado con badge dorado, drop-cap, callouts, separadores `✦`, blockquote dorado, tablas estilizadas.
+- Generar imágenes (hero + secciones) por guía y guardarlas en `frontend/public/images/enciclopedia/` (WebP), siguiendo la **fórmula de prompts** definida en `FEEDBACK_ENCICLOPEDIA_DISENO.md §6`.
+- El contenido de "qué imagen va en qué sección" se modela como datos (no hardcode en el render) para poder reutilizar la plantilla en todas las guías.
+
+---
+
+### ENC-004: Hub `/enciclopedia` con Emojis del Sistema y Tema Plano
+
+**Severidad:** 🟡 Media (identidad visual)
+**Módulo:** `frontend/src/components/features/encyclopedia/EnciclopediaHubContent.tsx`
+**Reportado por:** Ariel — hub principal de la enciclopedia (31/05/2026)
+
+#### Descripción del Problema
+
+El hub de la enciclopedia muestra 3 tarjetas (Tarot / Astrología / Guías) con **emojis nativos del sistema** (🃏 ⭐ 📚) sobre fondo blanco plano. Se ve como un prototipo, varía según el SO del usuario y rompe con la estética dorada ilustrada de la marca.
+
+#### Causa Raíz Identificada
+
+En [EnciclopediaHubContent.tsx](frontend/src/components/features/encyclopedia/EnciclopediaHubContent.tsx) cada sección usa `icon: '🃏' | '⭐' | '📚'` renderizados como texto, y las tarjetas son `bg-card` blancas sin imagen ni uso de los tokens oscuros/dorados de marca.
+
+#### Criterios de Aceptación
+
+1. **Dado** que entro a `/enciclopedia`
+   **Cuando** carga el hub
+   **Entonces** veo un encabezado con identidad de marca (banda oscura/gradiente + título Cormorant) y 3 tarjetas con **imagen temática** (no emojis del sistema).
+
+2. **Dado** que paso el mouse por una tarjeta
+   **Cuando** hago hover
+   **Entonces** hay una micro-interacción coherente (zoom suave de imagen + glow dorado).
+
+3. **Dado** distintos dispositivos/SO
+   **Cuando** se renderiza
+   **Entonces** los íconos/ilustraciones se ven idénticos (no dependen de emoji del sistema).
+
+#### Notas Técnicas
+
+- Reemplazar emojis por imágenes/ilustraciones de marca (3 assets, ver prompts en `FEEDBACK_ENCICLOPEDIA_DISENO.md §4.1`).
+- Encabezado con banda `bg-hero`/`bg-hero-mid` + filete dorado.
+- Mantener grid responsive; opcional romper simetría para acento editorial.
+- Tests del hub (render de 3 secciones, enlaces correctos, alt de imágenes).
+
+---
+
+### ENC-005: Listado `/enciclopedia/guias` con Filas Mínimas
+
+**Severidad:** 🟡 Media
+**Módulo:** `frontend/src/components/features/encyclopedia/GuiasContent.tsx`
+**Reportado por:** Ariel — índice de guías (31/05/2026)
+
+#### Descripción del Problema
+
+El índice de guías presenta cada guía como una **fila mínima** (título + snippet + flecha), sin imagen ni jerarquía, sobre fondo plano. No invita a entrar ni refleja la riqueza del contenido.
+
+#### Causa Raíz Identificada
+
+En [GuiasContent.tsx](frontend/src/components/features/encyclopedia/GuiasContent.tsx) cada `GuiaItem` es un `Link` con `bg-card` + texto + `→`. No hay thumbnail, chip de categoría ni tratamiento visual de marca.
+
+#### Criterios de Aceptación
+
+1. **Dado** que entro a `/enciclopedia/guias`
+   **Cuando** carga la lista
+   **Entonces** veo **tarjetas editoriales** con thumbnail temático, título Cormorant, snippet (2 líneas), chip de categoría dorado y CTA "Leer guía →".
+
+2. **Dado** que paso el mouse por una tarjeta
+   **Cuando** hago hover
+   **Entonces** hay elevación + borde dorado + micro-translate.
+
+3. **Dado** el orden actual (Guía del Tarot primero, fix previo BUG-017)
+   **Cuando** se listan
+   **Entonces** se conserva el orden sin regresiones.
+
+#### Notas Técnicas
+
+- Grid 2-col desktop / 1-col mobile.
+- Reutilizar los thumbnails de cabecera de cada guía (assets de ENC-003).
+- Tests del listado (tarjeta con imagen, chip, href).
+
+---
+
+---
+
+## PARTE B: TAREAS TÉCNICAS
+
+> **Convención de IDs:** serie `T-ENC-XXX` propia de este backlog.
+> Estimación en puntos de historia (1 punto ≈ 0.5 día). Todas las tareas son frontend salvo indicación.
+
+### Índice de Tareas Técnicas
+
+| ID        | Tarea                                                                      | Tipo     | Prioridad  | Estimación |
+| --------- | -------------------------------------------------------------------------- | -------- | ---------- | ---------- |
+| T-ENC-001 | Render editorial del Markdown de artículos (jerarquía + tokens de marca)   | Frontend | 🔴 Crítica | 3 pts      |
+| T-ENC-002 | "Cartas relacionadas": miniatura + nombre enlazando al detalle             | Frontend | 🟠 Alta    | 1.5 pts    |
+| T-ENC-003 | Componente `ArticleHero` + sistema editorial (callouts, separadores, etc.) | Frontend | 🟠 Alta    | 3 pts      |
+| T-ENC-004 | TOC "En esta guía" con scroll-spy                                          | Frontend | 🟢 Baja    | 2 pts      |
+| T-ENC-005 | Rediseño del Hub `/enciclopedia` (hero + tarjetas con imagen)              | Frontend | 🟡 Media   | 2 pts      |
+| T-ENC-006 | Rediseño de tarjetas de `/enciclopedia/guias` (editorial con thumbnail)    | Frontend | 🟡 Media   | 2 pts      |
+| T-ENC-007 | Generación y optimización de imágenes de la enciclopedia (assets)          | Assets   | 🟠 Alta    | 3 pts      |
+| T-ENC-008 | Micro-interacciones y reveal escalonado al scroll                          | Frontend | 🟢 Baja    | 1.5 pts    |
+| T-ENC-009 | Accesibilidad: `alt`, contraste AA en bandas oscuras, foco visible         | Frontend | 🟡 Media   | 1.5 pts    |
+
+**Estimación total:** ~19.5 puntos.
+
+---
+
+## TAREAS DETALLADAS
+
+### T-ENC-001: Render Editorial del Markdown de Artículos
+
+**Prioridad:** 🔴 Crítica
+**Estimación:** 3 puntos
+**Dependencias:** ninguna
+**Cubre Hallazgo:** ENC-001
+**Estado:** ⬜ Pendiente
+
+#### 📋 Descripción
+
+Eliminar la dependencia de las clases `prose` (inertes en Tailwind v4) y dar jerarquía y legibilidad reales al contenido Markdown, con los tokens de marca de Auguria.
+
+#### ✅ Tareas específicas
+
+- [ ] Crear componente reutilizable `MarkdownArticle` que mapee los nodos de `ReactMarkdown` (`components={{ h1, h2, h3, p, ul, ol, li, strong, em, blockquote, a, table, hr }}`) a estilos Tailwind con tokens de marca.
+- [ ] Títulos en Cormorant (`font-serif`), cuerpo en Lato (`font-sans`), enlaces lila (`text-primary`), acentos dorados (`secondary`).
+- [ ] Medida de lectura `max-w-[68ch]`, `text-lg`, `leading-relaxed`, ritmo vertical consistente.
+- [ ] Reemplazar el `<div className="prose …">` de `ArticleDetailView.tsx` por `MarkdownArticle`.
+- [ ] (Decisión) Si se opta por `@tailwindcss/typography`, instalar y configurar preset `prose` con tokens; documentar la elección.
+- [ ] Tests del render (presencia y estilos diferenciados de h1/h2/h3, listas, strong, enlaces).
+- [ ] Coverage ≥ 80%.
+
+#### 🎯 Criterios de Aceptación
+
+- Los artículos muestran jerarquía visual clara (h1/h2/h3 diferenciados del cuerpo).
+- Estilos coherentes con la identidad (Cormorant/Lato/lila/dorado).
+- Ciclo de calidad frontend completo pasa.
+
+#### 📁 Archivos involucrados
+
+- `frontend/src/components/features/encyclopedia/ArticleDetailView.tsx`
+- `frontend/src/components/features/encyclopedia/MarkdownArticle.tsx` (nuevo)
+- `frontend/src/components/features/encyclopedia/MarkdownArticle.test.tsx` (nuevo)
+- (posible) `package.json`, configuración de Tailwind
+
+---
+
+### T-ENC-002: "Cartas Relacionadas" con Miniatura + Nombre
+
+**Prioridad:** 🟠 Alta
+**Estimación:** 1.5 puntos
+**Dependencias:** ninguna
+**Cubre Hallazgo:** ENC-002
+**Estado:** ⬜ Pendiente
+
+#### ✅ Tareas específicas
+
+- [ ] Resolver cada ID de `relatedTarotCards` a su carta (nombre + slug + imagen), vía hook/endpoint existente.
+- [ ] Renderizar cada carta con `CardThumbnail` + nombre, enlazando a `/enciclopedia/tarot/[slug]`.
+- [ ] Conservar la condición de ocultar la sección cuando no hay cartas relacionadas.
+- [ ] Tests del nuevo render (miniatura, nombre, href).
+- [ ] Coverage ≥ 80%.
+
+#### 🎯 Criterios de Aceptación
+
+- La sección muestra cartas reales (miniatura + nombre), no IDs crudos.
+- Cada carta enlaza a su detalle sin regresiones.
+- Ciclo de calidad frontend completo pasa.
+
+#### 📁 Archivos involucrados
+
+- `frontend/src/components/features/encyclopedia/ArticleDetailView.tsx`
+- `frontend/src/components/features/encyclopedia/CardThumbnail.tsx` (reutilizar)
+- tests correspondientes
+
+---
+
+### T-ENC-003: Componente `ArticleHero` + Sistema Editorial
+
+**Prioridad:** 🟠 Alta
+**Estimación:** 3 puntos
+**Dependencias:** T-ENC-001 (render base), T-ENC-007 (assets de imagen)
+**Cubre Hallazgo:** ENC-003
+**Estado:** ⬜ Pendiente
+
+#### 📋 Descripción
+
+Dar a los artículos una plantilla editorial: hero con imagen, recursos visuales de sección y elementos de descanso de lectura.
+
+#### ✅ Tareas específicas
+
+- [ ] Crear `ArticleHero` (banda `bg-hero → bg-hero-mid`, imagen de cabecera con overlay, breadcrumb, categoría, título Cormorant, lead, meta).
+- [ ] Soportar imágenes por sección (modeladas como datos, no hardcode).
+- [ ] Recursos editoriales: callouts ("Clave", "Sabías que…"), separadores dorados `✦`, blockquote dorado, drop-cap en el primer párrafo.
+- [ ] Integrar en `ArticleDetailView` / página de detalle de guía.
+- [ ] Tests (hero, callouts, render de imágenes con alt).
+- [ ] Coverage ≥ 80%.
+
+#### 🎯 Criterios de Aceptación
+
+- Los artículos de guía muestran hero con imagen + cuerpo segmentado con recursos editoriales.
+- Coherencia visual con la marca (violeta/índigo/dorado).
+- Ciclo de calidad frontend completo pasa.
+
+#### 📁 Archivos involucrados
+
+- `frontend/src/components/features/encyclopedia/ArticleHero.tsx` (nuevo)
+- `frontend/src/components/features/encyclopedia/ArticleDetailView.tsx`
+- datos de contenido editorial por guía (nuevo archivo de datos)
+- tests correspondientes
+
+---
+
+### T-ENC-004: TOC "En Esta Guía" con Scroll-Spy
+
+**Prioridad:** 🟢 Baja
+**Estimación:** 2 puntos
+**Dependencias:** T-ENC-001
+**Cubre Hallazgo:** ENC-003 (navegación de lectura)
+**Estado:** ⬜ Pendiente
+
+#### ✅ Tareas específicas
+
+- [ ] Generar índice (TOC) a partir de los `H2` del artículo, con anclas.
+- [ ] Resaltar la sección activa al hacer scroll (scroll-spy).
+- [ ] Comportamiento responsive (TOC lateral en desktop, colapsable en mobile).
+- [ ] Tests (generación de anclas, marcado de sección activa).
+- [ ] Coverage ≥ 80%.
+
+#### 🎯 Criterios de Aceptación
+
+- El artículo muestra un índice navegable que refleja sus secciones.
+- La sección activa se resalta según el scroll.
+- Ciclo de calidad frontend completo pasa.
+
+#### 📁 Archivos involucrados
+
+- `frontend/src/components/features/encyclopedia/ArticleToc.tsx` (nuevo)
+- tests correspondientes
+
+---
+
+### T-ENC-005: Rediseño del Hub `/enciclopedia`
+
+**Prioridad:** 🟡 Media
+**Estimación:** 2 puntos
+**Dependencias:** T-ENC-007 (assets)
+**Cubre Hallazgo:** ENC-004
+**Estado:** ⬜ Pendiente
+
+#### ✅ Tareas específicas
+
+- [ ] Encabezado con banda oscura/gradiente (`bg-hero`/`bg-hero-mid`) + título Cormorant + filete dorado.
+- [ ] Reemplazar emojis (🃏 ⭐ 📚) por imágenes/ilustraciones de marca en las 3 tarjetas.
+- [ ] Tarjetas con imagen + overlay + título dorado + micro-interacción de hover (zoom + glow).
+- [ ] Mantener grid responsive y enlaces existentes.
+- [ ] Tests (3 secciones, enlaces correctos, alt de imágenes).
+- [ ] Coverage ≥ 80%.
+
+#### 🎯 Criterios de Aceptación
+
+- El hub refleja la identidad de marca (sin emojis del sistema).
+- Hover con micro-interacción coherente.
+- Ciclo de calidad frontend completo pasa.
+
+#### 📁 Archivos involucrados
+
+- `frontend/src/components/features/encyclopedia/EnciclopediaHubContent.tsx`
+- `frontend/src/app/enciclopedia/page.test.tsx`
+
+---
+
+### T-ENC-006: Rediseño de Tarjetas de `/enciclopedia/guias`
+
+**Prioridad:** 🟡 Media
+**Estimación:** 2 puntos
+**Dependencias:** T-ENC-007 (thumbnails)
+**Cubre Hallazgo:** ENC-005
+**Estado:** ⬜ Pendiente
+
+#### ✅ Tareas específicas
+
+- [ ] Convertir `GuiaItem` en tarjeta editorial: thumbnail + título Cormorant + snippet (2 líneas) + chip de categoría dorado + CTA "Leer guía →".
+- [ ] Grid 2-col desktop / 1-col mobile.
+- [ ] Hover: elevación + borde dorado + micro-translate.
+- [ ] Conservar el orden (Guía del Tarot primera) sin regresiones.
+- [ ] Tests (tarjeta con imagen, chip, href).
+- [ ] Coverage ≥ 80%.
+
+#### 🎯 Criterios de Aceptación
+
+- El índice de guías muestra tarjetas ricas con imagen y jerarquía.
+- Orden y enlaces conservados.
+- Ciclo de calidad frontend completo pasa.
+
+#### 📁 Archivos involucrados
+
+- `frontend/src/components/features/encyclopedia/GuiasContent.tsx`
+- `frontend/src/app/enciclopedia/guias/page.test.tsx`
+
+---
+
+### T-ENC-007: Generación y Optimización de Imágenes de la Enciclopedia
+
+**Prioridad:** 🟠 Alta
+**Estimación:** 3 puntos
+**Dependencias:** ninguna (habilita ENC-003/004/005/006)
+**Cubre Hallazgo:** ENC-003 (assets), ENC-004, ENC-005
+**Estado:** ⬜ Pendiente
+
+#### 📋 Descripción
+
+Producir el set de imágenes de la enciclopedia (hero del hub, cabeceras de guía e imágenes de sección) siguiendo el canon de marca y la fórmula de prompts del documento de feedback.
+
+#### ✅ Tareas específicas
+
+- [ ] Generar imágenes con IA siguiendo la **fórmula base** y los prompts por sección de `FEEDBACK_ENCICLOPEDIA_DISENO.md §5–6`.
+- [ ] Paleta violeta/índigo + dorado; `no text`; coherentes con `hero-bg.webp` / `tarot-cards.webp`.
+- [ ] Exportar a **WebP** y guardar en `frontend/public/images/enciclopedia/` con nombres semánticos (`guia-tarot-hero.webp`, `tarot-arcanos-mayores.webp`, etc.).
+- [ ] Optimizar peso (seguir `frontend/docs/IMAGE_OPTIMIZATION.md`).
+- [ ] Definir `alt` descriptivo en español para cada imagen.
+
+#### 🎯 Criterios de Aceptación
+
+- Set de imágenes disponible en `public/images/enciclopedia/`, optimizado y consistente con la marca.
+- Cada imagen con `alt` definido.
+
+#### 📁 Archivos involucrados
+
+- `frontend/public/images/enciclopedia/*` (nuevos)
+- `FEEDBACK_ENCICLOPEDIA_DISENO.md` (referencia de prompts)
+
+---
+
+### T-ENC-008: Micro-interacciones y Reveal Escalonado
+
+**Prioridad:** 🟢 Baja
+**Estimación:** 1.5 puntos
+**Dependencias:** T-ENC-003, T-ENC-005, T-ENC-006
+**Cubre Hallazgo:** ENC-003/004/005 (pulido)
+**Estado:** ⬜ Pendiente
+
+#### ✅ Tareas específicas
+
+- [ ] Reveal fade-up escalonado por sección al hacer scroll (sutil, respetando `prefers-reduced-motion`).
+- [ ] Hover states de tarjetas (hub, guías) con glow dorado y elevación.
+- [ ] Tests donde aplique / verificación visual.
+- [ ] Coverage ≥ 80%.
+
+#### 🎯 Criterios de Aceptación
+
+- Animaciones sutiles y performantes que respetan `prefers-reduced-motion`.
+- Ciclo de calidad frontend completo pasa.
+
+#### 📁 Archivos involucrados
+
+- componentes de enciclopedia (hub, guías, artículo)
+
+---
+
+### T-ENC-009: Accesibilidad de la Enciclopedia
+
+**Prioridad:** 🟡 Media
+**Estimación:** 1.5 puntos
+**Dependencias:** T-ENC-003, T-ENC-005
+**Cubre Hallazgo:** transversal (ENC-003/004)
+**Estado:** ⬜ Pendiente
+
+#### ✅ Tareas específicas
+
+- [ ] `alt` descriptivos en todas las imágenes nuevas.
+- [ ] Contraste AA del texto sobre bandas oscuras (`bg-hero`).
+- [ ] Foco visible y navegación por teclado en tarjetas y TOC.
+- [ ] Verificación con herramienta de accesibilidad.
+- [ ] Coverage ≥ 80% donde aplique.
+
+#### 🎯 Criterios de Aceptación
+
+- Texto sobre fondos oscuros cumple contraste AA.
+- Imágenes con `alt`; foco visible en elementos interactivos.
+- Ciclo de calidad frontend completo pasa.
+
+#### 📁 Archivos involucrados
+
+- componentes de enciclopedia afectados
+
+---
+
+## ORDEN DE EJECUCIÓN SUGERIDO
+
+1. **T-ENC-001** (fix de tipografía — mayor impacto, desbloquea lectura).
+2. **T-ENC-007** (assets — habilita el resto del rediseño visual).
+3. **T-ENC-002** (quick win visible: cartas relacionadas).
+4. **T-ENC-003** (hero + sistema editorial).
+5. **T-ENC-005** y **T-ENC-006** (hub y listado).
+6. **T-ENC-004** (TOC), **T-ENC-008** (micro-interacciones), **T-ENC-009** (a11y) como pulido final.
+
+---
+
+> **Nota:** este backlog se deriva del análisis en `FEEDBACK_ENCICLOPEDIA_DISENO.md`. Cada tarea debe ejecutarse siguiendo `docs/WORKFLOW_FRONTEND.md` (TDD, ciclo de calidad y PR a `develop`).

--- a/docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md
+++ b/docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md
@@ -269,7 +269,7 @@ En [GuiasContent.tsx](frontend/src/components/features/encyclopedia/GuiasContent
 **Estimación:** 3 puntos
 **Dependencias:** ninguna
 **Cubre Hallazgo:** ENC-001
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ Completada (rama `feature/T-ENC-001-render-editorial-markdown`)
 
 #### 📋 Descripción
 
@@ -277,13 +277,13 @@ Eliminar la dependencia de las clases `prose` (inertes en Tailwind v4) y dar jer
 
 #### ✅ Tareas específicas
 
-- [ ] Crear componente reutilizable `MarkdownArticle` que mapee los nodos de `ReactMarkdown` (`components={{ h1, h2, h3, p, ul, ol, li, strong, em, blockquote, a, table, hr }}`) a estilos Tailwind con tokens de marca.
-- [ ] Títulos en Cormorant (`font-serif`), cuerpo en Lato (`font-sans`), enlaces lila (`text-primary`), acentos dorados (`secondary`).
-- [ ] Medida de lectura `max-w-[68ch]`, `text-lg`, `leading-relaxed`, ritmo vertical consistente.
-- [ ] Reemplazar el `<div className="prose …">` de `ArticleDetailView.tsx` por `MarkdownArticle`.
-- [ ] (Decisión) Si se opta por `@tailwindcss/typography`, instalar y configurar preset `prose` con tokens; documentar la elección.
-- [ ] Tests del render (presencia y estilos diferenciados de h1/h2/h3, listas, strong, enlaces).
-- [ ] Coverage ≥ 80%.
+- [x] Crear componente reutilizable `MarkdownArticle` que mapee los nodos de `ReactMarkdown` (`components={{ h1, h2, h3, p, ul, ol, li, strong, em, blockquote, a, table, thead, th, td, code, hr }}`) a estilos Tailwind con tokens de marca.
+- [x] Títulos en Cormorant (`font-serif`), cuerpo en Lato (`font-sans`), enlaces lila (`text-primary`), acentos dorados (`secondary`).
+- [x] Medida de lectura `max-w-[68ch]`, `text-lg`, `leading-relaxed`, ritmo vertical consistente.
+- [x] Reemplazar el `<div className="prose …">` de `ArticleDetailView.tsx` por `MarkdownArticle`.
+- [x] (Decisión) **Opción B** elegida: mapeo de nodos a componentes propios, **sin** sumar `@tailwindcss/typography` (cero dependencias nuevas, permite acentos editoriales). Documentado en el JSDoc del componente.
+- [x] Tests del render (jerarquía h1/h2/h3, cuerpo, listas, strong, em, enlaces, blockquote, tabla GFM, separador, código inline).
+- [x] Coverage 100% del componente (≥ 80% requerido).
 
 #### 🎯 Criterios de Aceptación
 

--- a/docs/FEEDBACK_ENCICLOPEDIA_DISENO.md
+++ b/docs/FEEDBACK_ENCICLOPEDIA_DISENO.md
@@ -1,0 +1,279 @@
+# 🔮 Feedback de Diseño — Enciclopedia Mística
+
+> **Autor:** Análisis de diseño (skill `frontend-aesthetics`)
+> **Fecha:** 31 de mayo de 2026
+> **Alcance:** `/enciclopedia`, `/enciclopedia/guias`, `/enciclopedia/guias/[slug]` y artículos de detalle (signos, planetas, elementos, tarot).
+> **Objetivo:** Transformar la Enciclopedia de un muro de texto plano a una experiencia editorial inmersiva, coherente con la identidad mística de Auguria.
+
+---
+
+## 1. Resumen ejecutivo
+
+La Enciclopedia tiene **contenido de altísima calidad** pero una **presentación que lo desperdicia**. Hoy se ve como un documento de Word: texto corrido sobre fondo blanco, sin imágenes, sin jerarquía visual real y completamente desconectado del universo visual celeste/dorado que define a la marca (ver `hero-bg.webp`, `birth-chart-promo.webp`, `tarot-cards.webp`).
+
+El problema **no es solo estético**: hay un **bug técnico raíz** que aplana toda la tipografía (ver §2.1). Una vez resuelto, sumado a segmentación visual e imágenes, la Enciclopedia puede convertirse en un activo de marca y SEO de primer nivel.
+
+### Diagnóstico en una frase
+
+> Contenido editorial premium presentado con la jerarquía visual de un `.txt`.
+
+---
+
+## 2. Hallazgos técnicos (causa raíz)
+
+### 2.1. 🔴 CRÍTICO — Las clases `prose` no aplican estilos (títulos planos)
+
+En [ArticleDetailView.tsx](../frontend/src/components/features/encyclopedia/ArticleDetailView.tsx) el contenido Markdown se renderiza así:
+
+```tsx
+<div className="prose prose-neutral dark:prose-invert max-w-none">
+  <ReactMarkdown remarkPlugins={[remarkGfm]}>{article.content}</ReactMarkdown>
+</div>
+```
+
+Pero el proyecto **no tiene instalado `@tailwindcss/typography`** (verificado en [globals.css](../frontend/src/app/globals.css) y `package.json`). En Tailwind v4 esto significa que `prose`, `prose-neutral` y `dark:prose-invert` **no existen como utilidades** → se ignoran silenciosamente.
+
+**Consecuencia:** aunque el Markdown genera `<h1>`, `<h2>`, `<h3>`, `<ul>`, `<strong>` correctamente (confirmado en el árbol de accesibilidad), **todos se ven del mismo tamaño que un párrafo**. Por eso "Guía del Tarot: El Espejo del Alma", "1. ¿Qué es el Tarot?" y el cuerpo se ven idénticos: no hay ritmo ni jerarquía.
+
+> Esta es la causa #1 del "texto difícil de leer". Resolverla sola ya mejora el 60% de la experiencia.
+
+**Opciones de solución:**
+
+- **A (recomendada):** instalar `@tailwindcss/typography` y definir un preset `prose` con los tokens de Auguria (Cormorant para títulos, Lato para cuerpo, lavanda `#805ad5` para enlaces, dorado `#d69e2e` para acentos).
+- **B:** crear componentes custom para cada nodo de `ReactMarkdown` (mapeo `components={{ h1, h2, h3, p, ul, strong, blockquote }}`) con clases Tailwind. Da más control editorial (callouts, drop-caps, separadores) y evita una dependencia.
+
+> Recomendación: **Opción B** para los artículos editoriales (guías), porque permite insertar imágenes, callouts y separadores decorativos. La marca lo agradece.
+
+### 2.2. 🟠 "Cartas de Tarot Relacionadas" muestra `#1 #2 … #10`
+
+En la guía de Tarot, la sección de cartas relacionadas renderiza chips crudos con el ID numérico (`#1`, `#2`…). Es confuso y feo. Debe mostrar **miniatura + nombre** de la carta enlazando a `/enciclopedia/tarot/[slug]` (ya existe `CardThumbnail`).
+
+### 2.3. 🟠 Tema claro plano, sin atmósfera
+
+La Enciclopedia usa exclusivamente `bg-main` (crema) y `surface` (blanco) sin ningún uso de los tokens oscuros de marca (`--color-bg-hero #1a0a2e`, `--color-bg-hero-mid #2d1b69`, `--color-secondary-glow`). El resultado es genérico. La marca ya tiene un sistema celeste/dorado precioso que aquí no se aprovecha.
+
+### 2.4. 🟡 Hub con emojis del sistema (🃏 ⭐ 📚)
+
+En [EnciclopediaHubContent.tsx](../frontend/src/components/features/encyclopedia/EnciclopediaHubContent.tsx) las 3 secciones usan emojis nativos. Se ven como un prototipo, rompen con la estética dorada ilustrada y varían según el SO del usuario. Deben ser **ilustraciones/íconos de marca** o imágenes temáticas.
+
+### 2.5. 🟡 `/enciclopedia/guias` aparece sin contenido visible
+
+La lista de guías renderizó solo el header (sin tarjetas) en navegación directa. Verificar el estado de carga/seed; además, hoy las tarjetas de guía ([GuiasContent.tsx](../frontend/src/components/features/encyclopedia/GuiasContent.tsx)) son filas mínimas texto+flecha, sin imagen ni color.
+
+---
+
+## 3. Lineamientos de marca a respetar
+
+Extraídos de los tokens reales ([globals.css](../frontend/src/app/globals.css)) y de las imágenes existentes.
+
+| Elemento            | Valor                                 | Uso                                       |
+| ------------------- | ------------------------------------- | ----------------------------------------- |
+| Fuente títulos      | **Cormorant Garamond** (`font-serif`) | Display, headings de artículo             |
+| Fuente cuerpo       | **Lato** (`font-sans`)                | Párrafos, listas                          |
+| Crema papiro        | `#f9f7f2` (`bg-main`)                 | Fondo de lectura                          |
+| Superficie          | `#ffffff` (`surface`)                 | Tarjetas                                  |
+| Grafito             | `#2d3748` (`text-primary`)            | Texto                                     |
+| Gris suave          | `#718096` (`text-muted`)              | Subtítulos, metadatos                     |
+| **Lavanda místico** | `#805ad5` (`primary`)                 | Enlaces, acentos, CTA                     |
+| **Dorado mate**     | `#d69e2e` (`secondary`)               | Bordes, íconos, filetes decorativos       |
+| Noche profunda      | `#1a0a2e` (`bg-hero`)                 | Encabezados inmersivos, héroes de sección |
+| Índigo oscuro       | `#2d1b69` (`bg-hero-mid`)             | Gradientes                                |
+| Glow dorado         | `rgba(214,158,46,0.25)`               | Resplandores sutiles                      |
+| Sombra suave        | `0 4px 20px -2px rgba(128,90,213,.1)` | Tarjetas                                  |
+
+### Estilo visual de imágenes (canon de marca)
+
+De `hero-bg.webp`, `tarot-cards.webp`, `birth-chart-promo.webp`:
+
+- **Pintura digital etérea**, cielo nocturno violeta/índigo profundo.
+- **Luz dorada cálida**: luna creciente, estrellas, bokeh, polvo estelar.
+- **Línea dorada fina** para símbolos (cartas, rueda zodiacal, geometría sagrada).
+- Atmósfera onírica, brumosa, premium. Nada plano ni vectorial duro.
+- Para ilustraciones sobre fondo claro (ej. `incense-bg.webp`): **boceto a lápiz fino + detalle dorado**, mucho aire en blanco.
+
+---
+
+## 4. Rediseño propuesto por pantalla
+
+### 4.1. Hub `/enciclopedia`
+
+**Problema:** blanco plano + emojis.
+
+**Propuesta:**
+
+- **Hero de encabezado** con banda oscura `bg-hero → bg-hero-mid` (gradiente), título Cormorant grande en crema, partículas/estrellas sutiles (CSS, sin assets pesados) y un filete dorado.
+- **3 tarjetas inmersivas** (Tarot / Astrología / Guías), cada una con **imagen temática** de cabecera (no emoji), overlay degradado oscuro abajo, título dorado y micro-interacción en hover (zoom suave de imagen + glow dorado).
+- Layout: mantener grid 3-col en desktop, pero romper la simetría con la tarjeta central ligeramente elevada o con ratio distinto (acento editorial).
+
+**Imágenes a generar (3):**
+
+1. **Tarot** — _Prompt:_ `Ethereal digital painting, three ornate tarot cards with fine gold-line sacred geometry, fanned out, glowing softly against a deep violet and indigo night sky, golden bokeh and stardust, crescent moon glow, mystical premium atmosphere, dreamy haze, no text, 16:9` (alineado con `tarot-cards.webp`).
+2. **Astrología** — _Prompt:_ `Ethereal digital painting, luminous golden zodiac wheel with fine line constellations, deep violet indigo cosmic background, crescent moon, scattered stars and golden bokeh, dreamy mystical premium mood, no text, 16:9` (alineado con `hero-bg.webp`).
+3. **Guías** — _Prompt:_ `Ethereal digital painting, an open antique grimoire with glowing golden runes rising as light particles, deep violet night sky, crescent moon, soft golden bokeh and stardust, mystical premium atmosphere, dreamy haze, no text, 16:9`.
+
+---
+
+### 4.2. Listado `/enciclopedia/guias`
+
+**Problema:** filas texto+flecha, sin jerarquía ni imagen.
+
+**Propuesta — tarjetas editoriales:**
+
+- Grid 2-col (desktop) / 1-col (mobile).
+- Cada tarjeta: **thumbnail temático** (izquierda o cabecera), **título Cormorant**, snippet a 2 líneas, **chip de categoría dorado**, y CTA "Leer guía →" en lavanda.
+- Hover: elevación + borde dorado + leve translate.
+- Orden ya correcto (Guía del Tarot primero, fix BUG-017).
+
+**Imágenes:** reutilizar las cabeceras de cada guía (§4.3) en formato thumbnail.
+
+---
+
+### 4.3. Artículo de guía `/enciclopedia/guias/[slug]` — _el corazón del rediseño_
+
+**Problema:** muro de texto, sin ritmo, sin imágenes, títulos planos (bug §2.1).
+
+**Estructura editorial propuesta (plantilla para TODAS las guías):**
+
+```
+┌─────────────────────────────────────────────┐
+│  HERO DE ARTÍCULO (banda oscura bg-hero)     │
+│  · Breadcrumb                                 │
+│  · Categoría (chip dorado)                    │
+│  · Título Cormorant XL en crema               │
+│  · Subtítulo/lead (snippet)                   │
+│  · Imagen de cabecera temática (overlay)      │
+│  · Tiempo de lectura · nº de secciones        │
+├─────────────────────────────────────────────┤
+│  ÍNDICE / "En esta guía" (TOC anclado)        │
+│  Lista de secciones con scroll-spy            │
+├─────────────────────────────────────────────┤
+│  CUERPO con ritmo:                            │
+│   · H2 con número dorado en círculo           │
+│   · Drop-cap en el primer párrafo             │
+│   · Cada sección con su imagen/ilustración    │
+│   · Callouts: "Sabías que…", "Clave"          │
+│   · Listas con íconos (palos, tiradas)        │
+│   · Separadores decorativos dorados (✦)       │
+│   · Tablas estilizadas donde aplique          │
+├─────────────────────────────────────────────┤
+│  CTA inmersivo (banda oscura + glow)          │
+│  Cartas relacionadas (thumb + nombre) §2.2    │
+│  Artículos relacionados (tarjetas)            │
+└─────────────────────────────────────────────┘
+```
+
+**Mejoras transversales de lectura:**
+
+- Ancho de medida ~`max-w-[68ch]` para el cuerpo (legibilidad).
+- Interlineado `leading-relaxed`, `text-lg` en cuerpo.
+- H2: Cormorant + número en badge dorado circular.
+- H3: Cormorant medio + filete dorado corto debajo.
+- Primer párrafo de cada gran sección con **drop-cap** (letra capital dorada, Cormorant).
+- Reveal escalonado al hacer scroll (fade-up sutil por sección).
+
+---
+
+## 5. Plantilla aplicada: **Guía del Tarot** (ejemplo completo)
+
+Tomando el contenido actual y enriqueciéndolo con segmentos, títulos e imágenes.
+
+### Cabecera (hero)
+
+- **Imagen:** `Ethereal digital painting, three ornate Rider-Waite style tarot cards (The Fool, The World, The Magician) with fine gold-line illustration, glowing on a deep violet indigo cosmic background, golden bokeh, crescent moon, stardust, dreamy mystical premium, no text, 21:9 banner`
+- **Lead actual** (ya existe, mantener): "Descubre el antiguo arte adivinatorio del Tarot…"
+
+### Sección 1 — ¿Qué es el Tarot?
+
+- **Título sugerido:** "El Tarot: un mapa del viaje del alma"
+- **Imagen (lateral):** `Ethereal pencil-and-gold illustration, a single ornate tarot card emanating golden light, fine line art, soft cream background with subtle violet haze, mystical premium, no text, 4:5` (estilo `incense-bg.webp`).
+- **Callout "Clave":** "El Tarot no predice un futuro fijo: ilumina patrones, tendencias y posibilidades."
+
+### Sección 2 — Los 78 Arcanos
+
+- **Título sugerido:** "Los 78 Arcanos: la estructura del Tarot"
+- **Bloque visual de 2 columnas:**
+  - **Arcanos Mayores (22)** — _Imagen:_ `Ethereal digital painting, a procession of 22 glowing tarot major arcana silhouettes along a golden path under a starry violet sky, crescent moon, fine gold line, dreamy mystical, no text, 16:9`
+  - **Arcanos Menores (56)** — bloque de **4 palos con íconos dorados** (🔥 Bastos / 💧 Copas / 🗡 Espadas / ⭐ Pentáculos → reemplazar emojis por **íconos de línea dorada**). _Imagen opcional:_ `Four mystical suit symbols — wand, cup, sword, pentacle — in fine gold line on deep violet background with golden bokeh, elegant, no text, 16:9`.
+- Convertir los 4 palos en **tarjetas con ícono + elemento + keywords** (mejor que lista plana).
+
+### Sección 3 — ¿Cómo funciona una lectura?
+
+- **Título:** "Cómo se lee el Tarot"
+- **Tres tiradas como tarjetas ilustradas** (Carta del Día / Tres cartas / Cruz Celta), cada una con un diagrama de posición de cartas en línea dorada.
+  - _Imagen tiradas:_ `Three tarot spread layouts (single card, three-card line, celtic cross) drawn as elegant fine gold-line diagrams on deep violet background, minimal, no text, 16:9`
+- **Callout "Sabías que…":** sobre cartas invertidas (no son negativas).
+
+### Sección 4 — El Tarot como autoconocimiento
+
+- **Título:** "Tarot y autoconocimiento"
+- **Imagen:** `Ethereal digital painting, a person meditating with a glowing tarot card floating above their hands, golden light, violet cosmic haze, stars, dreamy introspective mood, no text, 16:9`
+- **Cita destacada (blockquote dorado):** referencia a los arquetipos de Jung.
+
+### Sección 5 — Historia breve
+
+- **Título:** "Una breve historia del Tarot"
+- **Línea de tiempo visual** (timeline vertical con hitos dorados): s.XV Italia → de Gébelin → Lévi → Waite-Smith 1909.
+- **Imagen:** `Ethereal vintage illustration, antique 15th century Italian trionfi tarot cards aged parchment with gold leaf detail, soft candlelight, mystical historical mood, no text, 16:9`
+
+### Cierre
+
+- **CTA inmersivo:** banda oscura + "Calcular mi Carta del Día / Hacer una tirada".
+- **Cartas relacionadas:** miniatura real + nombre (fix §2.2).
+
+---
+
+## 6. Guía de prompts de imágenes (para consistencia con IA)
+
+Para que toda imagen generada se sienta de la misma familia que los assets actuales, usar esta **fórmula base** y variar solo el sujeto:
+
+> `Ethereal digital painting, [SUJETO], fine gold line detail, deep violet and indigo night sky, crescent moon, golden bokeh and stardust, dreamy mystical premium atmosphere, soft haze, cinematic glow, no text, no watermark, [RATIO]`
+
+**Variantes según contexto:**
+
+- **Cabeceras de artículo:** ratio `21:9`, sujeto protagonista centrado.
+- **Imágenes de sección:** ratio `16:9` o `4:5` (lateral).
+- **Sobre fondo claro (crema):** cambiar a → `delicate pencil sketch with fine gold ink accents, on warm cream paper, lots of negative space, elegant, mystical, no text` (estilo `incense-bg.webp`).
+
+**Reglas:**
+
+- Siempre `no text` (los títulos los pone la UI).
+- Paleta: violeta/índigo + dorado. **Nunca** colores saturados fríos fuera de la familia.
+- Exportar en **WebP** y guardar en `frontend/public/images/enciclopedia/` con nombres semánticos (`guia-tarot-hero.webp`, `tarot-arcanos-mayores.webp`, etc.).
+- Definir `alt` descriptivo en español para accesibilidad/SEO.
+
+---
+
+## 7. Backlog de tareas propuesto
+
+> Pendiente de tu aprobación para convertir en tareas formales (TASK-XXX) siguiendo `docs/WORKFLOW_FRONTEND.md`.
+
+| #   | Tipo      | Prioridad | Tarea                                                                                                                                                     |
+| --- | --------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | 🐛 Fix    | 🔴 Alta   | Resolver tipografía de artículos: mapear nodos de `ReactMarkdown` a componentes con tokens de marca (Opción B §2.1) o instalar `@tailwindcss/typography`. |
+| 2   | 🐛 Fix    | 🟠 Media  | "Cartas relacionadas": render con miniatura + nombre enlazando al detalle (§2.2).                                                                         |
+| 3   | ✨ Feat   | 🟠 Media  | Componente `ArticleHero` (banda oscura + imagen + breadcrumb + lead + meta) para artículos de guía.                                                       |
+| 4   | ✨ Feat   | 🟠 Media  | Sistema editorial Markdown: H2 numerado, drop-cap, callouts ("Clave", "Sabías que…"), separadores dorados, blockquote, tablas.                            |
+| 5   | ✨ Feat   | 🟡 Media  | TOC "En esta guía" con scroll-spy.                                                                                                                        |
+| 6   | 🎨 Design | 🟠 Media  | Rediseño del Hub `/enciclopedia`: hero oscuro + 3 tarjetas con imagen (sin emojis).                                                                       |
+| 7   | 🎨 Design | 🟡 Media  | Rediseño tarjetas de `/enciclopedia/guias` (editorial con thumbnail).                                                                                     |
+| 8   | 🖼️ Assets | 🟠 Media  | Generar y optimizar imágenes (hero + secciones) por guía, en `public/images/enciclopedia/`.                                                               |
+| 9   | ✨ Feat   | 🟢 Baja   | Reveal escalonado al scroll + micro-interacciones de hover en tarjetas.                                                                                   |
+| 10  | ♿ A11y   | 🟡 Media  | `alt` descriptivos, contraste AA en bandas oscuras, foco visible.                                                                                         |
+
+---
+
+## 8. Antes / Después (resumen visual)
+
+| Aspecto             | Hoy                      | Propuesta                                  |
+| ------------------- | ------------------------ | ------------------------------------------ |
+| Jerarquía           | Todo igual (bug `prose`) | H1/H2/H3 Cormorant + numeración dorada     |
+| Imágenes            | Ninguna                  | Hero + 1 img/sección, canon violeta-dorado |
+| Tema                | Blanco plano             | Crema editorial + bandas oscuras de marca  |
+| Ritmo de lectura    | Muro de texto            | Secciones, callouts, separadores, drop-cap |
+| Hub                 | Emojis del SO            | Tarjetas ilustradas con hover              |
+| Cartas relacionadas | `#1 #2 #3…`              | Miniatura + nombre                         |
+| Identidad           | Genérica/"IA"            | Mística, premium, memorable                |
+
+---
+
+> **Siguiente paso sugerido:** confirmame si avanzo creando las tareas formales (§7) en el backlog de frontend y, si querés, arranco por la **Tarea #1** (fix de tipografía), que es la de mayor impacto/esfuerzo.

--- a/frontend/src/components/features/encyclopedia/ArticleDetailView.test.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailView.test.tsx
@@ -97,6 +97,24 @@ describe('ArticleDetailView', () => {
 
       expect(screen.getByTestId('markdown-content')).toHaveTextContent('## Contenido de prueba');
     });
+
+    it('should strip the leading top-level heading to avoid a duplicate title', () => {
+      const content = '# Aries\n\n## Carácter\n\nTexto.';
+      render(<ArticleDetailView article={createTestArticle({ nameEs: 'Aries', content })} />);
+
+      const markdown = screen.getByTestId('markdown-content');
+      expect(markdown).not.toHaveTextContent('# Aries');
+      expect(markdown).toHaveTextContent('## Carácter');
+    });
+
+    it('should render a single h1 on the page (the article title)', () => {
+      const content = '# Aries\n\n## Carácter\n\nTexto.';
+      render(<ArticleDetailView article={createTestArticle({ nameEs: 'Aries', content })} />);
+
+      const level1Headings = screen.getAllByRole('heading', { level: 1 });
+      expect(level1Headings).toHaveLength(1);
+      expect(level1Headings[0]).toHaveTextContent('Aries');
+    });
   });
 
   describe('Related tarot cards', () => {

--- a/frontend/src/components/features/encyclopedia/ArticleDetailView.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailView.tsx
@@ -7,6 +7,7 @@ import { ROUTES } from '@/lib/constants/routes';
 import { ArticleCategory, ARTICLE_CATEGORY_LABELS } from '@/types/encyclopedia-article.types';
 import type { ArticleDetail, ArticleSummary } from '@/types/encyclopedia-article.types';
 import { cn } from '@/lib/utils';
+import { stripLeadingMarkdownHeading } from '@/lib/utils/text';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -152,8 +153,9 @@ export function ArticleDetailView({ article, className }: ArticleDetailViewProps
         {article.snippet && <p className="text-muted-foreground text-lg">{article.snippet}</p>}
       </div>
 
-      {/* Contenido Markdown */}
-      <MarkdownArticle content={article.content} />
+      {/* Contenido Markdown — se elimina el título `#` inicial para no duplicar
+          el <h1> de la página (ya renderizado arriba con article.nameEs). */}
+      <MarkdownArticle content={stripLeadingMarkdownHeading(article.content)} />
 
       {/* Cartas de tarot relacionadas */}
       {hasRelatedTarotCards && (

--- a/frontend/src/components/features/encyclopedia/ArticleDetailView.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailView.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 
+import { MarkdownArticle } from './MarkdownArticle';
 import { ROUTES } from '@/lib/constants/routes';
 import { ArticleCategory, ARTICLE_CATEGORY_LABELS } from '@/types/encyclopedia-article.types';
 import type { ArticleDetail, ArticleSummary } from '@/types/encyclopedia-article.types';
@@ -154,9 +153,7 @@ export function ArticleDetailView({ article, className }: ArticleDetailViewProps
       </div>
 
       {/* Contenido Markdown */}
-      <div className="prose prose-neutral dark:prose-invert max-w-none">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{article.content}</ReactMarkdown>
-      </div>
+      <MarkdownArticle content={article.content} />
 
       {/* Cartas de tarot relacionadas */}
       {hasRelatedTarotCards && (

--- a/frontend/src/components/features/encyclopedia/MarkdownArticle.test.tsx
+++ b/frontend/src/components/features/encyclopedia/MarkdownArticle.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { MarkdownArticle } from './MarkdownArticle';
+
+// NOTE: react-markdown is intentionally NOT mocked here. The whole point of this
+// component is the node-to-element mapping, so we render real Markdown and assert
+// on the produced DOM (roles + brand classes).
+
+describe('MarkdownArticle', () => {
+  describe('Rendering', () => {
+    it('should render wrapper with data-testid', () => {
+      render(<MarkdownArticle content="Texto simple." />);
+
+      expect(screen.getByTestId('markdown-article')).toBeInTheDocument();
+    });
+
+    it('should constrain the reading measure (max-w-[68ch]) on the wrapper', () => {
+      render(<MarkdownArticle content="Texto simple." />);
+
+      expect(screen.getByTestId('markdown-article')).toHaveClass('max-w-[68ch]');
+    });
+
+    it('should apply additional className to the wrapper', () => {
+      render(<MarkdownArticle content="Texto." className="custom-class" />);
+
+      expect(screen.getByTestId('markdown-article')).toHaveClass('custom-class');
+    });
+  });
+
+  describe('Visual hierarchy (headings vs body)', () => {
+    it('should render an h1 with serif display styles', () => {
+      render(<MarkdownArticle content="# Título Principal" />);
+
+      const h1 = screen.getByRole('heading', { level: 1, name: 'Título Principal' });
+      expect(h1).toHaveClass('font-serif');
+      expect(h1.className).toMatch(/text-(4xl|5xl)/);
+      expect(h1.className).toMatch(/font-(bold|semibold)/);
+    });
+
+    it('should render an h2 with serif styles smaller than h1', () => {
+      render(<MarkdownArticle content="## Sección" />);
+
+      const h2 = screen.getByRole('heading', { level: 2, name: 'Sección' });
+      expect(h2).toHaveClass('font-serif');
+      expect(h2.className).toMatch(/text-3xl/);
+    });
+
+    it('should render an h3 with serif styles', () => {
+      render(<MarkdownArticle content="### Subsección" />);
+
+      const h3 = screen.getByRole('heading', { level: 3, name: 'Subsección' });
+      expect(h3).toHaveClass('font-serif');
+      expect(h3.className).toMatch(/text-2xl/);
+    });
+
+    it('should render paragraphs in the readable body style (text-lg, relaxed leading)', () => {
+      render(<MarkdownArticle content="Un párrafo de cuerpo." />);
+
+      const paragraph = screen.getByText('Un párrafo de cuerpo.');
+      expect(paragraph.tagName).toBe('P');
+      expect(paragraph).toHaveClass('text-lg');
+      expect(paragraph).toHaveClass('leading-relaxed');
+    });
+
+    it('should differentiate heading size from body size', () => {
+      render(<MarkdownArticle content={'# Encabezado\n\nCuerpo del texto.'} />);
+
+      const heading = screen.getByRole('heading', { level: 1 });
+      const body = screen.getByText('Cuerpo del texto.');
+
+      // Hierarchy must be visually distinct: heading is not the body size.
+      expect(heading.className).not.toMatch(/\btext-lg\b/);
+      expect(body.className).not.toMatch(/text-4xl|text-5xl/);
+    });
+  });
+
+  describe('Inline elements', () => {
+    it('should render links with the brand lila color and a valid href', () => {
+      render(<MarkdownArticle content="[Auguria](https://example.com)" />);
+
+      const link = screen.getByRole('link', { name: 'Auguria' });
+      expect(link).toHaveAttribute('href', 'https://example.com');
+      expect(link).toHaveClass('text-primary');
+    });
+
+    it('should render strong text in bold', () => {
+      render(<MarkdownArticle content="Texto con **énfasis fuerte**." />);
+
+      const strong = screen.getByText('énfasis fuerte');
+      expect(strong.tagName).toBe('STRONG');
+      expect(strong.className).toMatch(/font-(bold|semibold)/);
+    });
+
+    it('should render emphasis in italic', () => {
+      render(<MarkdownArticle content="Texto con *matiz*." />);
+
+      const em = screen.getByText('matiz');
+      expect(em.tagName).toBe('EM');
+      expect(em).toHaveClass('italic');
+    });
+
+    it('should render inline code with the lila accent', () => {
+      render(<MarkdownArticle content="Usa `font-serif` aquí." />);
+
+      const code = screen.getByText('font-serif');
+      expect(code.tagName).toBe('CODE');
+      expect(code).toHaveClass('text-primary');
+    });
+  });
+
+  describe('Lists', () => {
+    it('should render unordered list items with gold markers', () => {
+      render(<MarkdownArticle content={'- Primero\n- Segundo'} />);
+
+      const list = screen.getByRole('list');
+      expect(list.tagName).toBe('UL');
+      expect(list.className).toMatch(/marker:text-secondary/);
+      expect(screen.getByText('Primero')).toBeInTheDocument();
+      expect(screen.getByText('Segundo')).toBeInTheDocument();
+    });
+
+    it('should render ordered lists as decimal lists', () => {
+      render(<MarkdownArticle content={'1. Uno\n2. Dos'} />);
+
+      const list = screen.getByRole('list');
+      expect(list.tagName).toBe('OL');
+      expect(list).toHaveClass('list-decimal');
+    });
+  });
+
+  describe('Block elements (GFM)', () => {
+    it('should render blockquotes with a gold accent border', () => {
+      render(<MarkdownArticle content="> Una cita inspiradora." />);
+
+      const quote = screen.getByText('Una cita inspiradora.').closest('blockquote');
+      expect(quote).not.toBeNull();
+      expect(quote?.className).toMatch(/border-secondary/);
+    });
+
+    it('should render GFM tables', () => {
+      const md = ['| Carta | Significado |', '| --- | --- |', '| El Mago | Acción |'].join('\n');
+      render(<MarkdownArticle content={md} />);
+
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getByRole('columnheader', { name: 'Carta' })).toBeInTheDocument();
+      expect(screen.getByRole('cell', { name: 'El Mago' })).toBeInTheDocument();
+    });
+
+    it('should render a decorative separator for thematic breaks', () => {
+      render(<MarkdownArticle content={'Antes\n\n---\n\nDespués'} />);
+
+      expect(screen.getByRole('separator')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/features/encyclopedia/MarkdownArticle.tsx
+++ b/frontend/src/components/features/encyclopedia/MarkdownArticle.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+// 3. Third-party
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+// 6. Utils & types
+import { cn } from '@/lib/utils';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface MarkdownArticleProps {
+  /** Raw Markdown content to render */
+  content: string;
+  /** Additional CSS classes for the wrapper */
+  className?: string;
+}
+
+// ─── Editorial component map ────────────────────────────────────────────────────
+
+/**
+ * Maps every Markdown node to a brand-aligned Tailwind element.
+ *
+ * This replaces the inert `prose`/`prose-neutral` classes: Tailwind v4 ships
+ * without `@tailwindcss/typography`, so those utilities never existed and the
+ * content rendered as a flat wall of text. Mapping the nodes by hand keeps us
+ * dependency-free and lets us inject editorial details (gold accents, serif
+ * headings, decorative separators) coherent with the Auguria canon.
+ *
+ * Design tokens:
+ * - Headings → Cormorant Garamond (`font-serif`), graphite (`text-foreground`).
+ * - Body → Lato (`font-sans` from the wrapper), `text-lg leading-relaxed`.
+ * - Links → mystic lila (`text-primary`).
+ * - Accents (separators, list markers, quote border, table head) → gold (`secondary`).
+ */
+const MARKDOWN_COMPONENTS: Components = {
+  h1: ({ children }) => (
+    <h1 className="text-foreground mt-12 mb-6 font-serif text-4xl leading-tight font-bold first:mt-0 sm:text-5xl">
+      {children}
+    </h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="text-foreground border-secondary/30 mt-12 mb-5 border-b pb-2 font-serif text-3xl leading-snug font-bold first:mt-0">
+      {children}
+    </h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="text-foreground mt-8 mb-3 font-serif text-2xl leading-snug font-semibold">
+      {children}
+    </h3>
+  ),
+  p: ({ children }) => <p className="text-foreground mb-6 text-lg leading-relaxed">{children}</p>,
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      className="text-primary decoration-primary/40 hover:decoration-primary font-medium underline underline-offset-2 transition-colors"
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children }) => (
+    <ul className="marker:text-secondary mb-6 ml-6 list-disc space-y-2 text-lg leading-relaxed">
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="marker:text-secondary mb-6 ml-6 list-decimal space-y-2 text-lg leading-relaxed marker:font-semibold">
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => <li className="text-foreground pl-1">{children}</li>,
+  strong: ({ children }) => <strong className="text-foreground font-bold">{children}</strong>,
+  em: ({ children }) => <em className="text-foreground italic">{children}</em>,
+  blockquote: ({ children }) => (
+    <blockquote className="border-secondary bg-secondary/5 text-foreground/90 my-8 border-l-4 py-3 pr-4 pl-6 font-serif text-xl italic">
+      {children}
+    </blockquote>
+  ),
+  hr: () => (
+    <hr aria-hidden="false" className="border-secondary/40 mx-auto my-10 w-24 border-t-2" />
+  ),
+  code: ({ children }) => (
+    <code className="bg-muted text-primary rounded px-1.5 py-0.5 font-mono text-base">
+      {children}
+    </code>
+  ),
+  table: ({ children }) => (
+    <div className="my-8 overflow-x-auto">
+      <table className="w-full border-collapse text-left text-base">{children}</table>
+    </div>
+  ),
+  thead: ({ children }) => <thead className="bg-secondary/10">{children}</thead>,
+  th: ({ children }) => (
+    <th className="text-foreground border-secondary/40 border-b-2 px-4 py-2 font-serif font-semibold">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td className="text-foreground border-border border-b px-4 py-2">{children}</td>
+  ),
+};
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+/**
+ * MarkdownArticle Component
+ *
+ * Renders an article's Markdown content with real editorial hierarchy and the
+ * Auguria brand tokens (Cormorant headings, Lato body, lila links, gold accents).
+ * Reusable across every article type (guides, signs, planets, elements).
+ *
+ * @example
+ * ```tsx
+ * <MarkdownArticle content={article.content} />
+ * ```
+ */
+export function MarkdownArticle({ content, className }: MarkdownArticleProps) {
+  return (
+    <div data-testid="markdown-article" className={cn('max-w-[68ch] font-sans', className)}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={MARKDOWN_COMPONENTS}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/frontend/src/components/features/encyclopedia/index.ts
+++ b/frontend/src/components/features/encyclopedia/index.ts
@@ -101,3 +101,5 @@ export type { EncyclopediaHomeProps } from './EncyclopediaHome';
 // Article detail components
 export { ArticleDetailView } from './ArticleDetailView';
 export type { ArticleDetailViewProps } from './ArticleDetailView';
+export { MarkdownArticle } from './MarkdownArticle';
+export type { MarkdownArticleProps } from './MarkdownArticle';

--- a/frontend/src/lib/utils/text.test.ts
+++ b/frontend/src/lib/utils/text.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getInitials } from './text';
+import { getInitials, stripLeadingMarkdownHeading } from './text';
 
 describe('getInitials', () => {
   it('should return two-letter initials from two-word name', () => {
@@ -32,5 +32,42 @@ describe('getInitials', () => {
 
   it('should handle empty string', () => {
     expect(getInitials('')).toBe('');
+  });
+});
+
+describe('stripLeadingMarkdownHeading', () => {
+  it('should remove a leading top-level heading', () => {
+    expect(stripLeadingMarkdownHeading('# Aries\n\n## Carácter\nTexto.')).toBe(
+      '## Carácter\nTexto.'
+    );
+  });
+
+  it('should remove a leading heading preceded by blank lines (guide format)', () => {
+    const content = '\n# Guía del Tarot: El Espejo del Alma\n\n## 1. ¿Qué es el Tarot?';
+    expect(stripLeadingMarkdownHeading(content)).toBe('## 1. ¿Qué es el Tarot?');
+  });
+
+  it('should preserve a leading second-level heading (##)', () => {
+    const content = '## Sección\n\nTexto.';
+    expect(stripLeadingMarkdownHeading(content)).toBe(content);
+  });
+
+  it('should not remove a top-level heading that is not the first content', () => {
+    const content = 'Intro.\n\n# Título en el medio\n\nMás texto.';
+    expect(stripLeadingMarkdownHeading(content)).toBe(content);
+  });
+
+  it('should only remove the first leading heading, keeping the rest intact', () => {
+    const content = '# Primero\n\n# Segundo\n\nTexto.';
+    expect(stripLeadingMarkdownHeading(content)).toBe('# Segundo\n\nTexto.');
+  });
+
+  it('should return content unchanged when there is no heading', () => {
+    const content = 'Solo un párrafo sin encabezado.';
+    expect(stripLeadingMarkdownHeading(content)).toBe(content);
+  });
+
+  it('should handle an empty string', () => {
+    expect(stripLeadingMarkdownHeading('')).toBe('');
   });
 });

--- a/frontend/src/lib/utils/text.ts
+++ b/frontend/src/lib/utils/text.ts
@@ -20,3 +20,24 @@ export function getInitials(name: string): string {
   }
   return (words[0][0] + words[1][0]).toUpperCase();
 }
+
+/**
+ * Removes a leading top-level Markdown heading (`# Título`) from content.
+ *
+ * Encyclopedia articles embed their own title as the first `#` heading, but the
+ * page chrome already renders that title as the page <h1>. Stripping it avoids a
+ * duplicated, oversized title and keeps a single <h1> per page (correct outline).
+ *
+ * Only a single-hash (`#`) heading at the very start of the content is removed,
+ * along with the blank lines that follow it. Second/third-level headings
+ * (`##`, `###`) and headings further down in the document are preserved.
+ *
+ * @param content - Raw Markdown content
+ * @returns Content without its leading top-level heading
+ * @example
+ * stripLeadingMarkdownHeading('# Aries\n\n## Carácter') // '## Carácter'
+ * stripLeadingMarkdownHeading('## Sección\nTexto')      // '## Sección\nTexto'
+ */
+export function stripLeadingMarkdownHeading(content: string): string {
+  return content.replace(/^\s*#[ \t]+[^\n]*[\r\n]*/, '');
+}


### PR DESCRIPTION
## 🎯 Tarea

**T-ENC-001** — Render Editorial del Markdown de Artículos (cubre hallazgo **ENC-001**, 🔴 Crítica).
Backlog: `docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md`.

## 🐛 Causa raíz

El contenido de los artículos se veía como un muro de texto plano: las clases `prose prose-neutral dark:prose-invert` eran **inertes** porque el proyecto usa **Tailwind v4 sin `@tailwindcss/typography`**, así que esas utilidades nunca existieron y se ignoraban silenciosamente. `ReactMarkdown` generaba el HTML correcto (h1/h2/h3/ul/strong…) pero sin ningún estilo.

## ✨ Solución

Nuevo componente reutilizable **`MarkdownArticle`** que mapea los nodos de `ReactMarkdown` a estilos Tailwind con los tokens de marca de Auguria.

**Decisión de diseño — Opción B (recomendada en el backlog):** mapeo de nodos a componentes propios, **sin sumar dependencias** (`@tailwindcss/typography` descartado). Documentado en el JSDoc del componente.

### Cambios
- ➕ `MarkdownArticle.tsx` — mapeo de `h1, h2, h3, p, a, ul, ol, li, strong, em, blockquote, code, table, thead, th, td, hr`.
- 🔄 `ArticleDetailView.tsx` — reemplaza el `<div className="prose …">` por `<MarkdownArticle />`.
- 📦 `index.ts` — exporta `MarkdownArticle` + tipo.
- 📝 Backlog actualizado (T-ENC-001 → ✅ Completada).

### Tokens aplicados (criterios de aceptación)
- **Jerarquía real**: h1/h2/h3 en Cormorant (`font-serif`) con tamaños/pesos/espaciado diferenciados del cuerpo.
- **Marca**: cuerpo Lato (`font-sans`), enlaces lila (`text-primary`), acentos dorados (`secondary`) en separadores, marcadores de lista, borde de blockquote y cabecera de tablas.
- **Legibilidad**: `max-w-[68ch]`, `text-lg`, `leading-relaxed`, ritmo vertical consistente.
- **GFM**: tablas estilizadas, blockquote serif, código inline, separador decorativo.

## ✅ Validaciones

- [x] TDD: tests escritos primero (RED → GREEN)
- [x] 17 tests nuevos en `MarkdownArticle.test.tsx` + 21 existentes de `ArticleDetailView` siguen en verde
- [x] **Coverage 100%** del componente (≥80% requerido)
- [x] `npm run lint:fix` sin errores
- [x] `npm run type-check` sin errores
- [x] `npm run build` exitoso
- [x] `node scripts/validate-architecture.js` ✅
- [x] Texto user-facing en español · `'use client'` · `data-testid` · sin `any`

## 📸 Screenshots

> ⚠️ _Pendiente: adjuntar antes/después de un artículo (ej. `/enciclopedia/guias/guia-tarot`)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)