### PR TITLE
feat(encyclopedia): data editorial de las 6 guías restantes (T-ENC-010)

### DIFF
--- a/docs/BACKLOG_ENCICLOPEDIA_REDISENO_FASE_2.md
+++ b/docs/BACKLOG_ENCICLOPEDIA_REDISENO_FASE_2.md
@@ -66,17 +66,24 @@ luego 010 → 011 → 012 → 013.
 
 **Prioridad:** 🟠 Alta · **Estimación:** 5 pts · **Dependencias:** T-ENC-014 (assets)
 **Cubre:** gap de guías (numerología, péndulo, carta astral, rituales, horóscopo, horóscopo chino)
+**Estado:** ✅ COMPLETADA
+
+**Nota de implementación:** La data editorial apunta a los assets definidos en §C. Las imágenes se
+generarán con T-ENC-014; hasta entonces el componente muestra el fallback de marca (`ArticleHero`
+sin `src` queda gracefully sin imagen de sección). El slug del horóscopo occidental es
+`guia-horoscopo-occidental` (no `guia-horoscopo`). `guia-rituales` tiene 4 secciones H2 (no 6);
+`guia-horoscopo-occidental` tiene 3; `guia-horoscopo-chino` tiene 4.
 
 #### ✅ Tareas específicas
 
-- [ ] Para cada una de las 6 guías, añadir su entrada en `ARTICLE_EDITORIAL`
+- [x] Para cada una de las 6 guías, añadir su entrada en `ARTICLE_EDITORIAL`
       (`encyclopedia-editorial.data.ts`) con `hero` + `sections[].image` mapeadas por nº de H2,
       siguiendo la estructura de secciones documentada en §C.
-- [ ] Cada imagen con `alt` descriptivo en español.
-- [ ] Verificar que cada guía entra al modo editorial (ya gateado por `guide_*`) y renderiza
+- [x] Cada imagen con `alt` descriptivo en español.
+- [x] Verificar que cada guía entra al modo editorial (ya gateado por `guide_*`) y renderiza
       hero con imagen + imágenes de sección, sin tocar `ArticleDetailView`.
-- [ ] Tests de la data (entradas presentes, src/alt válidos por guía).
-- [ ] Coverage ≥ 80%.
+- [x] Tests de la data (entradas presentes, src/alt válidos por guía).
+- [x] Coverage ≥ 80% (100% statements/branch/funcs/lines).
 
 #### 🎯 Criterios de aceptación
 

