### PR TITLE
feat(encyclopedia): TOC "En esta guía" con scroll-spy (T-ENC-004)

### DIFF
--- a/docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md
+++ b/docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md
@@ -385,15 +385,23 @@ Dar a los artículos una plantilla editorial: hero con imagen, recursos visuales
 **Estimación:** 2 puntos
 **Dependencias:** T-ENC-001
 **Cubre Hallazgo:** ENC-003 (navegación de lectura)
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ Completada (rama `feature/T-ENC-004-toc-scroll-spy`)
 
 #### ✅ Tareas específicas
 
-- [ ] Generar índice (TOC) a partir de los `H2` del artículo, con anclas.
-- [ ] Resaltar la sección activa al hacer scroll (scroll-spy).
-- [ ] Comportamiento responsive (TOC lateral en desktop, colapsable en mobile).
-- [ ] Tests (generación de anclas, marcado de sección activa).
-- [ ] Coverage ≥ 80%.
+- [x] Generar índice (TOC) a partir de los `H2` del artículo, con anclas.
+- [x] Resaltar la sección activa al hacer scroll (scroll-spy).
+- [x] Comportamiento responsive (TOC lateral en desktop, colapsable en mobile).
+- [x] Tests (generación de anclas, marcado de sección activa).
+- [x] Coverage ≥ 80%.
+
+#### 📝 Notas de implementación
+
+- Nuevo util `extractArticleHeadings` + `getSectionAnchorId` en `lib/utils/text.ts`: deriva el TOC de los `## N.` (ignora `#`/`###` y `##` sin número), limpia markdown inline del label (negritas, cursiva, enlaces → texto) y construye el `id` de ancla (`seccion-N`). `getSectionAnchorId` es la **única fuente de verdad** del id, compartida entre el TOC y el heading renderizado (anclas y destinos siempre concuerdan).
+- `MarkdownArticle` (modo editorial) añade `id="seccion-N"` + `scroll-mt-24` a los H2 numerados — cero regresión para signos/planetas (modo no editorial sin id).
+- Nuevo `ArticleToc` (client): scroll-spy con `IntersectionObserver` (`rootMargin -80px 0px -70% 0px`, elige el heading más alto entre los visibles y conserva el último activo si ninguno intersecta). Responsive: `<details>` colapsable en mobile + barra lateral `lg:sticky` en desktop, ambas con `aria-current="location"` en la sección activa.
+- `ArticleDetailView` extrae el cuerpo a una variable compartida (DRY) y monta el layout de dos columnas (TOC `lg:order-2` + columna de lectura `max-w-[68ch]`) solo para guías con secciones numeradas.
+- Coverage 100% líneas/funciones en los archivos nuevos/tocados (≥ 95% ramas); ciclo de calidad frontend completo en verde.
 
 #### 🎯 Criterios de Aceptación
 
@@ -404,6 +412,9 @@ Dar a los artículos una plantilla editorial: hero con imagen, recursos visuales
 #### 📁 Archivos involucrados
 
 - `frontend/src/components/features/encyclopedia/ArticleToc.tsx` (nuevo)
+- `frontend/src/lib/utils/text.ts` (util `extractArticleHeadings` / `getSectionAnchorId`)
+- `frontend/src/components/features/encyclopedia/MarkdownArticle.tsx` (ids de ancla)
+- `frontend/src/components/features/encyclopedia/ArticleDetailView.tsx` (integración)
 - tests correspondientes
 
 ---

--- a/frontend/src/components/features/encyclopedia/ArticleDetailView.test.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 
 import { ArticleDetailView } from './ArticleDetailView';
 import { ArticleCategory } from '@/types/encyclopedia-article.types';
@@ -396,6 +396,58 @@ describe('ArticleDetailView', () => {
       );
 
       expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    });
