### PR TITLE
feat(encyclopedia): cartas relacionadas con miniatura + nombre (T-ENC-002)

### DIFF
--- a/docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md
+++ b/docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md
@@ -306,15 +306,21 @@ Eliminar la dependencia de las clases `prose` (inertes en Tailwind v4) y dar jer
 **Estimación:** 1.5 puntos
 **Dependencias:** ninguna
 **Cubre Hallazgo:** ENC-002
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ Completada (rama `feature/T-ENC-002-cartas-relacionadas-miniatura`)
 
 #### ✅ Tareas específicas
 
-- [ ] Resolver cada ID de `relatedTarotCards` a su carta (nombre + slug + imagen), vía hook/endpoint existente.
-- [ ] Renderizar cada carta con `CardThumbnail` + nombre, enlazando a `/enciclopedia/tarot/[slug]`.
-- [ ] Conservar la condición de ocultar la sección cuando no hay cartas relacionadas.
-- [ ] Tests del nuevo render (miniatura, nombre, href).
-- [ ] Coverage ≥ 80%.
+- [x] Resolver cada ID de `relatedTarotCards` a su carta (nombre + slug + imagen), vía hook/endpoint existente.
+- [x] Renderizar cada carta con `CardThumbnail` + nombre, enlazando a `/enciclopedia/tarot/[slug]`.
+- [x] Conservar la condición de ocultar la sección cuando no hay cartas relacionadas.
+- [x] Tests del nuevo render (miniatura, nombre, href).
+- [x] Coverage ≥ 80%.
+
+#### 📝 Notas de implementación
+
+- Nuevo componente `RelatedTarotCards` que resuelve los IDs contra el mazo completo (`useCards`, cacheado 1h — sin endpoint nuevo) y construye un mapa `id → CardSummary`. Los IDs desconocidos se omiten; si ninguno resuelve, no renderiza nada.
+- Se añadió un prop opcional `href` a `CardThumbnail` (default `/enciclopedia/{slug}`, retrocompatible) para enlazar a la ruta canónica de tarot `ROUTES.ENCICLOPEDIA_TAROT_CARD(slug)` sin afectar otros usos.
+- `ArticleDetailView` conserva el gate de la sección (oculta si `relatedTarotCards` es `null`/vacío) y delega la grilla al nuevo componente.
 
 #### 🎯 Criterios de Aceptación
 

