### PR TITLE
feat(encyclopedia): rediseño del Hub /enciclopedia con identidad de marca (T-ENC-005)

### DIFF
--- a/docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md
+++ b/docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md
@@ -425,16 +425,23 @@ Dar a los artículos una plantilla editorial: hero con imagen, recursos visuales
 **Estimación:** 2 puntos
 **Dependencias:** T-ENC-007 (assets)
 **Cubre Hallazgo:** ENC-004
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ Completada (rama `feature/T-ENC-005-rediseno-hub-enciclopedia`)
 
 #### ✅ Tareas específicas
 
-- [ ] Encabezado con banda oscura/gradiente (`bg-hero`/`bg-hero-mid`) + título Cormorant + filete dorado.
-- [ ] Reemplazar emojis (🃏 ⭐ 📚) por imágenes/ilustraciones de marca en las 3 tarjetas.
-- [ ] Tarjetas con imagen + overlay + título dorado + micro-interacción de hover (zoom + glow).
-- [ ] Mantener grid responsive y enlaces existentes.
-- [ ] Tests (3 secciones, enlaces correctos, alt de imágenes).
-- [ ] Coverage ≥ 80%.
+- [x] Encabezado con banda oscura/gradiente (`bg-hero`/`bg-hero-mid`) + título Cormorant + filete dorado.
+- [x] Reemplazar emojis (🃏 ⭐ 📚) por imágenes/ilustraciones de marca en las 3 tarjetas.
+- [x] Tarjetas con imagen + overlay + título dorado + micro-interacción de hover (zoom + glow).
+- [x] Mantener grid responsive y enlaces existentes.
+- [x] Tests (3 secciones, enlaces correctos, alt de imágenes).
+- [x] Coverage 100% en `EnciclopediaHubContent` (≥ 80% requerido).
+
+#### 📝 Notas de implementación
+
+- La banda de cabecera reutiliza el canon visual de `ArticleHero` (gradiente noche `HERO_GRADIENT`, estrellas `animate-twinkle`, luna creciente CSS y filete dorado), manteniendo coherencia entre el hub y el detalle de artículo.
+- Cada sección es una `SectionCard` (sub-componente): imagen `next/image` (`fill`, assets `hub-*.webp` de T-ENC-003/007), overlay de legibilidad, título Cormorant crema, descripción y CTA dorado. El emoji del sistema se eliminó del modelo de datos (`icon` → `image: { src, alt }`).
+- Micro-interacción de hover coherente vía `group`: zoom suave de imagen (`group-hover:scale-105`), glow dorado (`inset shadow`), elevación (`-translate-y-1`) y desplazamiento del CTA. Foco visible (`focus-visible:ring-secondary`) para accesibilidad por teclado.
+- Se conservan los `data-testid` y `href` existentes (cero regresión de navegación); los test-ids de sección quedan anidados dentro del `Link` de categoría.
 
 #### 🎯 Criterios de Aceptación
 