--- a/frontend/src/lib/data/encyclopedia-editorial.data.test.ts
+++ b/frontend/src/lib/data/encyclopedia-editorial.data.test.ts
@@ -107,7 +107,7 @@ describe('getArticleEditorial – guia-rituales', () => {
 });
 
 describe('getArticleEditorial – guia-horoscopo-occidental', () => {
-  assertGuideEditorial('guia-horoscopo-occidental', 'guia-horoscopo-hero.webp', 3);
+  assertGuideEditorial('guia-horoscopo-occidental', 'guia-horoscopo-occidental-hero.webp', 3);
 });
 
 describe('getArticleEditorial – guia-horoscopo-chino', () => {

--- a/frontend/src/lib/data/encyclopedia-editorial.data.test.ts
+++ b/frontend/src/lib/data/encyclopedia-editorial.data.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest';
 
 import { getArticleEditorial } from './encyclopedia-editorial.data';
 
-describe('getArticleEditorial', () => {
+// ─── Tarot (existente — sin regresión) ─────────────────────────────────────
+
+describe('getArticleEditorial – guia-tarot', () => {
   it('should return the editorial config for the tarot guide', () => {
     const editorial = getArticleEditorial('guia-tarot');
 
@@ -14,9 +16,7 @@ describe('getArticleEditorial', () => {
   it('should map per-section images keyed by the H2 section number', () => {
     const editorial = getArticleEditorial('guia-tarot');
 
-    // Sección 1 → ilustración lateral (estilo lápiz + dorado)
     expect(editorial?.sections?.[1]?.image?.src).toBe('/images/enciclopedia/tarot-que-es.webp');
-    // Sección 5 → historia
     expect(editorial?.sections?.[5]?.image?.src).toBe('/images/enciclopedia/tarot-historia.webp');
   });
 
@@ -39,9 +39,121 @@ describe('getArticleEditorial', () => {
       }
     }
   });
+});
 
+// ─── Slugs sin config (no debe romper) ────────────────────────────────────
+
+describe('getArticleEditorial – slugs sin config', () => {
   it('should return undefined for a slug without editorial config', () => {
     expect(getArticleEditorial('aries')).toBeUndefined();
     expect(getArticleEditorial('inexistente')).toBeUndefined();
+  });
+});
+
+// ─── Helper compartido ────────────────────────────────────────────────────
+
+function assertGuideEditorial(slug: string, heroFilename: string, expectedSectionCount: number) {
+  const editorial = getArticleEditorial(slug);
+
+  it(`${slug}: debe tener config editorial`, () => {
+    expect(editorial).toBeDefined();
+  });
+
+  it(`${slug}: hero src apunta al asset correcto`, () => {
+    expect(editorial?.hero?.src).toBe(`/images/enciclopedia/${heroFilename}`);
+  });
+
+  it(`${slug}: hero alt no está vacío`, () => {
+    expect(editorial?.hero?.alt.trim().length).toBeGreaterThan(0);
+  });
+
+  it(`${slug}: tiene ${expectedSectionCount} secciones con imagen`, () => {
+    const sections = Object.values(editorial?.sections ?? {});
+    const withImage = sections.filter((s) => s.image !== undefined);
+    expect(withImage.length).toBe(expectedSectionCount);
+  });
+
+  it(`${slug}: todas las imágenes de sección tienen alt en español (no vacío)`, () => {
+    const sections = Object.values(editorial?.sections ?? {});
+    for (const section of sections) {
+      if (section.image) {
+        expect(section.image.alt.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it(`${slug}: secciones están keyed por número de H2 (empiezan en 1)`, () => {
+    const keys = Object.keys(editorial?.sections ?? {}).map(Number);
+    expect(keys.every((k) => k >= 1)).toBe(true);
+  });
+}
+
+// ─── Las 6 guías restantes ─────────────────────────────────────────────────
+
+describe('getArticleEditorial – guia-numerologia', () => {
+  assertGuideEditorial('guia-numerologia', 'guia-numerologia-hero.webp', 5);
+});
+
+describe('getArticleEditorial – guia-pendulo', () => {
+  assertGuideEditorial('guia-pendulo', 'guia-pendulo-hero.webp', 5);
+});
+
+describe('getArticleEditorial – guia-carta-astral', () => {
+  assertGuideEditorial('guia-carta-astral', 'guia-carta-astral-hero.webp', 5);
+});
+
+describe('getArticleEditorial – guia-rituales', () => {
+  assertGuideEditorial('guia-rituales', 'guia-rituales-hero.webp', 4);
+});
+
+describe('getArticleEditorial – guia-horoscopo-occidental', () => {
+  assertGuideEditorial('guia-horoscopo-occidental', 'guia-horoscopo-hero.webp', 3);
+});
+
+describe('getArticleEditorial – guia-horoscopo-chino', () => {
+  assertGuideEditorial('guia-horoscopo-chino', 'guia-horoscopo-chino-hero.webp', 4);
+});
+
+// ─── Verificación de src individuales (spot-check por guía) ──────────────
+
+describe('getArticleEditorial – spot-checks de src de sección', () => {
+  it('numerologia: sección 1 → pitagoras, sección 5 → ciclos', () => {
+    const ed = getArticleEditorial('guia-numerologia');
+    expect(ed?.sections?.[1]?.image?.src).toBe('/images/enciclopedia/numerologia-pitagoras.webp');
+    expect(ed?.sections?.[5]?.image?.src).toBe('/images/enciclopedia/numerologia-ciclos.webp');
+  });
+
+  it('pendulo: sección 1 → historia, sección 5 → preguntar', () => {
+    const ed = getArticleEditorial('guia-pendulo');
+    expect(ed?.sections?.[1]?.image?.src).toBe('/images/enciclopedia/pendulo-historia.webp');
+    expect(ed?.sections?.[5]?.image?.src).toBe('/images/enciclopedia/pendulo-preguntar.webp');
+  });
+
+  it('carta-astral: sección 1 → requisitos, sección 5 → aspectos', () => {
+    const ed = getArticleEditorial('guia-carta-astral');
+    expect(ed?.sections?.[1]?.image?.src).toBe('/images/enciclopedia/carta-astral-requisitos.webp');
+    expect(ed?.sections?.[5]?.image?.src).toBe('/images/enciclopedia/carta-astral-aspectos.webp');
+  });
+
+  it('rituales: sección 1 → espacio, sección 4 → estructura', () => {
+    const ed = getArticleEditorial('guia-rituales');
+    expect(ed?.sections?.[1]?.image?.src).toBe('/images/enciclopedia/rituales-espacio.webp');
+    expect(ed?.sections?.[4]?.image?.src).toBe('/images/enciclopedia/rituales-estructura.webp');
+  });
+
+  it('horoscopo-occidental: sección 1 → elementos, sección 3 → compatibilidad', () => {
+    const ed = getArticleEditorial('guia-horoscopo-occidental');
+    expect(ed?.sections?.[1]?.image?.src).toBe('/images/enciclopedia/horoscopo-elementos.webp');
+    expect(ed?.sections?.[3]?.image?.src).toBe(
+      '/images/enciclopedia/horoscopo-compatibilidad.webp'
+    );
+  });
+
+  it('horoscopo-chino: sección 1 → carrera, sección 4 → compatibilidad', () => {
+    const ed = getArticleEditorial('guia-horoscopo-chino');
+    expect(ed?.sections?.[1]?.image?.src).toBe('/images/enciclopedia/horoscopo-chino-carrera.webp');
+    expect(ed?.sections?.[4]?.image?.src).toBe(
+      '/images/enciclopedia/horoscopo-chino-compatibilidad.webp'
+    );
   });
 });

--- a/frontend/src/lib/data/encyclopedia-editorial.data.ts
+++ b/frontend/src/lib/data/encyclopedia-editorial.data.ts
@@ -171,7 +171,7 @@ const ARTICLE_EDITORIAL: Record<string, ArticleEditorial> = {
       1: {
         image: {
           src: `${IMAGE_BASE}/pendulo-historia.webp`,
-          alt: 'Varillas de radiestesia antiguas y péndulo de latón sobre pergamino envejecido, ambiente mísitco vintage',
+          alt: 'Varillas de radiestesia antiguas y péndulo de latón sobre pergamino envejecido, ambiente místico vintage',
           width: 640,
           height: 794,
         },
@@ -306,7 +306,7 @@ const ARTICLE_EDITORIAL: Record<string, ArticleEditorial> = {
   // ─── Guía de Horóscopo Occidental ─────────────────────────────────────────
   'guia-horoscopo-occidental': {
     hero: {
-      src: `${IMAGE_BASE}/guia-horoscopo-hero.webp`,
+      src: `${IMAGE_BASE}/guia-horoscopo-occidental-hero.webp`,
       alt: 'Rueda zodiacal completa con doce glifos de signos brillantes y finas líneas de constelaciones',
     },
     sections: {

--- a/frontend/src/lib/data/encyclopedia-editorial.data.ts
+++ b/frontend/src/lib/data/encyclopedia-editorial.data.ts
@@ -53,6 +53,7 @@ export interface ArticleEditorial {
 // ─── Data ─────────────────────────────────────────────────────────────────────
 
 const ARTICLE_EDITORIAL: Record<string, ArticleEditorial> = {
+  // ─── Guía del Tarot ────────────────────────────────────────────────────────
   'guia-tarot': {
     hero: {
       src: `${IMAGE_BASE}/guia-tarot-hero.webp`,
@@ -103,6 +104,274 @@ const ARTICLE_EDITORIAL: Record<string, ArticleEditorial> = {
         image: {
           src: `${IMAGE_BASE}/tarot-historia.webp`,
           alt: 'Antiguas cartas trionfi italianas del siglo XV sobre pergamino con detalle en pan de oro',
+          width: 1000,
+          height: 558,
+        },
+      },
+    },
+  },
+
+  // ─── Guía de Numerología ───────────────────────────────────────────────────
+  'guia-numerologia': {
+    hero: {
+      src: `${IMAGE_BASE}/guia-numerologia-hero.webp`,
+      alt: 'Dígitos dorados del 1 al 9 flotando en geometría sagrada luminosa sobre cielo violeta índigo',
+    },
+    sections: {
+      1: {
+        image: {
+          src: `${IMAGE_BASE}/numerologia-pitagoras.webp`,
+          alt: 'Filósofo griego antiguo contemplando números dorados sobre un templo de mármol, atmósfera mística clásica',
+          width: 640,
+          height: 794,
+        },
+      },
+      2: {
+        image: {
+          src: `${IMAGE_BASE}/numerologia-numeros-base.webp`,
+          alt: 'Nueve numerales arquetípicos dorados radiantes dispuestos en círculo, cada uno brillando suavemente',
+          width: 1000,
+          height: 558,
+        },
+      },
+      3: {
+        image: {
+          src: `${IMAGE_BASE}/numerologia-maestros.webp`,
+          alt: 'Tres números maestros luminosos (11, 22 y 33) ascendiendo como pilares de luz dorada',
+          width: 1000,
+          height: 558,
+        },
+      },
+      4: {
+        image: {
+          src: `${IMAGE_BASE}/numerologia-mapa-alma.webp`,
+          alt: 'Fecha de nacimiento luminosa disolviéndose en corrientes de números dorados formando un mapa del alma',
+          width: 1000,
+          height: 558,
+        },
+      },
+      5: {
+        image: {
+          src: `${IMAGE_BASE}/numerologia-ciclos.webp`,
+          alt: 'Rueda espiral de calendario formada por dígitos dorados girando a través de las estaciones',
+          width: 1000,
+          height: 558,
+        },
+      },
+    },
+  },
+
+  // ─── Guía del Péndulo ─────────────────────────────────────────────────────
+  'guia-pendulo': {
+    hero: {
+      src: `${IMAGE_BASE}/guia-pendulo-hero.webp`,
+      alt: 'Péndulo de cristal suspendido en pleno movimiento irradiando arcos dorados sobre un mapa místico',
+    },
+    sections: {
+      1: {
+        image: {
+          src: `${IMAGE_BASE}/pendulo-historia.webp`,
+          alt: 'Varillas de radiestesia antiguas y péndulo de latón sobre pergamino envejecido, ambiente mísitco vintage',
+          width: 640,
+          height: 794,
+        },
+      },
+      2: {
+        image: {
+          src: `${IMAGE_BASE}/pendulo-tipos.webp`,
+          alt: 'Fila de diferentes péndulos de cristal —cuarzo, amatista, latón— colgando y brillando suavemente',
+          width: 1000,
+          height: 558,
+        },
+      },
+      3: {
+        image: {
+          src: `${IMAGE_BASE}/pendulo-limpieza.webp`,
+          alt: 'Péndulo bañado en luz de luna y humo de incienso en espiral durante un ritual de purificación',
+          width: 1000,
+          height: 558,
+        },
+      },
+      4: {
+        image: {
+          src: `${IMAGE_BASE}/pendulo-calibracion.webp`,
+          alt: 'Péndulo oscilando a lo largo de ejes dorados de sí/no, diagrama de calibración elegante',
+          width: 1000,
+          height: 558,
+        },
+      },
+      5: {
+        image: {
+          src: `${IMAGE_BASE}/pendulo-preguntar.webp`,
+          alt: 'Mano sosteniendo un péndulo sobre un cuaderno abierto con un resplandor dorado de enfoque introspectivo',
+          width: 1000,
+          height: 558,
+        },
+      },
+    },
+  },
+
+  // ─── Guía de Carta Astral ─────────────────────────────────────────────────
+  'guia-carta-astral': {
+    hero: {
+      src: `${IMAGE_BASE}/guia-carta-astral-hero.webp`,
+      alt: 'Rueda de carta natal luminosa con planetas y glifos zodiacales trazados en líneas doradas finas',
+    },
+    sections: {
+      1: {
+        image: {
+          src: `${IMAGE_BASE}/carta-astral-requisitos.webp`,
+          alt: 'Certificado de nacimiento, globo terráqueo y reloj antiguo irradiando luz, los datos del origen del alma',
+          width: 640,
+          height: 794,
+        },
+      },
+      2: {
+        image: {
+          src: `${IMAGE_BASE}/carta-astral-big3.webp`,
+          alt: 'Sol, Luna y ascendente alineados como trinidad luminosa sobre un paisaje cósmico dorado',
+          width: 1000,
+          height: 558,
+        },
+      },
+      3: {
+        image: {
+          src: `${IMAGE_BASE}/carta-astral-planetas.webp`,
+          alt: 'Procesión de planetas clásicos orbitando en cosmos violeta profundo con trazos dorados finos',
+          width: 1000,
+          height: 558,
+        },
+      },
+      4: {
+        image: {
+          src: `${IMAGE_BASE}/carta-astral-casas.webp`,
+          alt: 'Rueda de carta dividida en doce casas luminosas flotando sobre el horizonte terrestre',
+          width: 1000,
+          height: 558,
+        },
+      },
+      5: {
+        image: {
+          src: `${IMAGE_BASE}/carta-astral-aspectos.webp`,
+          alt: 'Líneas doradas geométricas (trígono, cuadratura, oposición) conectando planetas en la rueda astral',
+          width: 1000,
+          height: 558,
+        },
+      },
+    },
+  },
+
+  // ─── Guía de Rituales ─────────────────────────────────────────────────────
+  'guia-rituales': {
+    hero: {
+      src: `${IMAGE_BASE}/guia-rituales-hero.webp`,
+      alt: 'Altar místico con velas encendidas, cristales y hierbas brillando en atmósfera de ritual sagrado',
+    },
+    sections: {
+      1: {
+        image: {
+          src: `${IMAGE_BASE}/rituales-espacio.webp`,
+          alt: 'Círculo brillante de sal y velas formando un espacio sagrado protegido',
+          width: 640,
+          height: 794,
+        },
+      },
+      2: {
+        image: {
+          src: `${IMAGE_BASE}/rituales-rueda-tiempo.webp`,
+          alt: 'Rueda de fases lunares rodeada de glifos dorados de días de la semana, calendario lunar',
+          width: 1000,
+          height: 558,
+        },
+      },
+      3: {
+        image: {
+          src: `${IMAGE_BASE}/rituales-herramientas.webp`,
+          alt: 'Hierbas, cristales, velas de colores e incienso dispuestos como herramientas rituales con detalle dorado',
+          width: 1000,
+          height: 558,
+        },
+      },
+      4: {
+        image: {
+          src: `${IMAGE_BASE}/rituales-estructura.webp`,
+          alt: 'Elegante diagrama de los pasos de un ritual ascendiendo como luz dorada, minimalista',
+          width: 1000,
+          height: 558,
+        },
+      },
+    },
+  },
+
+  // ─── Guía de Horóscopo Occidental ─────────────────────────────────────────
+  'guia-horoscopo-occidental': {
+    hero: {
+      src: `${IMAGE_BASE}/guia-horoscopo-hero.webp`,
+      alt: 'Rueda zodiacal completa con doce glifos de signos brillantes y finas líneas de constelaciones',
+    },
+    sections: {
+      1: {
+        image: {
+          src: `${IMAGE_BASE}/horoscopo-elementos.webp`,
+          alt: 'Los cuatro símbolos elementales (fuego, tierra, aire, agua) en trazo dorado fino sobre cosmos violeta',
+          width: 640,
+          height: 794,
+        },
+      },
+      2: {
+        image: {
+          src: `${IMAGE_BASE}/horoscopo-arquetipos.webp`,
+          alt: 'Procesión de las doce constelaciones zodiacales a través de un cielo violeta estrellado',
+          width: 1000,
+          height: 558,
+        },
+      },
+      3: {
+        image: {
+          src: `${IMAGE_BASE}/horoscopo-compatibilidad.webp`,
+          alt: 'Dos ruedas de carta natal superpuestas en armonía dorada luminosa',
+          width: 1000,
+          height: 558,
+        },
+      },
+    },
+  },
+
+  // ─── Guía de Horóscopo Chino ──────────────────────────────────────────────
+  'guia-horoscopo-chino': {
+    hero: {
+      src: `${IMAGE_BASE}/guia-horoscopo-chino-hero.webp`,
+      alt: 'Los doce animales del zodíaco chino en trazo dorado fino dispuestos en círculo luminoso',
+    },
+    sections: {
+      1: {
+        image: {
+          src: `${IMAGE_BASE}/horoscopo-chino-carrera.webp`,
+          alt: 'Los doce animales zodiacales corriendo a través de un río mítico bajo un cielo dorado',
+          width: 640,
+          height: 794,
+        },
+      },
+      2: {
+        image: {
+          src: `${IMAGE_BASE}/horoscopo-chino-animales.webp`,
+          alt: 'Procesión de los doce animales del zodíaco chino, elegantes siluetas en línea dorada fina',
+          width: 1000,
+          height: 558,
+        },
+      },
+      3: {
+        image: {
+          src: `${IMAGE_BASE}/horoscopo-chino-wuxing.webp`,
+          alt: 'El ciclo Wu Xing —madera, fuego, tierra, metal, agua— representado como pentágono dorado brillante',
+          width: 1000,
+          height: 558,
+        },
+      },
+      4: {
+        image: {
+          src: `${IMAGE_BASE}/horoscopo-chino-compatibilidad.webp`,
+          alt: 'Parejas de animales del zodíaco chino en alineación dorada armoniosa',
           width: 1000,
           height: 558,
         },


### PR DESCRIPTION
## Resumen

- Añade 6 entradas en `ARTICLE_EDITORIAL` (`encyclopedia-editorial.data.ts`): `guia-numerologia`, `guia-pendulo`, `guia-carta-astral`, `guia-rituales`, `guia-horoscopo-occidental`, `guia-horoscopo-chino`.
- Cada entrada incluye `hero` + `sections[]` mapeados por número de H2 del artículo, siguiendo los assets definidos en `BACKLOG_ENCICLOPEDIA_REDISENO_FASE_2.md §C`.
- Todos los `alt` en español; cero regresión en `guia-tarot`.
- Tests expandidos: 47 tests, cobertura 100% statements/branch/funcs/lines.

## Decisiones técnicas

- El slug del horóscopo occidental es `guia-horoscopo-occidental` (verificado en el backend).
- `guia-rituales` tiene 4 secciones H2 reales (no 6 como lista el §C); `guia-horoscopo-occidental` tiene 3; `guia-horoscopo-chino` tiene 4. Las imágenes del §C sin sección H2 correspondiente no se registran.
- Los assets aún no existen en disco (dependen de T-ENC-014); el render hace fallback graceful hasta que se agreguen.

## Test plan

- [x] `npm run test -- src/lib/data/encyclopedia-editorial.data.test.ts` → 47/47 pasan
- [x] `npm run test:run` → 4979 tests, 0 fallos
- [x] `npm run type-check` → sin errores
- [x] `npm run lint:fix` → sin errores (solo warnings preexistentes)
- [x] `npm run build` → exitoso
- [x] `node scripts/validate-architecture.js` → ✅ VALIDACIÓN EXITOSA

## Archivos modificados

- `frontend/src/lib/data/encyclopedia-editorial.data.ts`
- `frontend/src/lib/data/encyclopedia-editorial.data.test.ts`
- `docs/BACKLOG_ENCICLOPEDIA_REDISENO_FASE_2.md` (tarea marcada como completada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)