--- a/frontend/src/components/features/encyclopedia/ArticleDetailView.test.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailView.test.tsx
@@ -127,12 +127,6 @@ describe('ArticleDetailView', () => {
   });
 
   describe('Related tarot cards', () => {
-    it('should show related tarot cards section when relatedTarotCards has items', () => {
-      render(<ArticleDetailView article={createTestArticle({ relatedTarotCards: [1, 3, 10] })} />);
-
-      expect(screen.getByTestId('related-tarot-cards')).toBeInTheDocument();
-    });
-
     it('should delegate the related card IDs to RelatedTarotCards (no raw IDs shown)', () => {
       render(<ArticleDetailView article={createTestArticle({ relatedTarotCards: [1, 3, 10] })} />);
 
@@ -140,16 +134,16 @@ describe('ArticleDetailView', () => {
       expect(screen.queryByText('#1')).not.toBeInTheDocument();
     });
 
-    it('should not show related tarot cards section when relatedTarotCards is null', () => {
+    it('should not render RelatedTarotCards when relatedTarotCards is null', () => {
       render(<ArticleDetailView article={createTestArticle({ relatedTarotCards: null })} />);
 
-      expect(screen.queryByTestId('related-tarot-cards')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('related-tarot-cards-mock')).not.toBeInTheDocument();
     });
 
-    it('should not show related tarot cards section when relatedTarotCards is empty', () => {
+    it('should not render RelatedTarotCards when relatedTarotCards is empty', () => {
       render(<ArticleDetailView article={createTestArticle({ relatedTarotCards: [] })} />);
 
-      expect(screen.queryByTestId('related-tarot-cards')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('related-tarot-cards-mock')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/features/encyclopedia/ArticleDetailView.test.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailView.test.tsx
@@ -17,6 +17,15 @@ vi.mock('remark-gfm', () => ({
   default: vi.fn(),
 }));
 
+// Mock RelatedTarotCards to isolate ArticleDetailView from the cards data hook.
+// We assert it receives the related card IDs; its own rendering (thumbnail,
+// name, href) is covered by RelatedTarotCards.test.tsx.
+vi.mock('./RelatedTarotCards', () => ({
+  RelatedTarotCards: ({ cardIds }: { cardIds: number[] }) => (
+    <div data-testid="related-tarot-cards-mock">{cardIds.join(',')}</div>
+  ),
+}));
+
 // Mock next/link
 vi.mock('next/link', () => ({
   default: ({
@@ -122,6 +131,13 @@ describe('ArticleDetailView', () => {
       render(<ArticleDetailView article={createTestArticle({ relatedTarotCards: [1, 3, 10] })} />);
 
       expect(screen.getByTestId('related-tarot-cards')).toBeInTheDocument();
+    });
+
+    it('should delegate the related card IDs to RelatedTarotCards (no raw IDs shown)', () => {
+      render(<ArticleDetailView article={createTestArticle({ relatedTarotCards: [1, 3, 10] })} />);
+
+      expect(screen.getByTestId('related-tarot-cards-mock')).toHaveTextContent('1,3,10');
+      expect(screen.queryByText('#1')).not.toBeInTheDocument();
     });
 
     it('should not show related tarot cards section when relatedTarotCards is null', () => {

--- a/frontend/src/components/features/encyclopedia/ArticleDetailView.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailView.tsx
@@ -158,13 +158,9 @@ export function ArticleDetailView({ article, className }: ArticleDetailViewProps
           el <h1> de la página (ya renderizado arriba con article.nameEs). */}
       <MarkdownArticle content={stripLeadingMarkdownHeading(article.content)} />
 
-      {/* Cartas de tarot relacionadas */}
-      {hasRelatedTarotCards && (
-        <section data-testid="related-tarot-cards" className="space-y-4">
-          <h2 className="text-foreground text-xl font-bold">Cartas de Tarot Relacionadas</h2>
-          <RelatedTarotCards cardIds={article.relatedTarotCards!} />
-        </section>
-      )}
+      {/* Cartas de tarot relacionadas — RelatedTarotCards renderiza la sección
+          completa (título incluido) o nada si ningún ID resuelve. */}
+      {hasRelatedTarotCards && <RelatedTarotCards cardIds={article.relatedTarotCards!} />}
 
       {/* Artículos relacionados */}
       {hasRelatedArticles && (

--- a/frontend/src/components/features/encyclopedia/ArticleDetailView.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailView.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 
 import { MarkdownArticle } from './MarkdownArticle';
+import { RelatedTarotCards } from './RelatedTarotCards';
 import { ROUTES } from '@/lib/constants/routes';
 import { ArticleCategory, ARTICLE_CATEGORY_LABELS } from '@/types/encyclopedia-article.types';
 import type { ArticleDetail, ArticleSummary } from '@/types/encyclopedia-article.types';
@@ -161,16 +162,7 @@ export function ArticleDetailView({ article, className }: ArticleDetailViewProps
       {hasRelatedTarotCards && (
         <section data-testid="related-tarot-cards" className="space-y-4">
           <h2 className="text-foreground text-xl font-bold">Cartas de Tarot Relacionadas</h2>
-          <div className="flex flex-wrap gap-2">
-            {article.relatedTarotCards!.map((cardId) => (
-              <span
-                key={cardId}
-                className="bg-muted text-muted-foreground rounded-md px-3 py-1 text-sm"
-              >
-                #{cardId}
-              </span>
-            ))}
-          </div>
+          <RelatedTarotCards cardIds={article.relatedTarotCards!} />
         </section>
       )}
 

--- a/frontend/src/components/features/encyclopedia/CardThumbnail.test.tsx
+++ b/frontend/src/components/features/encyclopedia/CardThumbnail.test.tsx
@@ -45,6 +45,18 @@ describe('CardThumbnail', () => {
 
       expect(screen.getByTestId('card-thumbnail-the-fool')).toBeInTheDocument();
     });
+
+    it('should use the href override when provided', () => {
+      render(
+        <CardThumbnail
+          card={createTestCard({ slug: 'the-fool' })}
+          href="/enciclopedia/tarot/the-fool"
+        />
+      );
+
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('href', '/enciclopedia/tarot/the-fool');
+    });
   });
 
   describe('Major Arcana badge', () => {

--- a/frontend/src/components/features/encyclopedia/CardThumbnail.tsx
+++ b/frontend/src/components/features/encyclopedia/CardThumbnail.tsx
@@ -16,6 +16,11 @@ export interface CardThumbnailProps {
   card: CardSummary;
   /** Additional CSS classes */
   className?: string;
+  /**
+   * Optional href override for the card link.
+   * Defaults to `/enciclopedia/{slug}` to preserve existing behavior.
+   */
+  href?: string;
 }
 
 /**
@@ -34,12 +39,12 @@ export interface CardThumbnailProps {
  * <CardThumbnail card={card} />
  * ```
  */
-export function CardThumbnail({ card, className }: CardThumbnailProps) {
+export function CardThumbnail({ card, className, href }: CardThumbnailProps) {
   const isMajor = card.arcanaType === ArcanaType.MAJOR;
   const badgeLabel = isMajor ? 'Arcanos Mayores' : card.suit ? SUIT_INFO[card.suit].nameEs : null;
 
   return (
-    <Link href={`/enciclopedia/${card.slug}`} className="group block">
+    <Link href={href ?? `/enciclopedia/${card.slug}`} className="group block">
       <div
         data-testid={`card-thumbnail-${card.slug}`}
         className={cn('overflow-hidden rounded-lg', className)}

--- a/frontend/src/components/features/encyclopedia/RelatedTarotCards.test.tsx
+++ b/frontend/src/components/features/encyclopedia/RelatedTarotCards.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { RelatedTarotCards } from './RelatedTarotCards';
+import { ArcanaType } from '@/types/encyclopedia.types';
+import type { CardSummary } from '@/types/encyclopedia.types';
+
+// Mock the useCards hook (data source for resolving card IDs)
+vi.mock('@/hooks/api/useEncyclopedia', () => ({
+  useCards: vi.fn(),
+}));
+
+import { useCards } from '@/hooks/api/useEncyclopedia';
+
+const mockUseCards = vi.mocked(useCards);
+
+function createCard(overrides?: Partial<CardSummary>): CardSummary {
+  return {
+    id: 1,
+    slug: 'the-magician',
+    nameEs: 'El Mago',
+    arcanaType: ArcanaType.MAJOR,
+    number: 1,
+    suit: null,
+    thumbnailUrl: '/images/tarot/magician.jpg',
+    ...overrides,
+  };
+}
+
+const ALL_CARDS: CardSummary[] = [
+  createCard({ id: 1, slug: 'the-magician', nameEs: 'El Mago' }),
+  createCard({ id: 3, slug: 'the-empress', nameEs: 'La Emperatriz' }),
+  createCard({ id: 10, slug: 'wheel-of-fortune', nameEs: 'La Rueda de la Fortuna' }),
+  createCard({ id: 5, slug: 'the-hierophant', nameEs: 'El Sumo Sacerdote' }),
+];
+
+function mockCards(cards: CardSummary[] | undefined, isLoading = false) {
+  mockUseCards.mockReturnValue({
+    data: cards,
+    isLoading,
+  } as ReturnType<typeof useCards>);
+}
+
+describe('RelatedTarotCards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Loading state', () => {
+    it('should render a skeleton while cards are loading', () => {
+      mockCards(undefined, true);
+
+      render(<RelatedTarotCards cardIds={[1, 3, 10]} />);
+
+      expect(screen.getByTestId('related-tarot-cards-skeleton')).toBeInTheDocument();
+    });
+  });
+
+  describe('Empty / unresolved state', () => {
+    it('should render nothing when no IDs resolve to a card', () => {
+      mockCards(ALL_CARDS);
+
+      const { container } = render(<RelatedTarotCards cardIds={[999, 1000]} />);
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should render nothing when cardIds is empty', () => {
+      mockCards(ALL_CARDS);
+
+      const { container } = render(<RelatedTarotCards cardIds={[]} />);
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should render nothing when cards data is undefined and not loading', () => {
+      mockCards(undefined, false);
+
+      const { container } = render(<RelatedTarotCards cardIds={[1, 3]} />);
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('Resolved cards', () => {
+    it('should render each related card name (not the raw ID)', () => {
+      mockCards(ALL_CARDS);
+
+      render(<RelatedTarotCards cardIds={[1, 3, 10]} />);
+
+      expect(screen.getByText('El Mago')).toBeInTheDocument();
+      expect(screen.getByText('La Emperatriz')).toBeInTheDocument();
+      expect(screen.getByText('La Rueda de la Fortuna')).toBeInTheDocument();
+      expect(screen.queryByText('#1')).not.toBeInTheDocument();
+    });
+
+    it('should render a thumbnail image for each card', () => {
+      mockCards(ALL_CARDS);
+
+      render(<RelatedTarotCards cardIds={[1, 3]} />);
+
+      expect(screen.getByAltText('El Mago')).toBeInTheDocument();
+      expect(screen.getByAltText('La Emperatriz')).toBeInTheDocument();
+    });
+
+    it('should link each card to its tarot detail page /enciclopedia/tarot/[slug]', () => {
+      mockCards(ALL_CARDS);
+
+      render(<RelatedTarotCards cardIds={[1, 3]} />);
+
+      const links = screen.getAllByRole('link');
+      const hrefs = links.map((link) => link.getAttribute('href'));
+      expect(hrefs).toContain('/enciclopedia/tarot/the-magician');
+      expect(hrefs).toContain('/enciclopedia/tarot/the-empress');
+    });
+
+    it('should only render cards whose IDs exist, skipping unknown IDs', () => {
+      mockCards(ALL_CARDS);
+
+      render(<RelatedTarotCards cardIds={[1, 999, 3]} />);
+
+      expect(screen.getByText('El Mago')).toBeInTheDocument();
+      expect(screen.getByText('La Emperatriz')).toBeInTheDocument();
+      expect(screen.getAllByRole('link')).toHaveLength(2);
+    });
+
+    it('should preserve the order given by cardIds', () => {
+      mockCards(ALL_CARDS);
+
+      render(<RelatedTarotCards cardIds={[10, 1, 3]} />);
+
+      const names = screen.getAllByTestId(/^card-thumbnail-/).map((el) => el.textContent);
+      expect(names).toEqual([
+        expect.stringContaining('La Rueda de la Fortuna'),
+        expect.stringContaining('El Mago'),
+        expect.stringContaining('La Emperatriz'),
+      ]);
+    });
+  });
+});

--- a/frontend/src/components/features/encyclopedia/RelatedTarotCards.test.tsx
+++ b/frontend/src/components/features/encyclopedia/RelatedTarotCards.test.tsx
@@ -54,6 +54,34 @@ describe('RelatedTarotCards', () => {
 
       expect(screen.getByTestId('related-tarot-cards-skeleton')).toBeInTheDocument();
     });
+
+    it('should render one skeleton placeholder per card ID', () => {
+      mockCards(undefined, true);
+
+      render(<RelatedTarotCards cardIds={[1, 3, 10]} />);
+
+      expect(screen.getByTestId('related-tarot-cards-skeleton').children).toHaveLength(3);
+    });
+  });
+
+  describe('Section wrapper', () => {
+    it('should render the section with its heading when cards resolve', () => {
+      mockCards(ALL_CARDS);
+
+      render(<RelatedTarotCards cardIds={[1, 3]} />);
+
+      expect(screen.getByTestId('related-tarot-cards')).toBeInTheDocument();
+      expect(screen.getByText('Cartas de Tarot Relacionadas')).toBeInTheDocument();
+    });
+
+    it('should not render the section heading when no IDs resolve', () => {
+      mockCards(ALL_CARDS);
+
+      render(<RelatedTarotCards cardIds={[999]} />);
+
+      expect(screen.queryByTestId('related-tarot-cards')).not.toBeInTheDocument();
+      expect(screen.queryByText('Cartas de Tarot Relacionadas')).not.toBeInTheDocument();
+    });
   });
 
   describe('Empty / unresolved state', () => {

--- a/frontend/src/components/features/encyclopedia/RelatedTarotCards.tsx
+++ b/frontend/src/components/features/encyclopedia/RelatedTarotCards.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { ReactNode } from 'react';
+
 import { Skeleton } from '@/components/ui/skeleton';
 import { useCards } from '@/hooks/api/useEncyclopedia';
 import { ROUTES } from '@/lib/constants/routes';
@@ -18,18 +20,30 @@ export interface RelatedTarotCardsProps {
 
 const GRID_CLASSES = 'grid grid-cols-3 gap-4 sm:grid-cols-4 md:grid-cols-6';
 
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function RelatedTarotCardsSection({ children }: { children: ReactNode }) {
+  return (
+    <section data-testid="related-tarot-cards" className="space-y-4">
+      <h2 className="text-foreground text-xl font-bold">Cartas de Tarot Relacionadas</h2>
+      {children}
+    </section>
+  );
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 /**
  * RelatedTarotCards Component
  *
- * Resolves an article's `relatedTarotCards` IDs to full card data and renders
- * each as a thumbnail + name linking to its tarot detail page, instead of the
- * raw numeric IDs.
+ * Renders the full "Cartas de Tarot Relacionadas" section: resolves an article's
+ * `relatedTarotCards` IDs to full card data and shows each as a thumbnail + name
+ * linking to its tarot detail page, instead of the raw numeric IDs.
  *
  * Card data is resolved from the full deck (`useCards`, cached for 1h) so no new
- * endpoint is required. Unknown IDs are skipped; when none resolve, nothing is
- * rendered.
+ * endpoint is required. Unknown IDs are skipped; when none resolve, the whole
+ * section (heading included) is hidden — owning the heading here avoids leaving
+ * an orphan title in the parent.
  *
  * @example
  * ```tsx
@@ -41,11 +55,13 @@ export function RelatedTarotCards({ cardIds }: RelatedTarotCardsProps) {
 
   if (isLoading) {
     return (
-      <div data-testid="related-tarot-cards-skeleton" className={GRID_CLASSES}>
-        {cardIds.map((id) => (
-          <Skeleton key={id} className="aspect-[2/3] rounded-md" />
-        ))}
-      </div>
+      <RelatedTarotCardsSection>
+        <div data-testid="related-tarot-cards-skeleton" className={GRID_CLASSES}>
+          {cardIds.map((id) => (
+            <Skeleton key={id} className="aspect-[2/3] rounded-md" />
+          ))}
+        </div>
+      </RelatedTarotCardsSection>
     );
   }
 
@@ -59,10 +75,16 @@ export function RelatedTarotCards({ cardIds }: RelatedTarotCardsProps) {
   }
 
   return (
-    <div className={GRID_CLASSES}>
-      {resolvedCards.map((card) => (
-        <CardThumbnail key={card.id} card={card} href={ROUTES.ENCICLOPEDIA_TAROT_CARD(card.slug)} />
-      ))}
-    </div>
+    <RelatedTarotCardsSection>
+      <div className={GRID_CLASSES}>
+        {resolvedCards.map((card) => (
+          <CardThumbnail
+            key={card.id}
+            card={card}
+            href={ROUTES.ENCICLOPEDIA_TAROT_CARD(card.slug)}
+          />
+        ))}
+      </div>
+    </RelatedTarotCardsSection>
   );
 }

--- a/frontend/src/components/features/encyclopedia/RelatedTarotCards.tsx
+++ b/frontend/src/components/features/encyclopedia/RelatedTarotCards.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { useCards } from '@/hooks/api/useEncyclopedia';
+import { ROUTES } from '@/lib/constants/routes';
+import type { CardSummary } from '@/types/encyclopedia.types';
+
+import { CardThumbnail } from './CardThumbnail';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface RelatedTarotCardsProps {
+  /** IDs of the tarot cards related to the article. */
+  cardIds: number[];
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const GRID_CLASSES = 'grid grid-cols-3 gap-4 sm:grid-cols-4 md:grid-cols-6';
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * RelatedTarotCards Component
+ *
+ * Resolves an article's `relatedTarotCards` IDs to full card data and renders
+ * each as a thumbnail + name linking to its tarot detail page, instead of the
+ * raw numeric IDs.
+ *
+ * Card data is resolved from the full deck (`useCards`, cached for 1h) so no new
+ * endpoint is required. Unknown IDs are skipped; when none resolve, nothing is
+ * rendered.
+ *
+ * @example
+ * ```tsx
+ * <RelatedTarotCards cardIds={[1, 3, 10]} />
+ * ```
+ */
+export function RelatedTarotCards({ cardIds }: RelatedTarotCardsProps) {
+  const { data: cards, isLoading } = useCards();
+
+  if (isLoading) {
+    return (
+      <div data-testid="related-tarot-cards-skeleton" className={GRID_CLASSES}>
+        {cardIds.map((id) => (
+          <Skeleton key={id} className="aspect-[2/3] rounded-md" />
+        ))}
+      </div>
+    );
+  }
+
+  const cardById = new Map<number, CardSummary>((cards ?? []).map((card) => [card.id, card]));
+  const resolvedCards = cardIds
+    .map((id) => cardById.get(id))
+    .filter((card): card is CardSummary => card !== undefined);
+
+  if (resolvedCards.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={GRID_CLASSES}>
+      {resolvedCards.map((card) => (
+        <CardThumbnail key={card.id} card={card} href={ROUTES.ENCICLOPEDIA_TAROT_CARD(card.slug)} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/features/encyclopedia/index.ts
+++ b/frontend/src/components/features/encyclopedia/index.ts
@@ -57,6 +57,7 @@ export { CardKeywords } from './CardKeywords';
 export { CardMetadata } from './CardMetadata';
 export { CardNavigation } from './CardNavigation';
 export { RelatedCards } from './RelatedCards';
+export { RelatedTarotCards } from './RelatedTarotCards';
 
 // Type exports — list components
 export type { CardThumbnailProps } from './CardThumbnail';
@@ -75,6 +76,7 @@ export type { CardKeywordsProps } from './CardKeywords';
 export type { CardMetadataProps } from './CardMetadata';
 export type { CardNavigationProps } from './CardNavigation';
 export type { RelatedCardsProps } from './RelatedCards';
+export type { RelatedTarotCardsProps } from './RelatedTarotCards';
 
 // Widget components
 export { EncyclopediaInfoWidget } from './EncyclopediaInfoWidget';


### PR DESCRIPTION
## Resumen

Cierra **T-ENC-002** del backlog `BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md` (cubre el hallazgo **ENC-002**).

La sección "Cartas de Tarot Relacionadas" mostraba **chips con el ID numérico crudo** (`#1 #2 … #10`), confuso y con apariencia de prototipo. Ahora muestra **miniatura + nombre** de cada carta, enlazando a su detalle.

## Cambios

- **Nuevo `RelatedTarotCards`**: resuelve cada ID de `relatedTarotCards` a su `CardSummary` usando el mazo completo (`useCards`, cacheado 1h → **sin endpoint nuevo**), construyendo un mapa `id → carta`. Omite IDs desconocidos y no renderiza nada si ninguno resuelve.
- **`CardThumbnail`**: nuevo prop opcional `href` (default `/enciclopedia/{slug}`, **retrocompatible**) para enlazar a la ruta canónica de tarot `ROUTES.ENCICLOPEDIA_TAROT_CARD(slug)` sin afectar otros usos.
- **`ArticleDetailView`**: conserva el gate de la sección (oculta si `relatedTarotCards` es `null`/vacío) y delega la grilla al nuevo componente.
- Exportaciones añadidas en `index.ts`.

## Criterios de aceptación

- [x] La sección muestra cartas reales (miniatura + nombre), no IDs crudos.
- [x] Cada carta enlaza a `/enciclopedia/tarot/[slug]` sin regresiones.
- [x] Se conserva ocultar la sección cuando no hay cartas relacionadas.
- [x] Ciclo de calidad frontend completo pasa.

## Validaciones

- [x] TDD (tests escritos primero)
- [x] `npm run lint:fix` (0 errores)
- [x] `npm run type-check` (sin errores)
- [x] `npm run test:run` → **4825 tests passed**, 7 skipped (395 archivos)
- [x] Coverage nuevos archivos: `RelatedTarotCards.tsx` **100%**; `CardThumbnail.tsx` 100% stmts/funcs/lines
- [x] `npm run build` exitoso
- [x] `node scripts/validate-architecture.js` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)