--- a/frontend/src/app/enciclopedia/page.test.tsx
+++ b/frontend/src/app/enciclopedia/page.test.tsx
@@ -123,10 +123,11 @@ describe('EnciclopediaPage (Hub principal)', () => {
     expect(astrologiaImg).toHaveAttribute('src', '/images/enciclopedia/hub-astrologia.webp');
     expect(guiasImg).toHaveAttribute('src', '/images/enciclopedia/hub-guias.webp');
 
-    // alt no vacío y en español
-    expect(tarotImg.getAttribute('alt')).toBeTruthy();
-    expect(astrologiaImg.getAttribute('alt')).toBeTruthy();
-    expect(guiasImg.getAttribute('alt')).toBeTruthy();
+    // alt descriptivo y temáticamente coherente con su sección (detecta alt
+    // ausentes o intercambiados, no solo cadenas vacías)
+    expect(tarotImg.getAttribute('alt')).toMatch(/tarot/i);
+    expect(astrologiaImg.getAttribute('alt')).toMatch(/zodiac|astro|constelac/i);
+    expect(guiasImg.getAttribute('alt')).toMatch(/libro|esot|guía/i);
   });
 
   it('no debe usar emojis del sistema como íconos de sección', () => {

--- a/frontend/src/app/enciclopedia/page.test.tsx
+++ b/frontend/src/app/enciclopedia/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import EnciclopediaPage from './page';
@@ -12,6 +12,13 @@ vi.mock('next/navigation', () => ({
     replace: vi.fn(),
     prefetch: vi.fn(),
   }),
+}));
+
+// Mock next/image (render a plain img so we can assert src/alt)
+vi.mock('next/image', () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} data-testid="next-image" />
+  ),
 }));
 
 vi.mock('next/link', () => ({
@@ -89,5 +96,43 @@ describe('EnciclopediaPage (Hub principal)', () => {
     renderWithProviders(<EnciclopediaPage />);
 
     expect(screen.getByTestId('encyclopedia-section-guias')).toHaveTextContent('Guías');
+  });
+
+  // ─── Rediseño T-ENC-005: identidad de marca ──────────────────────────────────
+
+  it('debe mostrar una banda de cabecera con identidad de marca', () => {
+    renderWithProviders(<EnciclopediaPage />);
+
+    const hero = screen.getByTestId('encyclopedia-hub-hero');
+    expect(hero).toBeInTheDocument();
+    expect(hero).toHaveTextContent('Enciclopedia Mística');
+  });
+
+  it('cada sección debe mostrar una imagen temática con alt descriptivo (no emojis)', () => {
+    renderWithProviders(<EnciclopediaPage />);
+
+    const tarot = screen.getByTestId('encyclopedia-section-tarot');
+    const astrologia = screen.getByTestId('encyclopedia-section-astrologia');
+    const guias = screen.getByTestId('encyclopedia-section-guias');
+
+    const tarotImg = within(tarot).getByTestId('next-image');
+    const astrologiaImg = within(astrologia).getByTestId('next-image');
+    const guiasImg = within(guias).getByTestId('next-image');
+
+    expect(tarotImg).toHaveAttribute('src', '/images/enciclopedia/hub-tarot.webp');
+    expect(astrologiaImg).toHaveAttribute('src', '/images/enciclopedia/hub-astrologia.webp');
+    expect(guiasImg).toHaveAttribute('src', '/images/enciclopedia/hub-guias.webp');
+
+    // alt no vacío y en español
+    expect(tarotImg.getAttribute('alt')).toBeTruthy();
+    expect(astrologiaImg.getAttribute('alt')).toBeTruthy();
+    expect(guiasImg.getAttribute('alt')).toBeTruthy();
+  });
+
+  it('no debe usar emojis del sistema como íconos de sección', () => {
+    renderWithProviders(<EnciclopediaPage />);
+
+    const hub = screen.getByTestId('encyclopedia-hub');
+    expect(hub.textContent ?? '').not.toMatch(/[🃏⭐📚]/u);
   });
 });

--- a/frontend/src/components/features/encyclopedia/EnciclopediaHubContent.tsx
+++ b/frontend/src/components/features/encyclopedia/EnciclopediaHubContent.tsx
@@ -1,5 +1,8 @@
+// 1. React & Next.js
+import Image from 'next/image';
 import Link from 'next/link';
 
+// 6. Utils & types
 import { ROUTES } from '@/lib/constants/routes';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -11,10 +14,31 @@ interface SectionConfig {
   href: string;
   linkTestId: string;
   sectionTestId: string;
-  icon: string;
+  /** Themed brand image replacing the legacy system emoji. */
+  image: { src: string; alt: string };
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Brand-night gradient used as the header band background and as the card image
+ * overlay (kept in sync with `ArticleHero` and the `--color-bg-hero` tokens).
+ */
+const HERO_GRADIENT = 'linear-gradient(160deg, #1a0a2e 0%, #2d1b69 55%, #1a0a2e 100%)';
+const CARD_OVERLAY =
+  'linear-gradient(180deg, rgba(26, 10, 46, 0.15) 0%, rgba(26, 10, 46, 0.55) 55%, rgba(26, 10, 46, 0.9) 100%)';
+const CREAM = '#f9f7f2';
+const CREAM_MUTED = 'rgba(249, 247, 242, 0.72)';
+
+// Decorative star positions — purely visual, no logic.
+const DECORATIVE_STARS = [
+  { top: '22%', left: '12%', size: 3, delay: '0s', duration: '2.8s' },
+  { top: '34%', left: '88%', size: 2, delay: '0.6s', duration: '3.2s' },
+  { top: '68%', left: '8%', size: 2, delay: '1s', duration: '2.5s' },
+  { top: '28%', left: '64%', size: 2, delay: '1.3s', duration: '3.4s' },
+];
+
+const IMAGE_BASE = '/images/enciclopedia';
 
 const ENCYCLOPEDIA_SECTIONS: SectionConfig[] = [
   {
@@ -25,7 +49,10 @@ const ENCYCLOPEDIA_SECTIONS: SectionConfig[] = [
     href: ROUTES.ENCICLOPEDIA_TAROT,
     linkTestId: 'encyclopedia-link-tarot',
     sectionTestId: 'encyclopedia-section-tarot',
-    icon: '🃏',
+    image: {
+      src: `${IMAGE_BASE}/hub-tarot.webp`,
+      alt: 'Cartas de tarot iluminadas con resplandor dorado sobre un fondo místico violeta',
+    },
   },
   {
     id: 'astrologia',
@@ -34,7 +61,10 @@ const ENCYCLOPEDIA_SECTIONS: SectionConfig[] = [
     href: ROUTES.ENCICLOPEDIA_ASTROLOGIA,
     linkTestId: 'encyclopedia-link-astrologia',
     sectionTestId: 'encyclopedia-section-astrologia',
-    icon: '⭐',
+    image: {
+      src: `${IMAGE_BASE}/hub-astrologia.webp`,
+      alt: 'Rueda zodiacal y constelaciones doradas en un cielo nocturno índigo',
+    },
   },
   {
     id: 'guias',
@@ -44,49 +74,161 @@ const ENCYCLOPEDIA_SECTIONS: SectionConfig[] = [
     href: ROUTES.ENCICLOPEDIA_GUIAS,
     linkTestId: 'encyclopedia-link-guias',
     sectionTestId: 'encyclopedia-section-guias',
-    icon: '📚',
+    image: {
+      src: `${IMAGE_BASE}/hub-guias.webp`,
+      alt: 'Libro abierto antiguo rodeado de símbolos esotéricos dorados y luz etérea',
+    },
   },
 ];
+
+// ─── Sub-components ─────────────────────────────────────────────────────────────
+
+/**
+ * SectionCard
+ *
+ * Editorial card for a hub section: themed brand image with a legibility
+ * overlay, gold title and CTA. Hover triggers a coherent micro-interaction
+ * (image zoom + gold glow) via the `group` utility.
+ */
+function SectionCard({ section }: { section: SectionConfig }) {
+  return (
+    <Link
+      data-testid={section.linkTestId}
+      href={section.href}
+      aria-label={`Explorar ${section.title}`}
+      className="group focus-visible:ring-secondary focus-visible:ring-offset-background relative block overflow-hidden rounded-2xl border border-white/10 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_18px_40px_-12px_rgba(214,158,46,0.45)] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+    >
+      <div
+        data-testid={section.sectionTestId}
+        className="relative flex min-h-[20rem] flex-col justify-end"
+      >
+        {/* Imagen temática de marca */}
+        <Image
+          src={section.image.src}
+          alt={section.image.alt}
+          fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+          className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+        />
+
+        {/* Overlay de legibilidad */}
+        <div className="absolute inset-0" style={{ background: CARD_OVERLAY }} aria-hidden="true" />
+
+        {/* Glow dorado en hover */}
+        <div
+          className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+          style={{ boxShadow: 'inset 0 0 60px 0 rgba(214, 158, 46, 0.35)' }}
+          aria-hidden="true"
+        />
+
+        {/* Contenido */}
+        <div className="relative z-10 p-6">
+          <h2 className="font-serif text-2xl font-semibold" style={{ color: CREAM }}>
+            {section.title}
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed" style={{ color: CREAM_MUTED }}>
+            {section.description}
+          </p>
+          <span
+            className="text-secondary mt-4 inline-flex items-center gap-1 text-sm font-medium transition-transform group-hover:translate-x-1"
+            aria-hidden="true"
+          >
+            Explorar {section.title} →
+          </span>
+        </div>
+
+        {/* Filete dorado inferior */}
+        <div
+          className="absolute inset-x-0 bottom-0 h-0.5"
+          style={{ background: 'linear-gradient(90deg, transparent, #d69e2e, transparent)' }}
+          aria-hidden="true"
+        />
+      </div>
+    </Link>
+  );
+}
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
 /**
  * EnciclopediaHubContent
  *
- * Hub principal de la Enciclopedia. Muestra las 3 grandes secciones:
- * Tarot, Astrología y Guías, cada una con su enlace de navegación.
+ * Hub principal de la Enciclopedia. Muestra una banda de cabecera con identidad
+ * de marca (gradiente noche + título Cormorant + filete dorado) y las 3 grandes
+ * secciones (Tarot, Astrología y Guías) como tarjetas editoriales con imagen
+ * temática y micro-interacción de hover (zoom + glow dorado).
+ *
+ * Reemplaza los emojis del sistema (🃏 ⭐ 📚) por ilustraciones de marca, de modo
+ * que el hub se ve idéntico en todos los SO (T-ENC-005 / hallazgo ENC-004).
  */
 export function EnciclopediaHubContent() {
   return (
-    <div className="container mx-auto px-4 py-8">
-      {/* Header */}
-      <div className="mb-10 text-center">
-        <h1 className="mb-3 font-serif text-4xl">Enciclopedia Mística</h1>
-        <p className="text-muted-foreground mx-auto max-w-xl text-lg">
-          Explora nuestro completo repositorio de conocimiento esotérico: tarot, astrología y guías
-          prácticas.
-        </p>
-      </div>
+    <div data-testid="encyclopedia-hub" className="container mx-auto px-4 py-8">
+      {/* Banda de cabecera con identidad de marca */}
+      <header
+        data-testid="encyclopedia-hub-hero"
+        className="relative mb-10 overflow-hidden rounded-2xl"
+        style={{ background: HERO_GRADIENT }}
+      >
+        {/* Estrellas decorativas */}
+        {DECORATIVE_STARS.map((star, i) => (
+          <span
+            key={i}
+            className="animate-twinkle absolute rounded-full bg-amber-200/80"
+            style={{
+              top: star.top,
+              left: star.left,
+              width: `${star.size}px`,
+              height: `${star.size}px`,
+              animationDelay: star.delay,
+              animationDuration: star.duration,
+            }}
+            aria-hidden="true"
+          />
+        ))}
 
-      {/* Sections grid */}
+        {/* Luna creciente decorativa (solo CSS) */}
+        <div
+          className="absolute top-6 right-8 z-0 opacity-30"
+          style={{
+            width: '72px',
+            height: '72px',
+            borderRadius: '50%',
+            boxShadow: 'inset -18px -6px 0 0 #d69e2e',
+            filter: 'blur(1px)',
+          }}
+          aria-hidden="true"
+        />
+
+        {/* Contenido */}
+        <div className="relative z-10 px-6 py-12 text-center sm:px-10 sm:py-16">
+          <h1
+            className="font-serif text-4xl leading-tight font-bold sm:text-5xl"
+            style={{ color: CREAM }}
+          >
+            Enciclopedia Mística
+          </h1>
+          <p
+            className="mx-auto mt-4 max-w-xl text-lg leading-relaxed"
+            style={{ color: CREAM_MUTED }}
+          >
+            Explora nuestro completo repositorio de conocimiento esotérico: tarot, astrología y
+            guías prácticas.
+          </p>
+        </div>
+
+        {/* Filete dorado inferior */}
+        <div
+          className="absolute inset-x-0 bottom-0 h-0.5"
+          style={{ background: 'linear-gradient(90deg, transparent, #d69e2e, transparent)' }}
+          aria-hidden="true"
+        />
+      </header>
+
+      {/* Grid de secciones */}
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {ENCYCLOPEDIA_SECTIONS.map((section) => (
-          <div
-            key={section.id}
-            data-testid={section.sectionTestId}
-            className="bg-card rounded-xl border p-6 transition-shadow hover:shadow-md"
-          >
-            <div className="mb-4 text-4xl">{section.icon}</div>
-            <h2 className="mb-2 font-serif text-2xl font-semibold">{section.title}</h2>
-            <p className="text-muted-foreground mb-4 text-sm">{section.description}</p>
-            <Link
-              data-testid={section.linkTestId}
-              href={section.href}
-              className="text-primary hover:text-primary/80 inline-flex items-center gap-1 text-sm font-medium transition-colors"
-            >
-              Explorar {section.title} →
-            </Link>
-          </div>
+          <SectionCard key={section.id} section={section} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Resumen

Rediseña el Hub `/enciclopedia` para alinearlo con la identidad mística de la marca (banda noche + dorado), eliminando los emojis del sistema. Cubre el hallazgo **ENC-004** del backlog `BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md`.

## Cambios

- **Banda de cabecera de marca**: gradiente noche (`bg-hero → bg-hero-mid`), título Cormorant, estrellas `animate-twinkle`, luna creciente CSS y filete dorado — reutiliza el canon visual de `ArticleHero`.
- **Tarjetas editoriales** (`SectionCard`): reemplazan los emojis (🃏 ⭐ 📚) por imágenes de marca (`hub-tarot/astrologia/guias.webp`) vía `next/image`, con overlay de legibilidad, título dorado y CTA.
- **Micro-interacción de hover** coherente: zoom suave de imagen + glow dorado + elevación + desplazamiento del CTA. Foco visible (`focus-visible:ring-secondary`) para navegación por teclado.
- **Cero regresión**: se conservan `data-testid`, `href` y grid responsive existentes.

## Tarea

- T-ENC-005 — Rediseño del Hub `/enciclopedia` (🟡 Media, 2 pts)

## Validaciones

- [x] Tests escritos antes (TDD) — banda, imágenes/alt, sin emojis
- [x] `test:run` (4898 tests) ✅ · Coverage 100% en `EnciclopediaHubContent`
- [x] `lint` (0 errores) · `type-check` ✅ · `build` ✅
- [x] `validate-architecture.js` ✅
- [x] Texto user-facing en español · `alt` descriptivos
- [x] Imágenes de marca (idénticas en todos los SO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)