### PR TITLE
feat(encyclopedia): rediseño de tarjetas de /enciclopedia/guias (T-ENC-006)

### DIFF
--- a/docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md
+++ b/docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md
@@ -462,16 +462,24 @@ Dar a los artículos una plantilla editorial: hero con imagen, recursos visuales
 **Estimación:** 2 puntos
 **Dependencias:** T-ENC-007 (thumbnails)
 **Cubre Hallazgo:** ENC-005
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ Completada (rama `feature/T-ENC-006-rediseno-tarjetas-guias`)
 
 #### ✅ Tareas específicas
 
-- [ ] Convertir `GuiaItem` en tarjeta editorial: thumbnail + título Cormorant + snippet (2 líneas) + chip de categoría dorado + CTA "Leer guía →".
-- [ ] Grid 2-col desktop / 1-col mobile.
-- [ ] Hover: elevación + borde dorado + micro-translate.
-- [ ] Conservar el orden (Guía del Tarot primera) sin regresiones.
-- [ ] Tests (tarjeta con imagen, chip, href).
-- [ ] Coverage ≥ 80%.
+- [x] Convertir `GuiaItem` en tarjeta editorial: thumbnail + título Cormorant + snippet (2 líneas) + chip de categoría dorado + CTA "Leer guía →".
+- [x] Grid 2-col desktop / 1-col mobile.
+- [x] Hover: elevación + borde dorado + micro-translate.
+- [x] Conservar el orden (Guía del Tarot primera) sin regresiones.
+- [x] Tests (tarjeta con imagen, chip, href).
+- [x] Coverage ≥ 80%.
+
+#### 📝 Notas de implementación
+
+- `GuiaItem` se reemplazó por `GuiaCard`: tarjeta editorial con thumbnail (`aspect-[16/9]`), overlay de legibilidad, chip de categoría dorado (`bg-secondary`), título Cormorant (`font-serif`), snippet `line-clamp-2` y CTA "Leer guía →". Hover coherente con el resto del rediseño (elevación `-translate-y-1`, borde dorado `hover:border-secondary`, glow y zoom de imagen `group-hover:scale-105`); foco visible por teclado.
+- **Thumbnail por categoría modelado como datos** (`GUIDE_THEME`): chip corto + asset temático opcional. Hoy solo la Guía del Tarot tiene asset (`guia-tarot-hero.webp`); el resto cae con elegancia a un **gradiente de marca con `✦`** hasta que aterricen sus imágenes (T-ENC-007 pendiente). `resolveThumbnail` prioriza un `imageUrl` del backend si existiera (a prueba de futuro).
+- Cabecera con banda de marca (gradiente noche + título Cormorant + filete dorado) coherente con el Hub (T-ENC-005) y `ArticleHero`.
+- Orden conservado (Guía del Tarot primera) y `ROUTES.ENCICLOPEDIA_GUIA(slug)` sin cambios → cero regresión de navegación.
+- Coverage `GuiasContent`: 100% líneas/funciones, 83% ramas (≥ 80% requerido); ciclo de calidad frontend completo en verde.
 
 #### 🎯 Criterios de Aceptación
 