+  });
+
+  describe('Table of contents (guides)', () => {
+    const guideContent =
+      '# Guía del Tarot\n\nIntro.\n\n## 1. ¿Qué es el Tarot?\n\nTexto.\n\n## 2. Los Arcanos\n\nMás texto.';
+
+    it('should render the TOC for guide articles with numbered sections', () => {
+      render(
+        <ArticleDetailView
+          article={createTestArticle({
+            slug: 'guia-tarot',
+            category: ArticleCategory.GUIDE_TAROT,
+            nameEs: 'Guía del Tarot',
+            content: guideContent,
+          })}
+        />
+      );
+
+      const toc = screen.getByTestId('article-toc');
+      expect(toc).toBeInTheDocument();
+      expect(within(toc).getAllByRole('link', { name: /¿Qué es el Tarot\?/ })[0]).toHaveAttribute(
+        'href',
+        '#seccion-1'
+      );
+    });
+
+    it('should not render the TOC for non-guide articles', () => {
+      render(
+        <ArticleDetailView
+          article={createTestArticle({
+            category: ArticleCategory.ZODIAC_SIGN,
+            content: '## 1. Carácter\n\nTexto.',
+          })}
+        />
+      );
+
+      expect(screen.queryByTestId('article-toc')).not.toBeInTheDocument();
+    });
+
+    it('should not render the TOC for a guide without numbered sections', () => {
+      render(
+        <ArticleDetailView
+          article={createTestArticle({
+            category: ArticleCategory.GUIDE_TAROT,
+            nameEs: 'Guía del Tarot',
+            content: '# Guía del Tarot\n\nSolo un párrafo introductorio sin secciones.',
+          })}
+        />
+      );
+
+      expect(screen.queryByTestId('article-toc')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/features/encyclopedia/ArticleDetailView.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import Link from 'next/link';
 
 import { ArticleHero } from './ArticleHero';
@@ -133,7 +134,13 @@ export function ArticleDetailView({ article, className }: ArticleDetailViewProps
   const isGuide = isGuideCategory(article.category);
   const editorial = getArticleEditorial(article.slug);
   const readingMeta = getArticleReadingMeta(article.content);
-  const headings = isGuide ? extractArticleHeadings(article.content) : [];
+  // Memoized so the array identity is stable across re-renders: ArticleToc keys
+  // its IntersectionObserver effect on `headings`, so a fresh array each render
+  // would tear down and rebuild the observer needlessly.
+  const headings = useMemo(
+    () => (isGuide ? extractArticleHeadings(article.content) : []),
+    [isGuide, article.content]
+  );
   const hasToc = headings.length > 0;
   const hasRelatedTarotCards =
     article.relatedTarotCards !== null && article.relatedTarotCards.length > 0;

--- a/frontend/src/components/features/encyclopedia/ArticleDetailView.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailView.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 
 import { ArticleHero } from './ArticleHero';
+import { ArticleToc } from './ArticleToc';
 import { MarkdownArticle } from './MarkdownArticle';
 import { RelatedTarotCards } from './RelatedTarotCards';
 import { ROUTES } from '@/lib/constants/routes';
@@ -10,7 +11,11 @@ import { getArticleEditorial } from '@/lib/data/encyclopedia-editorial.data';
 import { ArticleCategory, ARTICLE_CATEGORY_LABELS } from '@/types/encyclopedia-article.types';
 import type { ArticleDetail, ArticleSummary } from '@/types/encyclopedia-article.types';
 import { cn } from '@/lib/utils';
-import { getArticleReadingMeta, stripLeadingMarkdownHeading } from '@/lib/utils/text';
+import {
+  extractArticleHeadings,
+  getArticleReadingMeta,
+  stripLeadingMarkdownHeading,
+} from '@/lib/utils/text';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -128,9 +133,57 @@ export function ArticleDetailView({ article, className }: ArticleDetailViewProps
   const isGuide = isGuideCategory(article.category);
   const editorial = getArticleEditorial(article.slug);
   const readingMeta = getArticleReadingMeta(article.content);
+  const headings = isGuide ? extractArticleHeadings(article.content) : [];
+  const hasToc = headings.length > 0;
   const hasRelatedTarotCards =
     article.relatedTarotCards !== null && article.relatedTarotCards.length > 0;
   const hasRelatedArticles = article.relatedArticles.length > 0;
+
+  // Reading column body — shared between the guide layout (centered column with a
+  // lateral TOC) and the simple layout (signs, planets, …) so it stays DRY.
+  const articleBody = (
+    <>
+      {/* Contenido Markdown — se elimina el título `#` inicial para no duplicar
+          el <h1> de la página (ya renderizado en el hero/cabecera). En guías se
+          activa el modo editorial (drop-cap, badges numerados, ✦, imágenes y
+          callouts por sección modelados como datos). */}
+      <MarkdownArticle
+        content={stripLeadingMarkdownHeading(article.content)}
+        editorial={isGuide}
+        sections={editorial?.sections}
+        className={cn(isGuide && 'max-w-none')}
+      />
+
+      {/* Cartas de tarot relacionadas — RelatedTarotCards renderiza la sección
+          completa (título incluido) o nada si ningún ID resuelve. */}
+      {hasRelatedTarotCards && <RelatedTarotCards cardIds={article.relatedTarotCards!} />}
+
+      {/* Artículos relacionados */}
+      {hasRelatedArticles && (
+        <section data-testid="related-articles" className="space-y-4">
+          <h2 className="text-foreground text-xl font-bold">Artículos Relacionados</h2>
+          <div className="flex flex-col gap-3">
+            {article.relatedArticles.map((relatedArticle) => (
+              <RelatedArticleItem key={relatedArticle.id} article={relatedArticle} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* CTA al módulo correspondiente (guías con herramienta asociada) */}
+      {cta && (
+        <div className="border-t pt-6">
+          <Link
+            data-testid="article-cta"
+            href={cta.href}
+            className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center rounded-lg px-6 py-3 font-semibold transition-colors"
+          >
+            {cta.label}
+          </Link>
+        </div>
+      )}
+    </>
+  );
 
   return (
     <div data-testid="article-detail-view" className={cn('space-y-8', className)}>
@@ -182,49 +235,24 @@ export function ArticleDetailView({ article, className }: ArticleDetailViewProps
         </>
       )}
 
-      {/* Columna de lectura. En guías se centra como columna editorial (el hero
-          va a ancho completo arriba); el resto de artículos conserva su flujo. */}
-      <div className={cn('space-y-8', isGuide && 'mx-auto w-full max-w-[68ch]')}>
-        {/* Contenido Markdown — se elimina el título `#` inicial para no duplicar
-            el <h1> de la página (ya renderizado en el hero/cabecera). En guías se
-            activa el modo editorial (drop-cap, badges numerados, ✦, imágenes y
-            callouts por sección modelados como datos). */}
-        <MarkdownArticle
-          content={stripLeadingMarkdownHeading(article.content)}
-          editorial={isGuide}
-          sections={editorial?.sections}
-          className={cn(isGuide && 'max-w-none')}
-        />
-
-        {/* Cartas de tarot relacionadas — RelatedTarotCards renderiza la sección
-            completa (título incluido) o nada si ningún ID resuelve. */}
-        {hasRelatedTarotCards && <RelatedTarotCards cardIds={article.relatedTarotCards!} />}
-
-        {/* Artículos relacionados */}
-        {hasRelatedArticles && (
-          <section data-testid="related-articles" className="space-y-4">
-            <h2 className="text-foreground text-xl font-bold">Artículos Relacionados</h2>
-            <div className="flex flex-col gap-3">
-              {article.relatedArticles.map((relatedArticle) => (
-                <RelatedArticleItem key={relatedArticle.id} article={relatedArticle} />
-              ))}
-            </div>
-          </section>
-        )}
-
-        {/* CTA al módulo correspondiente (guías con herramienta asociada) */}
-        {cta && (
-          <div className="border-t pt-6">
-            <Link
-              data-testid="article-cta"
-              href={cta.href}
-              className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center rounded-lg px-6 py-3 font-semibold transition-colors"
-            >
-              {cta.label}
-            </Link>
+      {/* Columna de lectura. En guías con secciones se acompaña de un índice (TOC)
+          lateral en desktop / colapsable en mobile; el hero va a ancho completo
+          arriba. El resto de artículos conserva su flujo simple. */}
+      {isGuide ? (
+        <div className="lg:flex lg:items-start lg:justify-center lg:gap-10">
+          {hasToc && (
+            <ArticleToc
+              headings={headings}
+              className="mb-8 lg:order-2 lg:mb-0 lg:w-60 lg:shrink-0"
+            />
+          )}
+          <div className="mx-auto w-full max-w-[68ch] space-y-8 lg:order-1 lg:mx-0">
+            {articleBody}
           </div>
-        )}
-      </div>
+        </div>
+      ) : (
+        <div className="space-y-8">{articleBody}</div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/features/encyclopedia/ArticleToc.test.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleToc.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ArticleToc } from './ArticleToc';
+import type { ArticleHeading } from '@/lib/utils/text';
+
+// ─── Controllable IntersectionObserver ──────────────────────────────────────────
+// The global setup mocks IntersectionObserver as a no-op. Here we replace it with
+// a controllable stub that records each instance + its callback, so we can drive
+// the scroll-spy behaviour deterministically.
+
+interface ObserverInstance {
+  callback: IntersectionObserverCallback;
+  elements: Element[];
+}
+
+let observers: ObserverInstance[] = [];
+
+class ControllableIntersectionObserver {
+  callback: IntersectionObserverCallback;
+  elements: Element[] = [];
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    observers.push(this);
+  }
+
+  observe(el: Element) {
+    this.elements.push(el);
+  }
+
+  unobserve(el: Element) {
+    this.elements = this.elements.filter((e) => e !== el);
+  }
+
+  disconnect() {
+    this.elements = [];
+  }
+}
+
+/** Fires the latest observer's callback with the given visibility entries. */
+function fireIntersection(entries: Array<{ id: string; isIntersecting: boolean; top: number }>) {
+  const observer = observers[observers.length - 1];
+  const observerEntries = entries.map(({ id, isIntersecting, top }) => ({
+    target: document.getElementById(id) as Element,
+    isIntersecting,
+    boundingClientRect: { top } as DOMRectReadOnly,
+  })) as unknown as IntersectionObserverEntry[];
+  act(() => {
+    observer.callback(observerEntries, observer as unknown as IntersectionObserver);
+  });
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────────
+
+const HEADINGS: ArticleHeading[] = [
+  { id: 'seccion-1', number: 1, label: '¿Qué es el Tarot?' },
+  { id: 'seccion-2', number: 2, label: 'Los Arcanos Mayores' },
+  { id: 'seccion-3', number: 3, label: 'Las Tiradas' },
+];
+
+/** Renders the TOC alongside matching heading anchors so the observer can attach. */
+function renderWithAnchors(headings: ArticleHeading[] = HEADINGS) {
+  return render(
+    <>
+      {headings.map((h) => (
+        <h2 key={h.id} id={h.id}>
+          {h.label}
+        </h2>
+      ))}
+      <ArticleToc headings={headings} />
+    </>
+  );
+}
+
+/** The desktop variant of the TOC (always-visible sidebar list). */
+function desktopToc() {
+  return within(screen.getByTestId('article-toc-desktop'));
+}
+
+describe('ArticleToc', () => {
+  const originalObserver = window.IntersectionObserver;
+
+  beforeEach(() => {
+    observers = [];
+    // The global setup defines IntersectionObserver as `writable` (no-op), so we
+    // assign our controllable stub directly and restore it afterwards.
+    window.IntersectionObserver =
+      ControllableIntersectionObserver as unknown as typeof IntersectionObserver;
+  });
+
+  afterEach(() => {
+    window.IntersectionObserver = originalObserver;
+  });
+
+  describe('Rendering', () => {
+    it('should render the TOC nav with an accessible label', () => {
+      renderWithAnchors();
+
+      const toc = screen.getByTestId('article-toc');
+      expect(toc).toBeInTheDocument();
+      expect(toc.tagName).toBe('NAV');
+      expect(toc).toHaveAttribute('aria-label', 'En esta guía');
+    });
+
+    it('should render one link per heading pointing to its anchor', () => {
+      renderWithAnchors();
+
+      const links = desktopToc().getAllByRole('link');
+      expect(links).toHaveLength(3);
+      expect(links[0]).toHaveAttribute('href', '#seccion-1');
+      expect(links[1]).toHaveAttribute('href', '#seccion-2');
+      expect(links[2]).toHaveAttribute('href', '#seccion-3');
+    });
+
+    it('should render each heading label', () => {
+      renderWithAnchors();
+
+      expect(desktopToc().getByRole('link', { name: /¿Qué es el Tarot\?/ })).toBeInTheDocument();
+      expect(desktopToc().getByRole('link', { name: /Los Arcanos Mayores/ })).toBeInTheDocument();
+      expect(desktopToc().getByRole('link', { name: /Las Tiradas/ })).toBeInTheDocument();
+    });
+
+    it('should render a collapsible variant for mobile', () => {
+      renderWithAnchors();
+
+      const mobile = screen.getByTestId('article-toc-mobile');
+      expect(mobile.tagName).toBe('DETAILS');
+      expect(within(mobile).getByText('En esta guía')).toBeInTheDocument();
+    });
+
+    it('should render nothing when there are no headings', () => {
+      const { container } = render(<ArticleToc headings={[]} />);
+
+      expect(container).toBeEmptyDOMElement();
+      expect(screen.queryByTestId('article-toc')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Active section (scroll-spy)', () => {
+    it('should mark the first section active initially', () => {
+      renderWithAnchors();
+
+      expect(desktopToc().getByRole('link', { name: /¿Qué es el Tarot\?/ })).toHaveAttribute(
+        'aria-current',
+        'location'
+      );
+    });
+
+    it('should highlight the section that intersects the viewport', () => {
+      renderWithAnchors();
+
+      fireIntersection([{ id: 'seccion-2', isIntersecting: true, top: 40 }]);
+
+      expect(desktopToc().getByRole('link', { name: /Los Arcanos Mayores/ })).toHaveAttribute(
+        'aria-current',
+        'location'
+      );
+      expect(desktopToc().getByRole('link', { name: /¿Qué es el Tarot\?/ })).not.toHaveAttribute(
+        'aria-current'
+      );
+    });
+
+    it('should pick the topmost section when several intersect at once', () => {
+      renderWithAnchors();
+
+      fireIntersection([
+        { id: 'seccion-3', isIntersecting: true, top: 220 },
+        { id: 'seccion-2', isIntersecting: true, top: 60 },
+      ]);
+
+      expect(desktopToc().getByRole('link', { name: /Los Arcanos Mayores/ })).toHaveAttribute(
+        'aria-current',
+        'location'
+      );
+    });
+
+    it('should keep the last active section when none intersect', () => {
+      renderWithAnchors();
+
+      fireIntersection([{ id: 'seccion-2', isIntersecting: true, top: 40 }]);
+      fireIntersection([{ id: 'seccion-2', isIntersecting: false, top: -10 }]);
+
+      expect(desktopToc().getByRole('link', { name: /Los Arcanos Mayores/ })).toHaveAttribute(
+        'aria-current',
+        'location'
+      );
+    });
+
+    it('should mark a section active when its link is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithAnchors();
+
+      await user.click(desktopToc().getByRole('link', { name: /Las Tiradas/ }));
+
+      expect(desktopToc().getByRole('link', { name: /Las Tiradas/ })).toHaveAttribute(
+        'aria-current',
+        'location'
+      );
+    });
+  });
+});

--- a/frontend/src/components/features/encyclopedia/ArticleToc.test.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleToc.test.tsx
@@ -188,6 +188,38 @@ describe('ArticleToc', () => {
       );
     });
 
+    it('should reset the active section to the first when the headings change', () => {
+      const { rerender } = renderWithAnchors();
+
+      // Scroll-spy moves the active section away from the first…
+      fireIntersection([{ id: 'seccion-2', isIntersecting: true, top: 40 }]);
+      expect(desktopToc().getByRole('link', { name: /Los Arcanos Mayores/ })).toHaveAttribute(
+        'aria-current',
+        'location'
+      );
+
+      // …then navigating to another guide (same component instance, new headings)
+      // resets the highlight to the new article's first section.
+      const otherHeadings: ArticleHeading[] = [
+        { id: 'seccion-1', number: 1, label: 'Introducción a los Rituales' },
+        { id: 'seccion-2', number: 2, label: 'Herramientas' },
+      ];
+      rerender(
+        <>
+          {otherHeadings.map((h) => (
+            <h2 key={h.id} id={h.id}>
+              {h.label}
+            </h2>
+          ))}
+          <ArticleToc headings={otherHeadings} />
+        </>
+      );
+
+      expect(
+        desktopToc().getByRole('link', { name: /Introducción a los Rituales/ })
+      ).toHaveAttribute('aria-current', 'location');
+    });
+
     it('should mark a section active when its link is clicked', async () => {
       const user = userEvent.setup();
       renderWithAnchors();

--- a/frontend/src/components/features/encyclopedia/ArticleToc.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleToc.tsx
@@ -98,6 +98,18 @@ function TocLinkList({ headings, activeId, onSelect }: TocLinkListProps) {
 export function ArticleToc({ headings, className }: ArticleTocProps) {
   const [activeId, setActiveId] = useState<string | null>(headings[0]?.id ?? null);
 
+  // Reset the active section to the first when the set of sections changes. The
+  // App Router reuses this component instance when navigating between guides, so
+  // without this the highlight would keep the previous article's section until
+  // the observer's first callback. Adjusting state during render (the React
+  // idiom) avoids an effect-driven extra commit and a stale frame.
+  const headingsKey = headings.map((heading) => heading.id).join('|');
+  const [prevHeadingsKey, setPrevHeadingsKey] = useState(headingsKey);
+  if (prevHeadingsKey !== headingsKey) {
+    setPrevHeadingsKey(headingsKey);
+    setActiveId(headings[0]?.id ?? null);
+  }
+
   useEffect(() => {
     if (headings.length === 0) {
       return;

--- a/frontend/src/components/features/encyclopedia/ArticleToc.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleToc.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+// 1. React & Next.js
+import { useEffect, useState } from 'react';
+
+// 2. Icons
+import { List } from 'lucide-react';
+
+// 6. Utils & types
+import { cn } from '@/lib/utils';
+import type { ArticleHeading } from '@/lib/utils/text';
+
+// ─── Constants ──────────────────────────────────────────────────────────────────
+
+/**
+ * Scroll-spy activation band: a heading becomes "active" once it crosses into
+ * the top ~30% of the viewport (offset 80px for sticky chrome), so the TOC
+ * highlights the section the reader is actually on, not the one barely entering.
+ */
+const SCROLL_SPY_ROOT_MARGIN = '-80px 0px -70% 0px';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ArticleTocProps {
+  /** Navigable headings derived from the article (see `extractArticleHeadings`). */
+  headings: ArticleHeading[];
+  /** Additional CSS classes for the wrapper `<nav>`. */
+  className?: string;
+}
+
+interface TocLinkListProps {
+  headings: ArticleHeading[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────────────────
+
+/**
+ * The ordered list of anchor links. Shared by the mobile (collapsible) and the
+ * desktop (sticky sidebar) variants so they stay visually and behaviourally in
+ * sync. The active link carries `aria-current="location"` for assistive tech.
+ */
+function TocLinkList({ headings, activeId, onSelect }: TocLinkListProps) {
+  return (
+    <ol className="space-y-1">
+      {headings.map((heading) => {
+        const isActive = heading.id === activeId;
+        return (
+          <li key={heading.id}>
+            <a
+              href={`#${heading.id}`}
+              aria-current={isActive ? 'location' : undefined}
+              onClick={() => onSelect(heading.id)}
+              className={cn(
+                'flex items-baseline gap-2 rounded-md px-3 py-1.5 text-sm transition-colors',
+                isActive
+                  ? 'bg-secondary/10 text-foreground font-semibold'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/60'
+              )}
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  'shrink-0 tabular-nums',
+                  isActive ? 'text-secondary' : 'text-muted-foreground/60'
+                )}
+              >
+                {heading.number}.
+              </span>
+              <span>{heading.label}</span>
+            </a>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+/**
+ * ArticleToc Component
+ *
+ * "En esta guía" table of contents with scroll-spy. Builds a navigable index
+ * from an article's numbered `## N.` sections (see `extractArticleHeadings`) and
+ * highlights the section currently in view via an `IntersectionObserver`.
+ *
+ * Responsive: a collapsible `<details>` on mobile (rendered above the content)
+ * and a sticky sidebar list on desktop (`lg:`). Renders nothing when there are
+ * no headings.
+ *
+ * @example
+ * ```tsx
+ * <ArticleToc headings={extractArticleHeadings(article.content)} />
+ * ```
+ */
+export function ArticleToc({ headings, className }: ArticleTocProps) {
+  const [activeId, setActiveId] = useState<string | null>(headings[0]?.id ?? null);
+
+  useEffect(() => {
+    if (headings.length === 0) {
+      return;
+    }
+
+    const elements = headings
+      .map((heading) => document.getElementById(heading.id))
+      .filter((element): element is HTMLElement => element !== null);
+
+    if (elements.length === 0) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.filter((entry) => entry.isIntersecting);
+        if (visible.length === 0) {
+          // Keep the last active section so the TOC never goes blank between
+          // sections (e.g. while scrolling through a long figure).
+          return;
+        }
+        const topmost = visible.reduce((closest, entry) =>
+          entry.boundingClientRect.top < closest.boundingClientRect.top ? entry : closest
+        );
+        setActiveId(topmost.target.id);
+      },
+      { rootMargin: SCROLL_SPY_ROOT_MARGIN, threshold: 0 }
+    );
+
+    elements.forEach((element) => observer.observe(element));
+    return () => observer.disconnect();
+  }, [headings]);
+
+  if (headings.length === 0) {
+    return null;
+  }
+
+  const title = (
+    <span className="text-foreground flex items-center gap-2 font-serif text-base font-semibold">
+      <List className="text-secondary h-4 w-4" aria-hidden="true" />
+      En esta guía
+    </span>
+  );
+
+  return (
+    <nav
+      data-testid="article-toc"
+      aria-label="En esta guía"
+      className={cn('lg:sticky lg:top-24 lg:self-start', className)}
+    >
+      {/* Mobile: índice colapsable encima del contenido */}
+      <details data-testid="article-toc-mobile" className="bg-card rounded-xl border p-4 lg:hidden">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-2 [&::-webkit-details-marker]:hidden">
+          {title}
+        </summary>
+        <div className="mt-3">
+          <TocLinkList headings={headings} activeId={activeId} onSelect={setActiveId} />
+        </div>
+      </details>
+
+      {/* Desktop: barra lateral fija */}
+      <div data-testid="article-toc-desktop" className="hidden lg:block">
+        <div className="mb-3">{title}</div>
+        <TocLinkList headings={headings} activeId={activeId} onSelect={setActiveId} />
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/components/features/encyclopedia/MarkdownArticle.test.tsx
+++ b/frontend/src/components/features/encyclopedia/MarkdownArticle.test.tsx
@@ -214,6 +214,21 @@ describe('MarkdownArticle', () => {
       expect(screen.getByText('78')).toBeInTheDocument();
     });
 
+    it('should give numbered headings a stable anchor id for the TOC', () => {
+      render(<MarkdownArticle content="## 2. Los Arcanos" editorial />);
+
+      const heading = screen.getByRole('heading', { level: 2, name: 'Los Arcanos' });
+      expect(heading).toHaveAttribute('id', 'seccion-2');
+      // Offset so the anchored heading isn't hidden under sticky chrome.
+      expect(heading.className).toMatch(/scroll-mt/);
+    });
+
+    it('should not add an anchor id to headings without a leading number', () => {
+      render(<MarkdownArticle content="## Sección sin número" editorial />);
+
+      expect(screen.getByRole('heading', { level: 2 })).not.toHaveAttribute('id');
+    });
+
     it('should render the ✦ decorative separator for thematic breaks', () => {
       render(<MarkdownArticle content={'Antes\n\n---\n\nDespués'} editorial />);
 

--- a/frontend/src/components/features/encyclopedia/MarkdownArticle.tsx
+++ b/frontend/src/components/features/encyclopedia/MarkdownArticle.tsx
@@ -13,6 +13,7 @@ import { ArticleCallout } from './ArticleCallout';
 
 // 6. Utils & types
 import { cn } from '@/lib/utils';
+import { getSectionAnchorId } from '@/lib/utils/text';
 import type { EditorialSection } from '@/lib/data/encyclopedia-editorial.data';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -184,7 +185,10 @@ function buildEditorialComponents(sections?: Record<number, EditorialSection>): 
 
       return (
         <>
-          <h2 className="text-foreground border-secondary/30 mt-12 mb-5 flex items-center gap-3 border-b pb-2 font-serif text-3xl leading-snug font-bold first:mt-0">
+          <h2
+            id={number !== null ? getSectionAnchorId(number) : undefined}
+            className="text-foreground border-secondary/30 mt-12 mb-5 flex scroll-mt-24 items-center gap-3 border-b pb-2 font-serif text-3xl leading-snug font-bold first:mt-0"
+          >
             {number !== null && (
               <span
                 data-testid="section-number"

--- a/frontend/src/components/features/encyclopedia/index.ts
+++ b/frontend/src/components/features/encyclopedia/index.ts
@@ -109,3 +109,5 @@ export { ArticleCallout } from './ArticleCallout';
 export type { ArticleCalloutProps } from './ArticleCallout';
 export { MarkdownArticle } from './MarkdownArticle';
 export type { MarkdownArticleProps } from './MarkdownArticle';
+export { ArticleToc } from './ArticleToc';
+export type { ArticleTocProps } from './ArticleToc';

--- a/frontend/src/lib/utils/text.test.ts
+++ b/frontend/src/lib/utils/text.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { getArticleReadingMeta, getInitials, stripLeadingMarkdownHeading } from './text';
+import {
+  extractArticleHeadings,
+  getArticleReadingMeta,
+  getInitials,
+  getSectionAnchorId,
+  stripLeadingMarkdownHeading,
+} from './text';
 
 describe('getInitials', () => {
   it('should return two-letter initials from two-word name', () => {
@@ -100,5 +106,69 @@ describe('getArticleReadingMeta', () => {
 
   it('should return zeroed meta for empty content', () => {
     expect(getArticleReadingMeta('')).toEqual({ readingTimeMinutes: 0, sectionCount: 0 });
+  });
+});
+
+describe('getSectionAnchorId', () => {
+  it('should build a stable anchor id from a section number', () => {
+    expect(getSectionAnchorId(1)).toBe('seccion-1');
+    expect(getSectionAnchorId(12)).toBe('seccion-12');
+  });
+});
+
+describe('extractArticleHeadings', () => {
+  it('should extract numbered second-level headings as TOC entries', () => {
+    const content =
+      '# Guía del Tarot\n\nIntro.\n\n## 1. ¿Qué es el Tarot?\n\nTexto.\n\n## 2. Los Arcanos\n\nMás texto.';
+
+    expect(extractArticleHeadings(content)).toEqual([
+      { id: 'seccion-1', number: 1, label: '¿Qué es el Tarot?' },
+      { id: 'seccion-2', number: 2, label: 'Los Arcanos' },
+    ]);
+  });
+
+  it('should ignore the leading top-level heading (#)', () => {
+    const content = '# Guía del Tarot\n\n## 1. Primera\n\nTexto.';
+
+    expect(extractArticleHeadings(content)).toEqual([
+      { id: 'seccion-1', number: 1, label: 'Primera' },
+    ]);
+  });
+
+  it('should ignore third-level headings (###)', () => {
+    const content = '## 1. Sección\n\n### 1.1 Subsección\n\nTexto.';
+
+    expect(extractArticleHeadings(content)).toEqual([
+      { id: 'seccion-1', number: 1, label: 'Sección' },
+    ]);
+  });
+
+  it('should ignore second-level headings without a leading number', () => {
+    const content = '## Sin número\n\nTexto.\n\n## 1. Con número\n\nMás texto.';
+
+    expect(extractArticleHeadings(content)).toEqual([
+      { id: 'seccion-1', number: 1, label: 'Con número' },
+    ]);
+  });
+
+  it('should strip inline markdown from the label (plain-text TOC)', () => {
+    const content = '## 2. Los **78** Arcanos y el _camino_\n\nTexto.';
+
+    expect(extractArticleHeadings(content)).toEqual([
+      { id: 'seccion-2', number: 2, label: 'Los 78 Arcanos y el camino' },
+    ]);
+  });
+
+  it('should convert inline links to their visible text in the label', () => {
+    const content = '## 3. Ver la [Cruz Celta](/tiradas) en detalle\n\nTexto.';
+
+    expect(extractArticleHeadings(content)).toEqual([
+      { id: 'seccion-3', number: 3, label: 'Ver la Cruz Celta en detalle' },
+    ]);
+  });
+
+  it('should return an empty array for content without numbered sections', () => {
+    expect(extractArticleHeadings('# Solo título\n\nUn párrafo.')).toEqual([]);
+    expect(extractArticleHeadings('')).toEqual([]);
   });
 });

--- a/frontend/src/lib/utils/text.ts
+++ b/frontend/src/lib/utils/text.ts
@@ -79,3 +79,65 @@ export function getArticleReadingMeta(content: string): ArticleReadingMeta {
 
   return { readingTimeMinutes, sectionCount };
 }
+
+/** A navigable table-of-contents entry derived from an article's `## N.` heading. */
+export interface ArticleHeading {
+  /** Anchor id matching the rendered heading's `id` (e.g. `seccion-1`). */
+  id: string;
+  /** Section number from the `## N. …` heading. */
+  number: number;
+  /** Plain-text label (inline markdown stripped) for display in the TOC. */
+  label: string;
+}
+
+/**
+ * Builds the anchor id for a section number. Single source of truth shared by
+ * the TOC ({@link extractArticleHeadings}) and the rendered heading
+ * (`MarkdownArticle`), so links and targets always agree.
+ *
+ * @example getSectionAnchorId(2) // 'seccion-2'
+ */
+export function getSectionAnchorId(sectionNumber: number): string {
+  return `seccion-${sectionNumber}`;
+}
+
+/** Matches numbered second-level headings (`## N. Título`), ignoring `#`/`###`. */
+const SECTION_HEADING_RE = /^##(?!#)[ \t]+(\d+)\.[ \t]+(.+?)[ \t]*$/gm;
+
+/**
+ * Strips inline markdown (emphasis, code, links) from a heading so the TOC shows
+ * clean plain text. Links collapse to their visible text (`[texto](url)` → `texto`).
+ */
+function stripInlineMarkdown(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links → visible text
+    .replace(/[*_`]/g, '') // bold / italic / inline-code markers
+    .trim();
+}
+
+/**
+ * Extracts the navigable table of contents from an article's raw Markdown.
+ *
+ * Only numbered second-level headings (`## N. …`) are included — matching the
+ * editorial structure of the encyclopedia guides — so the leading title (`#`),
+ * sub-sections (`###`) and unnumbered `##` headings are ignored. Each entry's
+ * `id` is built with {@link getSectionAnchorId}, keeping it in sync with the
+ * anchors rendered by `MarkdownArticle`.
+ *
+ * @param content - Raw Markdown content
+ * @example
+ * extractArticleHeadings('## 1. Intro\n\nTexto.')
+ * // [{ id: 'seccion-1', number: 1, label: 'Intro' }]
+ */
+export function extractArticleHeadings(content: string): ArticleHeading[] {
+  const headings: ArticleHeading[] = [];
+  for (const match of content.matchAll(SECTION_HEADING_RE)) {
+    const number = Number(match[1]);
+    headings.push({
+      id: getSectionAnchorId(number),
+      number,
+      label: stripInlineMarkdown(match[2]),
+    });
+  }
+  return headings;
+}


### PR DESCRIPTION
## Resumen

Implementa la tarea **T-ENC-004** del backlog de rediseño de la Enciclopedia: un índice "En esta guía" (TOC) con scroll-spy para los artículos de guía.

- **Util `extractArticleHeadings` + `getSectionAnchorId`** (`lib/utils/text.ts`): deriva el TOC de los encabezados `## N.` (ignora `#`/`###` y `##` sin número), limpia markdown inline del label (negritas, cursiva, enlaces → texto) y construye el `id` de ancla (`seccion-N`). `getSectionAnchorId` es la **única fuente de verdad** del id, compartida entre el TOC y el heading renderizado, de modo que anclas y destinos siempre concuerdan.
- **`MarkdownArticle`** (modo editorial): añade `id="seccion-N"` + `scroll-mt-24` a los H2 numerados. Cero regresión para signos/planetas (modo no editorial sin id).
- **`ArticleToc`** (nuevo, client): scroll-spy con `IntersectionObserver` (elige el heading más alto entre los visibles y conserva el último activo si ninguno intersecta). Responsive: `<details>` colapsable en mobile + barra lateral `lg:sticky` en desktop, ambas con `aria-current="location"` en la sección activa.
- **`ArticleDetailView`**: extrae el cuerpo de lectura a una variable compartida (DRY) y monta el layout de dos columnas (TOC + columna `max-w-[68ch]`) solo para guías con secciones numeradas.

## Criterios de aceptación

- [x] Índice navegable que refleja las secciones del artículo (anclas `#seccion-N`).
- [x] Sección activa resaltada según el scroll (scroll-spy).
- [x] Responsive: TOC lateral en desktop, colapsable en mobile.
- [x] Ciclo de calidad frontend completo en verde.

## Validaciones

- [x] TDD (tests escritos antes de la implementación)
- [x] `npm run test:run` — 4894 tests en verde
- [x] Coverage ≥ 80% (100% líneas/funciones en archivos nuevos/tocados, ≥ 95% ramas)
- [x] `npm run lint` (0 errores) · `npm run type-check` · `npm run build`
- [x] `node scripts/validate-architecture.js`

## Referencias

- Tarea: **T-ENC-004** — `docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)