--- a/frontend/src/app/enciclopedia/guias/page.test.tsx
+++ b/frontend/src/app/enciclopedia/guias/page.test.tsx
@@ -25,6 +25,13 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+// Mock next/image (render a plain img so we can assert src/alt)
+vi.mock('next/image', () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} data-testid="next-image" />
+  ),
+}));
+
 const mockUseArticlesByCategory = vi.fn();
 
 vi.mock('@/hooks/api/useEncyclopediaArticles', () => ({
@@ -137,5 +144,84 @@ describe('GuiasPage (/enciclopedia/guias)', () => {
     const requestedCategories = mockUseArticlesByCategory.mock.calls.map((call) => call[0]);
     expect(requestedCategories).toContain(ArticleCategory.GUIDE_TAROT);
     expect(requestedCategories[0]).toBe(ArticleCategory.GUIDE_TAROT);
+  });
+
+  it('debe renderizar la tarjeta de la Guía del Tarot con thumbnail temático e imagen con alt', () => {
+    const tarotGuide = buildGuideArticle(
+      10,
+      'guia-tarot',
+      'Guía del Tarot',
+      ArticleCategory.GUIDE_TAROT
+    );
+    mockUseArticlesByCategory.mockImplementation((cat: ArticleCategory) => {
+      if (cat === ArticleCategory.GUIDE_TAROT) return { data: [tarotGuide], isLoading: false };
+      return { data: [], isLoading: false };
+    });
+
+    renderWithProviders(<GuiasPage />);
+
+    const image = screen.getByTestId('next-image');
+    expect(image).toHaveAttribute('src', expect.stringContaining('guia-tarot-hero.webp'));
+    expect(image).toHaveAccessibleName(expect.stringMatching(/tarot/i));
+  });
+
+  it('debe mostrar un chip de categoría dorado y el CTA "Leer guía"', () => {
+    const tarotGuide = buildGuideArticle(
+      10,
+      'guia-tarot',
+      'Guía del Tarot',
+      ArticleCategory.GUIDE_TAROT
+    );
+    mockUseArticlesByCategory.mockImplementation((cat: ArticleCategory) => {
+      if (cat === ArticleCategory.GUIDE_TAROT) return { data: [tarotGuide], isLoading: false };
+      return { data: [], isLoading: false };
+    });
+
+    renderWithProviders(<GuiasPage />);
+
+    expect(screen.getByText('Tarot')).toBeInTheDocument();
+    expect(screen.getByText(/leer guía/i)).toBeInTheDocument();
+  });
+
+  it('debe preferir el imageUrl del backend cuando está disponible', () => {
+    const numerologyGuide: ArticleSummary = {
+      ...buildGuideArticle(
+        1,
+        'guia-numerologia',
+        'Guía de Numerología',
+        ArticleCategory.GUIDE_NUMEROLOGY
+      ),
+      imageUrl: '/images/enciclopedia/guia-numerologia.webp',
+    };
+    mockUseArticlesByCategory.mockImplementation((cat: ArticleCategory) => {
+      if (cat === ArticleCategory.GUIDE_NUMEROLOGY)
+        return { data: [numerologyGuide], isLoading: false };
+      return { data: [], isLoading: false };
+    });
+
+    renderWithProviders(<GuiasPage />);
+
+    const image = screen.getByTestId('next-image');
+    expect(image).toHaveAttribute('src', '/images/enciclopedia/guia-numerologia.webp');
+    expect(image).toHaveAccessibleName(expect.stringMatching(/guía de numerología/i));
+  });
+
+  it('debe usar un fallback decorativo cuando la guía no tiene imagen temática', () => {
+    const numerologyGuide = buildGuideArticle(
+      1,
+      'guia-numerologia',
+      'Guía de Numerología',
+      ArticleCategory.GUIDE_NUMEROLOGY
+    );
+    mockUseArticlesByCategory.mockImplementation((cat: ArticleCategory) => {
+      if (cat === ArticleCategory.GUIDE_NUMEROLOGY)
+        return { data: [numerologyGuide], isLoading: false };
+      return { data: [], isLoading: false };
+    });
+
+    renderWithProviders(<GuiasPage />);
+
+    expect(screen.getByTestId('guia-thumb-fallback')).toBeInTheDocument();
+    expect(screen.queryByTestId('next-image')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/features/encyclopedia/GuiasContent.tsx
+++ b/frontend/src/components/features/encyclopedia/GuiasContent.tsx
@@ -116,6 +116,7 @@ function GuiaCard({ article }: GuiaCardProps) {
             alt={image.alt}
             fill
             sizes="(max-width: 768px) 100vw, 50vw"
+            unoptimized
             className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
           />
         ) : (

--- a/frontend/src/components/features/encyclopedia/GuiasContent.tsx
+++ b/frontend/src/components/features/encyclopedia/GuiasContent.tsx
@@ -1,14 +1,43 @@
 'use client';
 
+// 1. React & Next.js
+import Image from 'next/image';
 import Link from 'next/link';
 
+// 6. Utils & types
 import { useArticlesByCategory } from '@/hooks/api/useEncyclopediaArticles';
 import { ROUTES } from '@/lib/constants/routes';
 import { ArticleCategory } from '@/types/encyclopedia-article.types';
 import type { ArticleSummary } from '@/types/encyclopedia-article.types';
 
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface GuideTheme {
+  /** Short category label shown in the gold chip. */
+  chip: string;
+  /** Themed thumbnail; falls back to a brand gradient when absent. */
+  image?: { src: string; alt: string };
+}
+
 // ─── Constants ────────────────────────────────────────────────────────────────
 
+const IMAGE_BASE = '/images/enciclopedia';
+
+/**
+ * Brand-night gradient used as the header band background and as the thumbnail
+ * fallback (kept in sync with `ArticleHero` / `EnciclopediaHubContent`).
+ */
+const HERO_GRADIENT = 'linear-gradient(160deg, #1a0a2e 0%, #2d1b69 55%, #1a0a2e 100%)';
+const THUMB_FALLBACK_GRADIENT = 'linear-gradient(150deg, #2d1b69 0%, #1a0a2e 60%, #2d1b69 100%)';
+const THUMB_OVERLAY =
+  'linear-gradient(180deg, rgba(26, 10, 46, 0) 35%, rgba(26, 10, 46, 0.45) 100%)';
+const GOLD_FILLET = 'linear-gradient(90deg, transparent, #d69e2e, transparent)';
+const CREAM = '#f9f7f2';
+const CREAM_MUTED = 'rgba(249, 247, 242, 0.72)';
+
+/**
+ * Guide categories, in display order. The Tarot guide stays first (BUG-017 fix).
+ */
 const GUIDE_CATEGORIES: ArticleCategory[] = [
   ArticleCategory.GUIDE_TAROT,
   ArticleCategory.GUIDE_NUMEROLOGY,
@@ -19,37 +48,127 @@ const GUIDE_CATEGORIES: ArticleCategory[] = [
   ArticleCategory.GUIDE_CHINESE,
 ];
 
-// ─── Sub-components ───────────────────────────────────────────────────────────
+/**
+ * Per-category editorial theme: short gold chip label and an optional themed
+ * thumbnail. Only the Tarot guide ships an asset today (T-ENC-007 pending); the
+ * rest gracefully fall back to a brand gradient until their image lands.
+ */
+const GUIDE_THEME: Partial<Record<ArticleCategory, GuideTheme>> = {
+  [ArticleCategory.GUIDE_TAROT]: {
+    chip: 'Tarot',
+    image: {
+      src: `${IMAGE_BASE}/guia-tarot-hero.webp`,
+      alt: 'Ilustración mística de cartas de tarot con resplandor dorado',
+    },
+  },
+  [ArticleCategory.GUIDE_NUMEROLOGY]: { chip: 'Numerología' },
+  [ArticleCategory.GUIDE_PENDULUM]: { chip: 'Péndulo' },
+  [ArticleCategory.GUIDE_BIRTH_CHART]: { chip: 'Carta Astral' },
+  [ArticleCategory.GUIDE_RITUAL]: { chip: 'Rituales' },
+  [ArticleCategory.GUIDE_HOROSCOPE]: { chip: 'Horóscopo' },
+  [ArticleCategory.GUIDE_CHINESE]: { chip: 'Horóscopo Chino' },
+};
 
-interface GuiaItemProps {
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getGuideTheme(category: ArticleCategory): GuideTheme {
+  return GUIDE_THEME[category] ?? { chip: 'Guía' };
+}
+
+/**
+ * Resolves the thumbnail for an article: prefers a backend-provided `imageUrl`
+ * (future-proof), then the category theme asset, otherwise `null` (fallback).
+ */
+function resolveThumbnail(article: ArticleSummary, theme: GuideTheme): GuideTheme['image'] | null {
+  if (article.imageUrl) {
+    return { src: article.imageUrl, alt: `Imagen ilustrativa de ${article.nameEs}` };
+  }
+  return theme.image ?? null;
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────────────────
+
+interface GuiaCardProps {
   article: ArticleSummary;
 }
 
-function GuiaItem({ article }: GuiaItemProps) {
+/**
+ * GuiaCard
+ *
+ * Editorial card for a guide: themed thumbnail (or brand gradient fallback) with
+ * a gold category chip, Cormorant title, 2-line snippet and a "Leer guía →" CTA.
+ * Hover triggers a coherent micro-interaction (lift + gold border + image zoom).
+ */
+function GuiaCard({ article }: GuiaCardProps) {
+  const theme = getGuideTheme(article.category);
+  const image = resolveThumbnail(article, theme);
+
   return (
     <Link
       href={ROUTES.ENCICLOPEDIA_GUIA(article.slug)}
-      className="bg-card hover:bg-accent flex items-center justify-between rounded-lg border p-4 transition-colors"
+      className="group border-border bg-card hover:border-secondary focus-visible:ring-secondary focus-visible:ring-offset-background relative flex flex-col overflow-hidden rounded-2xl border transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_18px_40px_-12px_rgba(214,158,46,0.45)] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
     >
-      <div>
-        <h3 className="font-medium">{article.nameEs}</h3>
-        {article.snippet && (
-          <p className="text-muted-foreground mt-1 line-clamp-2 text-sm">{article.snippet}</p>
+      {/* Thumbnail */}
+      <div className="relative aspect-[16/9] overflow-hidden">
+        {image ? (
+          <Image
+            src={image.src}
+            alt={image.alt}
+            fill
+            sizes="(max-width: 768px) 100vw, 50vw"
+            className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+          />
+        ) : (
+          <div
+            data-testid="guia-thumb-fallback"
+            className="absolute inset-0 flex items-center justify-center transition-transform duration-500 ease-out group-hover:scale-105"
+            style={{ background: THUMB_FALLBACK_GRADIENT }}
+            aria-hidden="true"
+          >
+            <span className="font-serif text-5xl" style={{ color: 'rgba(214, 158, 46, 0.55)' }}>
+              ✦
+            </span>
+          </div>
         )}
+
+        {/* Overlay de legibilidad */}
+        <div
+          className="absolute inset-0"
+          style={{ background: THUMB_OVERLAY }}
+          aria-hidden="true"
+        />
+
+        {/* Chip de categoría dorado */}
+        <span className="bg-secondary text-secondary-foreground absolute top-3 left-3 rounded-full px-3 py-1 text-xs font-semibold tracking-[0.08em] uppercase">
+          {theme.chip}
+        </span>
       </div>
-      <span className="text-muted-foreground ml-4 shrink-0 text-sm">→</span>
+
+      {/* Cuerpo */}
+      <div className="flex flex-1 flex-col p-5">
+        <h3 className="font-serif text-xl font-semibold">{article.nameEs}</h3>
+        {article.snippet && (
+          <p className="text-muted-foreground mt-2 line-clamp-2 text-sm leading-relaxed">
+            {article.snippet}
+          </p>
+        )}
+        <span
+          className="text-secondary mt-4 inline-flex items-center gap-1 text-sm font-medium transition-transform group-hover:translate-x-1"
+          aria-hidden="true"
+        >
+          Leer guía →
+        </span>
+      </div>
     </Link>
   );
 }
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function CategorySection({ category }: { category: ArticleCategory }) {
   const { data: articles } = useArticlesByCategory(category);
   return (
     <>
       {(articles ?? []).map((article) => (
-        <GuiaItem key={article.id} article={article} />
+        <GuiaCard key={article.id} article={article} />
       ))}
     </>
   );
@@ -60,22 +179,46 @@ function CategorySection({ category }: { category: ArticleCategory }) {
 /**
  * GuiasContent
  *
- * Fetches and renders all guide articles across the 7 guide categories.
- * Uses one hook call per category (as per the API design).
+ * Listado editorial de las 7 guías prácticas. Muestra una banda de cabecera con
+ * identidad de marca (gradiente noche + título Cormorant + filete dorado) y una
+ * grilla de tarjetas editoriales (thumbnail temático, chip de categoría dorado,
+ * título Cormorant, snippet y CTA), reemplazando las filas planas previas
+ * (T-ENC-006 / hallazgo ENC-005). Usa una llamada al hook por categoría.
  */
 export function GuiasContent() {
   return (
     <div className="container mx-auto px-4 py-8">
-      {/* Header */}
-      <div className="mb-8">
-        <h1 className="mb-2 font-serif text-3xl font-bold">Guías</h1>
-        <p className="text-muted-foreground">
-          Aprende con nuestras guías prácticas sobre espiritualidad y esoterismo.
-        </p>
-      </div>
+      {/* Banda de cabecera con identidad de marca */}
+      <header
+        data-testid="guias-hero"
+        className="relative mb-8 overflow-hidden rounded-2xl"
+        style={{ background: HERO_GRADIENT }}
+      >
+        <div className="relative z-10 px-6 py-10 text-center sm:px-10 sm:py-12">
+          <h1
+            className="font-serif text-3xl leading-tight font-bold sm:text-4xl"
+            style={{ color: CREAM }}
+          >
+            Guías
+          </h1>
+          <p
+            className="mx-auto mt-3 max-w-xl text-base leading-relaxed"
+            style={{ color: CREAM_MUTED }}
+          >
+            Aprende con nuestras guías prácticas sobre espiritualidad y esoterismo.
+          </p>
+        </div>
 
-      {/* List */}
-      <div className="flex flex-col gap-3">
+        {/* Filete dorado inferior */}
+        <div
+          className="absolute inset-x-0 bottom-0 h-0.5"
+          style={{ background: GOLD_FILLET }}
+          aria-hidden="true"
+        />
+      </header>
+
+      {/* Grid de tarjetas */}
+      <div className="grid gap-6 md:grid-cols-2">
         {GUIDE_CATEGORIES.map((category) => (
           <CategorySection key={category} category={category} />
         ))}


### PR DESCRIPTION
## 📋 Resumen

Rediseño del índice de guías (`/enciclopedia/guias`) — **T-ENC-006**, cubre el hallazgo **ENC-005**. Reemplaza las filas planas (título + snippet + flecha sobre fondo blanco) por **tarjetas editoriales** con identidad de marca.

## ✨ Cambios

- **`GuiaCard`** (reemplaza `GuiaItem`): thumbnail temático (`aspect-[16/9]`) con overlay de legibilidad, **chip de categoría dorado**, **título Cormorant** (`font-serif`), snippet `line-clamp-2` y CTA **"Leer guía →"**.
- **Grid 2-col desktop / 1-col mobile** (`md:grid-cols-2`).
- **Hover coherente** con el resto del rediseño: elevación (`-translate-y-1`), borde dorado (`hover:border-secondary`), glow y zoom de imagen (`group-hover:scale-105`). **Foco visible** por teclado (`focus-visible:ring-secondary`).
- **Thumbnail por categoría modelado como datos** (`GUIDE_THEME`): solo la Guía del Tarot tiene asset hoy (`guia-tarot-hero.webp`); el resto cae con elegancia a un **gradiente de marca con ✦** hasta que aterricen sus imágenes (**T-ENC-007** pendiente). `resolveThumbnail` prioriza un `imageUrl` del backend si existiera (a prueba de futuro).
- **Cabecera con banda de marca** (gradiente noche + título Cormorant + filete dorado) coherente con el Hub (T-ENC-005) y `ArticleHero`.
- **Orden conservado** (Guía del Tarot primera, fix previo BUG-017) y `ROUTES.ENCICLOPEDIA_GUIA(slug)` sin cambios → cero regresión de navegación.

## 🧪 Validaciones

- [x] TDD: tests primero (red → green)
- [x] `npm run test:run` → **4902 passed**, 7 skipped (preexistentes)
- [x] Coverage `GuiasContent`: **100% líneas/funciones**, 83% ramas (≥ 80% requerido)
- [x] `npm run type-check` sin errores
- [x] `npm run lint:fix` sin nuevos warnings
- [x] `npm run build` exitoso
- [x] `node scripts/validate-architecture.js` ✅
- [x] Texto user-facing en español · `'use client'` · `data-testid` · IDs numéricos · rutas centralizadas

## 🎯 Criterios de Aceptación

- ✅ El índice muestra tarjetas ricas con imagen y jerarquía.
- ✅ Orden y enlaces conservados.
- ✅ Ciclo de calidad frontend completo pasa.

Ref: `docs/BACKLOG_ENCICLOPEDIA_REDISENO_2026_05.md` → T-ENC-006

🤖 Generated with [Claude Code](https://claude.com/claude-code)