### PR TITLE
feat(dashboard): tarjeta de widget común (WidgetCard) + normalización de tokens (T-DASH-003)

### DIFF
--- a/docs/BACKLOG_DASHBOARD_REDISENO_2026_06.md
+++ b/docs/BACKLOG_DASHBOARD_REDISENO_2026_06.md
@@ -405,16 +405,29 @@ Reemplazar el layout 2/3 + 1/3 de `UserDashboard` por una distribución que use 
 **Estimación:** 2.5 puntos
 **Dependencias:** ninguna (idealmente antes de T-DASH-006)
 **Cubre Hallazgo:** DASH-003
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ Completada (rama `feature/T-DASH-003-widget-card-tokens`)
 
 #### ✅ Tareas específicas
 
-- [ ] Crear `DashboardCard`/`WidgetCard` con encabezado estandarizado (ícono + título `font-serif` + acción opcional) y tratamiento de marca coherente.
-- [ ] Migrar los widgets a ese contenedor sin alterar su lógica de datos ni `data-testid`.
-- [ ] Normalizar `NumerologyWidget` y `UpgradeBanner` a `font-serif` en títulos.
-- [ ] Reemplazar grises/acentos hardcodeados por tokens; quitar todas las clases `dark:` del dashboard.
-- [ ] Tests de regresión visual mínima (encabezado, título serif, tokens) por widget tocado.
-- [ ] Coverage ≥ 80%.
+- [x] Crear `DashboardCard`/`WidgetCard` con encabezado estandarizado (ícono + título `font-serif` + acción opcional) y tratamiento de marca coherente.
+- [x] Migrar los widgets a ese contenedor sin alterar su lógica de datos ni `data-testid`.
+- [x] Normalizar `NumerologyWidget` y `UpgradeBanner` a `font-serif` en títulos.
+- [x] Reemplazar grises/acentos hardcodeados por tokens; quitar todas las clases `dark:` del dashboard.
+- [x] Tests de regresión visual mínima (encabezado, título serif, tokens) por widget tocado.
+- [x] Coverage ≥ 80%.
+
+> **Notas de implementación:**
+> - Nuevo componente compartido `WidgetCard` (`components/features/dashboard/WidgetCard.tsx`):
+>   `Card` + encabezado estándar (slot de ícono con **acento dorado** `text-secondary`, título
+>   `font-serif text-xl`, acción opcional) que reenvía `data-testid` y `className`.
+> - Migrados a `WidgetCard`: `NumerologyWidget`, `SacredEventsWidget`, `MyServicesWidget`,
+>   `PersonalizedRitualsWidget`, `StatsSection`, `DidYouKnowSection`.
+> - `HoroscopeWidget` y `ChineseHoroscopeWidget` ya cumplían el canon (título serif + solo colores
+>   semánticos, sin `dark:`) → se auditaron y se dejaron sin cambios.
+> - `QuickActions` y `UpgradeBanner` no son tarjetas de widget: se normalizaron tokens y se añadió
+>   `font-serif` al título del banner. **Todas** las clases `dark:` del dashboard fueron eliminadas.
+> - Se conservan los colores **semánticos** de estado (verde/ámbar/rojo/rosa en `STATUS_CONFIG`,
+>   `IMPORTANCE_INFO`, colores por número de numerología, scores de horóscopo).
 
 #### 🎯 Criterios de Aceptación
 

--- a/frontend/src/components/features/dashboard/DidYouKnowSection.tsx
+++ b/frontend/src/components/features/dashboard/DidYouKnowSection.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Lightbulb } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { WidgetCard } from './WidgetCard';
 
 /**
  * Collection of interesting tarot facts
@@ -44,18 +44,10 @@ export function DidYouKnowSection() {
   const [fact] = useState<string>(() => getRandomFact());
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center gap-2">
-          <Lightbulb className="h-5 w-5 text-yellow-500" />
-          <CardTitle className="font-serif text-xl">¿Sabías que...?</CardTitle>
-        </div>
-      </CardHeader>
-      <CardContent>
-        <p className="text-gray-700 dark:text-gray-300" data-testid="tarot-fact">
-          {fact}
-        </p>
-      </CardContent>
-    </Card>
+    <WidgetCard title="¿Sabías que...?" icon={<Lightbulb className="h-5 w-5" />}>
+      <p className="text-muted-foreground" data-testid="tarot-fact">
+        {fact}
+      </p>
+    </WidgetCard>
   );
 }

--- a/frontend/src/components/features/dashboard/MyServicesWidget.test.tsx
+++ b/frontend/src/components/features/dashboard/MyServicesWidget.test.tsx
@@ -294,4 +294,18 @@ describe('MyServicesWidget', () => {
     const viewAllLink = screen.getByTestId('widget-view-all-link');
     expect(viewAllLink).toHaveAttribute('href', '/mis-servicios');
   });
+
+  describe('T-DASH-003 · Encabezado unificado (WidgetCard)', () => {
+    it('renders the title as a serif heading', () => {
+      vi.mocked(useHolisticServicesHook.useMyPurchases).mockReturnValue({
+        data: [createMockPurchase({ id: 1 })],
+        isLoading: false,
+      } as unknown as ReturnType<typeof useHolisticServicesHook.useMyPurchases>);
+
+      render(<MyServicesWidget />, { wrapper });
+
+      const heading = screen.getByRole('heading', { name: 'Mis Servicios' });
+      expect(heading).toHaveClass('font-serif');
+    });
+  });
 });

--- a/frontend/src/components/features/dashboard/MyServicesWidget.tsx
+++ b/frontend/src/components/features/dashboard/MyServicesWidget.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { HandHeart, ArrowRight, CalendarDays, Clock } from 'lucide-react';
 import { Card } from '@/components/ui/card';
+import { WidgetCard } from './WidgetCard';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ErrorDisplay } from '@/components/ui/error-display';
 import { useMyPurchases } from '@/hooks/api/useHolisticServices';
@@ -43,10 +44,10 @@ function PurchaseItem({ purchase }: PurchaseItemProps) {
   return (
     <div
       data-testid={`widget-purchase-${purchase.id}`}
-      className="flex items-center justify-between gap-3 rounded-lg border bg-white p-3"
+      className="bg-card flex items-center justify-between gap-3 rounded-lg border p-3"
     >
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium text-gray-900">{serviceName}</p>
+        <p className="text-foreground truncate text-sm font-medium">{serviceName}</p>
         <div className="mt-1 flex items-center gap-2">
           <span
             className={cn(
@@ -58,11 +59,11 @@ function PurchaseItem({ purchase }: PurchaseItemProps) {
           </span>
           {hasAppointment && (
             <>
-              <span className="flex items-center gap-1 text-xs text-gray-500">
+              <span className="text-muted-foreground flex items-center gap-1 text-xs">
                 <CalendarDays className="h-3 w-3" />
                 {formatDateShort(purchase.selectedDate as string)}
               </span>
-              <span className="flex items-center gap-1 text-xs text-gray-500">
+              <span className="text-muted-foreground flex items-center gap-1 text-xs">
                 <Clock className="h-3 w-3" />
                 {purchase.selectedTime}
               </span>
@@ -117,13 +118,12 @@ export function MyServicesWidget() {
   const remainingCount = purchases.length - MAX_VISIBLE_PURCHASES;
 
   return (
-    <Card className="p-6" data-testid="my-services-widget">
-      {/* Header */}
-      <div className="mb-4 flex items-center gap-2">
-        <HandHeart className="h-5 w-5 text-purple-600" />
-        <h3 className="font-serif text-lg font-semibold text-gray-900">Mis Servicios</h3>
-      </div>
-
+    <WidgetCard
+      title="Mis Servicios"
+      titleAs="h3"
+      icon={<HandHeart className="h-5 w-5" />}
+      data-testid="my-services-widget"
+    >
       {/* Purchase list */}
       <div className="space-y-2">
         {visiblePurchases.map((purchase) => (
@@ -134,12 +134,12 @@ export function MyServicesWidget() {
       {/* Footer link */}
       <Link
         href={ROUTES.MIS_SERVICIOS}
-        className="mt-4 flex items-center justify-center gap-1 text-sm font-medium text-purple-600 hover:text-purple-800"
+        className="text-primary hover:text-primary/80 mt-4 flex items-center justify-center gap-1 text-sm font-medium"
         data-testid="widget-view-all-link"
       >
         {remainingCount > 0 ? `Ver todos (${purchases.length})` : 'Ver todos mis servicios'}
         <ArrowRight className="h-4 w-4" />
       </Link>
-    </Card>
+    </WidgetCard>
   );
 }

--- a/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.test.tsx
+++ b/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.test.tsx
@@ -204,8 +204,8 @@ describe('PersonalizedRitualsWidget', () => {
 
       const { container } = render(<PersonalizedRitualsWidget />, { wrapper });
 
-      // Check that icon wrapper exists
-      const iconWrapper = container.querySelector('.bg-purple-500\\/20');
+      // Check that icon wrapper exists (brand token background)
+      const iconWrapper = container.querySelector('.bg-primary\\/10');
       expect(iconWrapper).toBeInTheDocument();
     });
   });
@@ -237,6 +237,18 @@ describe('PersonalizedRitualsWidget', () => {
       expect(
         container.querySelector('[data-testid="personalized-rituals-widget"]')
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('T-DASH-003 · Encabezado unificado (WidgetCard)', () => {
+    it('renders the title as a serif heading', () => {
+      mockAuthStore('free');
+      mockRecommendationsHook(undefined);
+
+      render(<PersonalizedRitualsWidget />, { wrapper });
+
+      const heading = screen.getByRole('heading', { name: 'Rituales Recomendados para Ti' });
+      expect(heading).toHaveClass('font-serif');
     });
   });
 });

--- a/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.tsx
+++ b/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.tsx
@@ -2,6 +2,7 @@
 
 import { Sparkles, Heart, DollarSign, Shield, Brain } from 'lucide-react';
 import { Card } from '@/components/ui/card';
+import { WidgetCard } from './WidgetCard';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useRitualRecommendations } from '@/hooks/api/useRitualRecommendations';
@@ -60,14 +61,12 @@ export function PersonalizedRitualsWidget() {
   // Free user: Show upsell
   if (!isPremium) {
     return (
-      <Card
-        className="bg-gradient-to-br from-purple-500/5 to-amber-500/5 p-6"
+      <WidgetCard
+        title="Rituales Recomendados para Ti"
+        icon={<Sparkles className="h-5 w-5" />}
+        className="bg-secondary/5"
         data-testid="personalized-rituals-widget"
       >
-        <div className="mb-4 flex items-center gap-3">
-          <Sparkles className="h-6 w-6 text-amber-500" />
-          <h2 className="font-serif text-xl">Rituales Recomendados para Ti</h2>
-        </div>
         <p className="text-muted-foreground mb-4 text-sm">
           Con Premium, analizamos tus lecturas para sugerirte rituales personalizados según tu
           momento energético actual.
@@ -75,7 +74,7 @@ export function PersonalizedRitualsWidget() {
         <Button asChild>
           <Link href="/premium">Desbloquear recomendaciones</Link>
         </Button>
-      </Card>
+      </WidgetCard>
     );
   }
 
@@ -87,72 +86,67 @@ export function PersonalizedRitualsWidget() {
   // Error state
   if (isError) {
     return (
-      <Card className="p-6" data-testid="personalized-rituals-widget">
-        <div className="mb-4 flex items-center gap-3">
-          <Sparkles className="h-6 w-6 text-purple-500" />
-          <h2 className="font-serif text-xl">Rituales para Ti</h2>
-        </div>
+      <WidgetCard
+        title="Rituales para Ti"
+        icon={<Sparkles className="h-5 w-5" />}
+        data-testid="personalized-rituals-widget"
+      >
         <p className="text-sm text-red-600">
           Error al cargar recomendaciones. Inténtalo de nuevo más tarde.
         </p>
-      </Card>
+      </WidgetCard>
     );
   }
 
   // No recommendations available
   if (!data?.hasRecommendations) {
     return (
-      <Card className="p-6" data-testid="personalized-rituals-widget">
-        <div className="mb-4 flex items-center gap-3">
-          <Sparkles className="h-6 w-6 text-purple-500" />
-          <h2 className="font-serif text-xl">Rituales para Ti</h2>
-        </div>
+      <WidgetCard
+        title="Rituales para Ti"
+        icon={<Sparkles className="h-5 w-5" />}
+        data-testid="personalized-rituals-widget"
+      >
         <p className="text-muted-foreground text-sm">
           Realiza algunas lecturas más para que podamos analizar tu energía y recomendarte rituales
           personalizados.
         </p>
-      </Card>
+      </WidgetCard>
     );
   }
 
   // Show recommendations
   return (
-    <Card className="p-6" data-testid="personalized-rituals-widget">
-      <div className="mb-4 flex items-center gap-3">
-        <Sparkles className="h-6 w-6 text-purple-500" />
-        <h2 className="font-serif text-xl">Recomendado para Ti</h2>
-      </div>
+    <WidgetCard
+      title="Recomendado para Ti"
+      icon={<Sparkles className="h-5 w-5" />}
+      data-testid="personalized-rituals-widget"
+      contentClassName="space-y-4"
+    >
+      {data.recommendations.slice(0, 2).map((rec) => {
+        const Icon = PATTERN_ICONS[rec.pattern] || Sparkles;
 
-      <div className="space-y-4">
-        {data.recommendations.slice(0, 2).map((rec) => {
-          const Icon = PATTERN_ICONS[rec.pattern] || Sparkles;
-
-          return (
-            <div
-              key={rec.pattern}
-              className="rounded-lg bg-gradient-to-r from-purple-500/10 to-transparent p-4"
-            >
-              <div className="flex items-start gap-3">
-                <div className="rounded-full bg-purple-500/20 p-2">
-                  <Icon className="h-5 w-5 text-purple-600" />
-                </div>
-                <div className="flex-1">
-                  <p className="text-muted-foreground mb-2 text-sm">{rec.message}</p>
-                  <div className="flex flex-wrap gap-2">
-                    {rec.suggestedCategories.map((cat) => (
-                      <Link key={cat} href={`/rituales?category=${cat}`}>
-                        <Button variant="outline" size="sm">
-                          Ver rituales de {cat}
-                        </Button>
-                      </Link>
-                    ))}
-                  </div>
+        return (
+          <div key={rec.pattern} className="bg-primary/5 rounded-lg p-4">
+            <div className="flex items-start gap-3">
+              <div className="bg-primary/10 rounded-full p-2">
+                <Icon className="text-primary h-5 w-5" />
+              </div>
+              <div className="flex-1">
+                <p className="text-muted-foreground mb-2 text-sm">{rec.message}</p>
+                <div className="flex flex-wrap gap-2">
+                  {rec.suggestedCategories.map((cat) => (
+                    <Link key={cat} href={`/rituales?category=${cat}`}>
+                      <Button variant="outline" size="sm">
+                        Ver rituales de {cat}
+                      </Button>
+                    </Link>
+                  ))}
                 </div>
               </div>
             </div>
-          );
-        })}
-      </div>
-    </Card>
+          </div>
+        );
+      })}
+    </WidgetCard>
   );
 }

--- a/frontend/src/components/features/dashboard/QuickActions.test.tsx
+++ b/frontend/src/components/features/dashboard/QuickActions.test.tsx
@@ -124,10 +124,10 @@ describe('QuickActions', () => {
     const newReadingButton = screen.getByText('Nueva Lectura');
     const buttonElement = newReadingButton.closest('a');
 
-    // Check for primary styling classes (purple gradient)
+    // Check for primary styling classes (brand gradient using design tokens)
     expect(buttonElement).toHaveClass('bg-gradient-to-r');
-    expect(buttonElement).toHaveClass('from-purple-600');
-    expect(buttonElement).toHaveClass('to-pink-600');
+    expect(buttonElement).toHaveClass('from-primary');
+    expect(buttonElement).toHaveClass('to-primary/80');
   });
 
   it('should have secondary styling on other buttons', () => {

--- a/frontend/src/components/features/dashboard/QuickActions.test.tsx
+++ b/frontend/src/components/features/dashboard/QuickActions.test.tsx
@@ -127,7 +127,7 @@ describe('QuickActions', () => {
     // Check for primary styling classes (brand gradient using design tokens)
     expect(buttonElement).toHaveClass('bg-gradient-to-r');
     expect(buttonElement).toHaveClass('from-primary');
-    expect(buttonElement).toHaveClass('to-primary/80');
+    expect(buttonElement).toHaveClass('to-secondary');
   });
 
   it('should have secondary styling on other buttons', () => {

--- a/frontend/src/components/features/dashboard/QuickActions.tsx
+++ b/frontend/src/components/features/dashboard/QuickActions.tsx
@@ -34,7 +34,7 @@ function QuickActionCard({
         'block rounded-lg p-6 transition-all duration-200',
         'hover:scale-105 hover:shadow-lg',
         isPrimary
-          ? 'from-primary to-primary/80 bg-gradient-to-r text-white shadow-md'
+          ? 'from-primary to-secondary bg-gradient-to-r text-white shadow-md'
           : 'border-border bg-card hover:border-primary/40 border'
       )}
     >

--- a/frontend/src/components/features/dashboard/QuickActions.tsx
+++ b/frontend/src/components/features/dashboard/QuickActions.tsx
@@ -34,36 +34,29 @@ function QuickActionCard({
         'block rounded-lg p-6 transition-all duration-200',
         'hover:scale-105 hover:shadow-lg',
         isPrimary
-          ? 'bg-gradient-to-r from-purple-600 to-pink-600 text-white shadow-md'
-          : 'border border-gray-200 bg-white hover:border-purple-300 dark:border-gray-700 dark:bg-gray-800'
+          ? 'from-primary to-primary/80 bg-gradient-to-r text-white shadow-md'
+          : 'border-border bg-card hover:border-primary/40 border'
       )}
     >
       <div className="flex items-start gap-4">
         <div
           className={cn(
             'flex h-12 w-12 items-center justify-center rounded-full',
-            isPrimary ? 'bg-white/20' : 'bg-purple-100 dark:bg-purple-900/30'
+            isPrimary ? 'bg-white/20' : 'bg-primary/10'
           )}
         >
-          <div className={cn(isPrimary ? 'text-white' : 'text-purple-600 dark:text-purple-400')}>
-            {icon}
-          </div>
+          <div className={cn(isPrimary ? 'text-white' : 'text-primary')}>{icon}</div>
         </div>
         <div className="flex-1">
           <h3
             className={cn(
               'mb-1 font-serif text-xl font-semibold',
-              isPrimary ? 'text-white' : 'text-gray-900 dark:text-gray-100'
+              isPrimary ? 'text-white' : 'text-foreground'
             )}
           >
             {title}
           </h3>
-          <p
-            className={cn(
-              'text-sm',
-              isPrimary ? 'text-white/90' : 'text-gray-600 dark:text-gray-400'
-            )}
-          >
+          <p className={cn('text-sm', isPrimary ? 'text-white/90' : 'text-muted-foreground')}>
             {description}
           </p>
         </div>

--- a/frontend/src/components/features/dashboard/SacredEventsWidget.test.tsx
+++ b/frontend/src/components/features/dashboard/SacredEventsWidget.test.tsx
@@ -422,4 +422,13 @@ describe('SacredEventsWidget', () => {
       expect(link).toHaveAttribute('href', '/premium');
     });
   });
+
+  describe('T-DASH-003 · Encabezado unificado (WidgetCard)', () => {
+    it('renders the title as a serif heading', () => {
+      renderComponent();
+
+      const heading = screen.getByRole('heading', { name: 'Calendario Sagrado' });
+      expect(heading).toHaveClass('font-serif');
+    });
+  });
 });

--- a/frontend/src/components/features/dashboard/SacredEventsWidget.tsx
+++ b/frontend/src/components/features/dashboard/SacredEventsWidget.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { CalendarHeart, Moon, Sun, Sparkles, ChevronRight } from 'lucide-react';
-import { Card } from '@/components/ui/card';
+import { WidgetCard } from './WidgetCard';
 import { Badge } from '@/components/ui/badge';
 import { Spinner } from '@/components/ui/spinner';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -59,24 +59,26 @@ const EventItem = ({ event, showDate = false }: EventItemProps) => {
   const importanceInfo = IMPORTANCE_INFO[event.importance];
 
   return (
-    <div className="flex items-start justify-between gap-3 rounded-lg border border-gray-200 bg-white p-3 transition-colors hover:border-purple-300">
+    <div className="border-border bg-card hover:border-primary/40 flex items-start justify-between gap-3 rounded-lg border p-3 transition-colors">
       <div className="flex flex-1 items-start gap-3">
         <div className="mt-0.5">
-          <Icon className="h-5 w-5 text-purple-600" />
+          <Icon className="text-secondary h-5 w-5" />
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
-            <h4 className="text-sm font-medium text-gray-900">{event.name}</h4>
+            <h4 className="text-foreground text-sm font-medium">{event.name}</h4>
             <Badge variant="secondary" className={importanceInfo.color}>
               {getImportanceBadgeText(event.importance)}
             </Badge>
           </div>
-          {showDate && <p className="mt-1 text-xs text-gray-500">{getDaysUntilLabel(daysUntil)}</p>}
+          {showDate && (
+            <p className="text-muted-foreground mt-1 text-xs">{getDaysUntilLabel(daysUntil)}</p>
+          )}
         </div>
       </div>
       <Link
         href={`/rituales?event=${event.eventType}`}
-        className="flex items-center gap-1 text-xs font-medium whitespace-nowrap text-purple-600 hover:text-purple-700"
+        className="text-primary hover:text-primary/80 flex items-center gap-1 text-xs font-medium whitespace-nowrap"
       >
         Ver rituales
         <ChevronRight className="h-3 w-3" />
@@ -114,24 +116,23 @@ export function SacredEventsWidget() {
   const hasAnyEvents = hasTodayEvents || hasUpcomingEvents;
 
   return (
-    <Card className="p-6" data-testid="sacred-events-widget">
-      {/* Header */}
-      <div className="mb-4 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <CalendarHeart className="h-5 w-5 text-purple-600" />
-          <h3 className="text-lg font-semibold text-gray-900">Calendario Sagrado</h3>
-        </div>
-        {isPremium && (
+    <WidgetCard
+      title="Calendario Sagrado"
+      titleAs="h3"
+      icon={<CalendarHeart className="h-5 w-5" />}
+      data-testid="sacred-events-widget"
+      action={
+        isPremium && (
           <Link
             href="/rituales"
-            className="flex items-center gap-1 text-sm font-medium text-purple-600 hover:text-purple-700"
+            className="text-primary hover:text-primary/80 flex items-center gap-1 text-sm font-medium"
           >
             Ver todo
             <ChevronRight className="h-4 w-4" />
           </Link>
-        )}
-      </div>
-
+        )
+      }
+    >
       {/* Loading State */}
       {isLoading && (
         <div className="py-8">
@@ -166,8 +167,8 @@ export function SacredEventsWidget() {
           {/* Today Events */}
           {hasTodayEvents && (
             <div>
-              <h4 className="mb-3 flex items-center gap-2 text-sm font-medium text-gray-700">
-                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-purple-100 text-xs font-semibold text-purple-700">
+              <h4 className="text-foreground mb-3 flex items-center gap-2 text-sm font-medium">
+                <span className="bg-primary/10 text-primary inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold">
                   !
                 </span>
                 Hoy
@@ -184,7 +185,7 @@ export function SacredEventsWidget() {
           {hasUpcomingEvents && (
             <div>
               {hasTodayEvents && (
-                <h4 className="mt-4 mb-3 text-sm font-medium text-gray-700">Próximos eventos</h4>
+                <h4 className="text-foreground mt-4 mb-3 text-sm font-medium">Próximos eventos</h4>
               )}
               <div className="space-y-2">
                 {upcomingEvents.map((event) => (
@@ -198,7 +199,7 @@ export function SacredEventsWidget() {
 
       {/* Premium Upsell for Free Users */}
       {!isPremium && !isLoading && (
-        <div className="mt-4 border-t border-gray-200 pt-4">
+        <div className="border-border mt-4 border-t pt-4">
           <PremiumUpsellCard
             title="Desbloquea el calendario completo"
             description="Accede a todos los eventos sagrados del año y planifica tus rituales con anticipación."
@@ -207,6 +208,6 @@ export function SacredEventsWidget() {
           />
         </div>
       )}
-    </Card>
+    </WidgetCard>
   );
 }

--- a/frontend/src/components/features/dashboard/StatsSection.tsx
+++ b/frontend/src/components/features/dashboard/StatsSection.tsx
@@ -2,9 +2,9 @@
 
 import { BarChart3, BookOpen } from 'lucide-react';
 import { useUserCapabilities } from '@/hooks/api/useUserCapabilities';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ErrorDisplay } from '@/components/ui/error-display';
+import { WidgetCard } from './WidgetCard';
 
 /**
  * Stat card component
@@ -18,14 +18,14 @@ interface StatCardProps {
 
 function StatCard({ icon, label, value, description }: StatCardProps) {
   return (
-    <div className="flex items-start gap-3 rounded-lg border border-gray-200 p-4">
-      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-purple-100">
-        <div className="text-purple-600">{icon}</div>
+    <div className="border-border flex items-start gap-3 rounded-lg border p-4">
+      <div className="bg-secondary/15 flex h-10 w-10 items-center justify-center rounded-full">
+        <div className="text-secondary">{icon}</div>
       </div>
       <div className="flex-1">
-        <p className="text-sm text-gray-600">{label}</p>
-        <p className="text-2xl font-bold text-gray-900">{value}</p>
-        {description && <p className="mt-1 text-xs text-gray-500">{description}</p>}
+        <p className="text-muted-foreground text-sm">{label}</p>
+        <p className="text-foreground text-2xl font-bold">{value}</p>
+        {description && <p className="text-muted-foreground mt-1 text-xs">{description}</p>}
       </div>
     </div>
   );
@@ -49,32 +49,24 @@ export function StatsSection() {
 
   if (isLoading) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="font-serif text-xl">Tus Estadísticas</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4" data-testid="stats-loading">
+      <WidgetCard title="Tus Estadísticas" icon={<BarChart3 className="h-5 w-5" />}>
+        <div className="space-y-4" data-testid="stats-loading">
           <Skeleton className="h-20 w-full" />
           <Skeleton className="h-20 w-full" />
-        </CardContent>
-      </Card>
+        </div>
+      </WidgetCard>
     );
   }
 
   if (error) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="font-serif text-xl">Tus Estadísticas</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <ErrorDisplay
-            data-testid="retry-button"
-            message="No pudimos cargar tus estadísticas. Por favor, intenta nuevamente."
-            onRetry={() => refetch()}
-          />
-        </CardContent>
-      </Card>
+      <WidgetCard title="Tus Estadísticas" icon={<BarChart3 className="h-5 w-5" />}>
+        <ErrorDisplay
+          data-testid="retry-button"
+          message="No pudimos cargar tus estadísticas. Por favor, intenta nuevamente."
+          onRetry={() => refetch()}
+        />
+      </WidgetCard>
     );
   }
 
@@ -87,25 +79,21 @@ export function StatsSection() {
   const remaining = dailyReadingsLimit - dailyReadingsCount;
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <CardTitle className="font-serif text-xl">Tus Estadísticas</CardTitle>
-          <BarChart3 className="h-5 w-5 text-purple-600" />
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <StatCard
-          icon={<BookOpen className="h-5 w-5" />}
-          label="Lecturas de Hoy"
-          value={`${dailyReadingsCount} / ${dailyReadingsLimit}`}
-          description={
-            remaining > 0
-              ? `Te quedan ${remaining} ${remaining === 1 ? 'lectura' : 'lecturas'} hoy`
-              : 'Has alcanzado tu límite diario'
-          }
-        />
-      </CardContent>
-    </Card>
+    <WidgetCard
+      title="Tus Estadísticas"
+      icon={<BarChart3 className="h-5 w-5" />}
+      contentClassName="space-y-4"
+    >
+      <StatCard
+        icon={<BookOpen className="h-5 w-5" />}
+        label="Lecturas de Hoy"
+        value={`${dailyReadingsCount} / ${dailyReadingsLimit}`}
+        description={
+          remaining > 0
+            ? `Te quedan ${remaining} ${remaining === 1 ? 'lectura' : 'lecturas'} hoy`
+            : 'Has alcanzado tu límite diario'
+        }
+      />
+    </WidgetCard>
   );
 }

--- a/frontend/src/components/features/dashboard/WidgetCard.test.tsx
+++ b/frontend/src/components/features/dashboard/WidgetCard.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Sparkles } from 'lucide-react';
+
+import { WidgetCard } from './WidgetCard';
+
+describe('WidgetCard', () => {
+  it('renders the title as a serif heading', () => {
+    render(<WidgetCard title="Mi Widget">Contenido</WidgetCard>);
+
+    const heading = screen.getByRole('heading', { name: 'Mi Widget' });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveClass('font-serif');
+  });
+
+  it('renders as an h2 heading by default and honours titleAs', () => {
+    const { rerender } = render(<WidgetCard title="Titulo">Contenido</WidgetCard>);
+    expect(screen.getByRole('heading', { name: 'Titulo', level: 2 })).toBeInTheDocument();
+
+    rerender(
+      <WidgetCard title="Titulo" titleAs="h3">
+        Contenido
+      </WidgetCard>
+    );
+    expect(screen.getByRole('heading', { name: 'Titulo', level: 3 })).toBeInTheDocument();
+  });
+
+  it('renders the icon inside a gold-accented (secondary) slot', () => {
+    render(
+      <WidgetCard title="Con icono" icon={<Sparkles data-testid="widget-icon" />}>
+        Contenido
+      </WidgetCard>
+    );
+
+    const icon = screen.getByTestId('widget-icon');
+    expect(icon).toBeInTheDocument();
+    // The icon slot carries the gold brand accent token.
+    expect(icon.parentElement).toHaveClass('text-secondary');
+  });
+
+  it('renders the optional action node', () => {
+    render(
+      <WidgetCard title="Con accion" action={<a href="/mas">Ver más</a>}>
+        Contenido
+      </WidgetCard>
+    );
+
+    expect(screen.getByRole('link', { name: 'Ver más' })).toBeInTheDocument();
+  });
+
+  it('renders children content', () => {
+    render(
+      <WidgetCard title="Con contenido">
+        <p>Cuerpo del widget</p>
+      </WidgetCard>
+    );
+
+    expect(screen.getByText('Cuerpo del widget')).toBeInTheDocument();
+  });
+
+  it('forwards data-testid to the card container', () => {
+    render(
+      <WidgetCard title="Testable" data-testid="mi-widget">
+        Contenido
+      </WidgetCard>
+    );
+
+    expect(screen.getByTestId('mi-widget')).toBeInTheDocument();
+  });
+
+  it('applies additional className to the card container', () => {
+    render(
+      <WidgetCard title="Con clase" data-testid="con-clase" className="custom-class">
+        Contenido
+      </WidgetCard>
+    );
+
+    expect(screen.getByTestId('con-clase')).toHaveClass('custom-class');
+  });
+
+  it('does not render a header icon slot when no icon is provided', () => {
+    render(
+      <WidgetCard title="Sin icono" data-testid="sin-icono">
+        Contenido
+      </WidgetCard>
+    );
+
+    // Only the heading should be present in the header, no empty accent slot.
+    expect(screen.queryByTestId('sin-icono')?.querySelector('.text-secondary')).toBeNull();
+  });
+});

--- a/frontend/src/components/features/dashboard/WidgetCard.tsx
+++ b/frontend/src/components/features/dashboard/WidgetCard.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+/**
+ * WidgetCard — contenedor común para los widgets del dashboard (T-DASH-003).
+ *
+ * Unifica el "tratamiento de tarjeta" de todos los widgets del home para que se
+ * lean como un sistema y no como piezas sueltas (hallazgo DASH-003):
+ *
+ * - Tarjeta de marca: primitiva `Card` de shadcn con padding `p-6`.
+ * - Encabezado estandarizado: slot de ícono con **acento dorado** (`text-secondary`),
+ *   título en `font-serif` (Cormorant) y una acción opcional a la derecha
+ *   ("Ver más" / "Ver todo").
+ * - Solo tokens de marca; sin grises hardcodeados ni clases `dark:`.
+ *
+ * El ícono se recibe sin clase de color (ej. `<CalendarHeart className="h-5 w-5" />`);
+ * el propio `WidgetCard` le aplica el acento dorado a través del slot contenedor.
+ *
+ * @example
+ * ```tsx
+ * <WidgetCard
+ *   title="Calendario Sagrado"
+ *   icon={<CalendarHeart className="h-5 w-5" />}
+ *   action={<Link href="/rituales">Ver todo</Link>}
+ *   data-testid="sacred-events-widget"
+ * >
+ *   {content}
+ * </WidgetCard>
+ * ```
+ */
+export interface WidgetCardProps {
+  /** Título del widget (se renderiza con `font-serif`). */
+  title: string;
+  /** Ícono opcional del encabezado (sin clase de color: hereda el acento dorado). */
+  icon?: React.ReactNode;
+  /** Acción opcional a la derecha del encabezado (ej. enlace "Ver más"). */
+  action?: React.ReactNode;
+  /** Nivel semántico del título. Por defecto `h2`. */
+  titleAs?: 'h2' | 'h3';
+  /** Clases adicionales para el contenedor `Card`. */
+  className?: string;
+  /** Clases adicionales para el contenedor del cuerpo. */
+  contentClassName?: string;
+  /** Identificador para tests, reenviado al contenedor `Card`. */
+  'data-testid'?: string;
+  /** Contenido del widget. */
+  children: React.ReactNode;
+}
+
+export function WidgetCard({
+  title,
+  icon,
+  action,
+  titleAs: TitleTag = 'h2',
+  className,
+  contentClassName,
+  'data-testid': dataTestId,
+  children,
+}: WidgetCardProps) {
+  return (
+    <Card className={cn('p-6', className)} data-testid={dataTestId}>
+      <div className="mb-4 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          {icon && <span className="text-secondary flex items-center">{icon}</span>}
+          <TitleTag className="text-card-foreground font-serif text-xl">{title}</TitleTag>
+        </div>
+        {action}
+      </div>
+      <div className={contentClassName}>{children}</div>
+    </Card>
+  );
+}

--- a/frontend/src/components/features/dashboard/index.ts
+++ b/frontend/src/components/features/dashboard/index.ts
@@ -5,6 +5,8 @@
  */
 
 export { DashboardHero } from './DashboardHero';
+export { WidgetCard } from './WidgetCard';
+export type { WidgetCardProps } from './WidgetCard';
 export { QuickActions } from './QuickActions';
 export { DidYouKnowSection } from './DidYouKnowSection';
 export { StatsSection } from './StatsSection';

--- a/frontend/src/components/features/numerology/NumerologyWidget.test.tsx
+++ b/frontend/src/components/features/numerology/NumerologyWidget.test.tsx
@@ -434,4 +434,16 @@ describe('NumerologyWidget', () => {
       expect(screen.getByRole('link', { name: /ver informe completo/i })).toBeInTheDocument();
     });
   });
+
+  describe('T-DASH-003 · Encabezado unificado (WidgetCard)', () => {
+    it('renders the title as a serif heading', () => {
+      mockUseMyNumerologyProfile.mockReturnValue({ data: null, isLoading: false, error: null });
+      mockUseDayNumber.mockReturnValue({ data: null, isLoading: false, error: null });
+
+      render(<NumerologyWidget />);
+
+      const heading = screen.getByRole('heading', { name: 'Tu Numerología' });
+      expect(heading).toHaveClass('font-serif');
+    });
+  });
 });

--- a/frontend/src/components/features/numerology/NumerologyWidget.tsx
+++ b/frontend/src/components/features/numerology/NumerologyWidget.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import Link from 'next/link';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Hash, Settings } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Settings } from 'lucide-react';
+import { WidgetCard } from '@/components/features/dashboard/WidgetCard';
 import { useMyNumerologyProfile, useDayNumber } from '@/hooks/api/useNumerology';
 import { NUMEROLOGY_NUMBERS_INFO } from '@/lib/utils/numerology';
 import { cn } from '@/lib/utils';
@@ -34,100 +35,104 @@ export function NumerologyWidget() {
   // No data state (no profile)
   if (!profile) {
     return (
-      <Card data-testid="numerology-widget-no-data">
-        <CardHeader>
-          <CardTitle>Tu Numerología</CardTitle>
-        </CardHeader>
-        <CardContent className="py-8 text-center">
-          <p className="mb-4 text-gray-600">
-            Configura tu fecha de nacimiento para ver tu perfil numerológico
-          </p>
-          <Button asChild size="sm">
-            <Link href={ROUTES.PERFIL}>
-              <Settings className="mr-2 h-4 w-4" />
-              Configurar
-            </Link>
-          </Button>
-        </CardContent>
-      </Card>
+      <WidgetCard
+        title="Tu Numerología"
+        icon={<Hash className="h-5 w-5" />}
+        data-testid="numerology-widget-no-data"
+        contentClassName="py-8 text-center"
+      >
+        <p className="text-muted-foreground mb-4">
+          Configura tu fecha de nacimiento para ver tu perfil numerológico
+        </p>
+        <Button asChild size="sm">
+          <Link href={ROUTES.PERFIL}>
+            <Settings className="mr-2 h-4 w-4" />
+            Configurar
+          </Link>
+        </Button>
+      </WidgetCard>
     );
   }
 
   // Success state
   const lifePathInfo = NUMEROLOGY_NUMBERS_INFO[profile.lifePath.value] || {
     emoji: '🔢',
-    color: 'text-gray-500',
+    color: 'text-muted-foreground',
   };
 
   const isMasterLifePath = profile.lifePath.isMaster;
 
   return (
-    <Card data-testid="numerology-widget">
-      <CardHeader>
-        <CardTitle>Tu Numerología</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {/* Life Path Number */}
-        <div className="rounded-lg border border-purple-200 bg-gradient-to-br from-purple-50 to-indigo-50 p-4">
-          <div className="flex items-center gap-3">
-            <div className="text-4xl">{lifePathInfo.emoji}</div>
-            <div className="flex-1">
-              <div className="text-sm font-medium text-gray-600 uppercase">Camino de Vida</div>
-              <div className={cn('text-3xl font-bold', lifePathInfo.color)}>
-                {profile.lifePath.value}
+    <WidgetCard
+      title="Tu Numerología"
+      icon={<Hash className="h-5 w-5" />}
+      data-testid="numerology-widget"
+      contentClassName="space-y-4"
+    >
+      {/* Life Path Number */}
+      <div className="border-primary/20 bg-primary/5 rounded-lg border p-4">
+        <div className="flex items-center gap-3">
+          <div className="text-4xl">{lifePathInfo.emoji}</div>
+          <div className="flex-1">
+            <div className="text-muted-foreground text-sm font-medium uppercase">
+              Camino de Vida
+            </div>
+            <div className={cn('text-3xl font-bold', lifePathInfo.color)}>
+              {profile.lifePath.value}
+            </div>
+            <div className="text-foreground text-sm font-semibold">{profile.lifePath.name}</div>
+            {isMasterLifePath && (
+              <div className="bg-secondary/15 text-secondary mt-1 inline-block rounded-full px-2 py-0.5 text-xs font-semibold">
+                ⭐ Maestro
               </div>
-              <div className="text-sm font-semibold text-gray-700">{profile.lifePath.name}</div>
-              {isMasterLifePath && (
-                <div className="mt-1 inline-block rounded-full bg-purple-100 px-2 py-0.5 text-xs font-semibold text-purple-600">
-                  ⭐ Maestro
-                </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Day Number */}
+      {dayNumber && (
+        <div className="rounded-lg border p-4">
+          <div className="flex items-start gap-3">
+            <div className="text-3xl">
+              {NUMEROLOGY_NUMBERS_INFO[dayNumber.dayNumber]?.emoji || '📅'}
+            </div>
+            <div className="flex-1">
+              <div className="text-muted-foreground text-sm font-medium uppercase">
+                Número del Día
+              </div>
+              <div
+                className={cn(
+                  'text-2xl font-bold',
+                  NUMEROLOGY_NUMBERS_INFO[dayNumber.dayNumber]?.color || 'text-foreground'
+                )}
+              >
+                {dayNumber.dayNumber}
+              </div>
+              {dayNumber.meaning && (
+                <>
+                  <div className="text-foreground mt-1 text-sm font-medium">
+                    {dayNumber.meaning.name}
+                  </div>
+                  {[11, 22, 33].includes(dayNumber.dayNumber) && (
+                    <div className="bg-secondary/15 text-secondary mt-1 inline-block rounded-full px-2 py-0.5 text-xs font-semibold">
+                      ⭐ Maestro
+                    </div>
+                  )}
+                  <p className="text-muted-foreground mt-2 line-clamp-2 text-xs">
+                    {dayNumber.meaning.description}
+                  </p>
+                </>
               )}
             </div>
           </div>
         </div>
+      )}
 
-        {/* Day Number */}
-        {dayNumber && (
-          <div className="rounded-lg border p-4">
-            <div className="flex items-start gap-3">
-              <div className="text-3xl">
-                {NUMEROLOGY_NUMBERS_INFO[dayNumber.dayNumber]?.emoji || '📅'}
-              </div>
-              <div className="flex-1">
-                <div className="text-sm font-medium text-gray-600 uppercase">Número del Día</div>
-                <div
-                  className={cn(
-                    'text-2xl font-bold',
-                    NUMEROLOGY_NUMBERS_INFO[dayNumber.dayNumber]?.color || 'text-gray-700'
-                  )}
-                >
-                  {dayNumber.dayNumber}
-                </div>
-                {dayNumber.meaning && (
-                  <>
-                    <div className="mt-1 text-sm font-medium text-gray-700">
-                      {dayNumber.meaning.name}
-                    </div>
-                    {[11, 22, 33].includes(dayNumber.dayNumber) && (
-                      <div className="mt-1 inline-block rounded-full bg-purple-100 px-2 py-0.5 text-xs font-semibold text-purple-600">
-                        ⭐ Maestro
-                      </div>
-                    )}
-                    <p className="mt-2 line-clamp-2 text-xs text-gray-600">
-                      {dayNumber.meaning.description}
-                    </p>
-                  </>
-                )}
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Link to full profile */}
-        <Button asChild variant="outline" className="w-full" size="sm">
-          <Link href={ROUTES.NUMEROLOGIA}>Ver informe completo</Link>
-        </Button>
-      </CardContent>
-    </Card>
+      {/* Link to full profile */}
+      <Button asChild variant="outline" className="w-full" size="sm">
+        <Link href={ROUTES.NUMEROLOGIA}>Ver informe completo</Link>
+      </Button>
+    </WidgetCard>
   );
 }

--- a/frontend/src/components/features/readings/UpgradeBanner.test.tsx
+++ b/frontend/src/components/features/readings/UpgradeBanner.test.tsx
@@ -72,7 +72,7 @@ describe('UpgradeBanner', () => {
 
     const banner = container.firstChild as HTMLElement;
     expect(banner.className).toMatch(/from-primary/);
-    expect(banner.className).toMatch(/to-primary\/80/);
+    expect(banner.className).toMatch(/to-secondary/);
   });
 
   it('should render the title with the serif brand typography', () => {

--- a/frontend/src/components/features/readings/UpgradeBanner.test.tsx
+++ b/frontend/src/components/features/readings/UpgradeBanner.test.tsx
@@ -67,12 +67,21 @@ describe('UpgradeBanner', () => {
     expect(icon).toBeInTheDocument();
   });
 
-  it('should have purple-pink gradient styles', () => {
+  it('should have brand gradient styles using design tokens', () => {
     const { container } = render(<UpgradeBanner />);
 
     const banner = container.firstChild as HTMLElement;
-    expect(banner.className).toMatch(/from-purple-500/);
-    expect(banner.className).toMatch(/to-pink-500/);
+    expect(banner.className).toMatch(/from-primary/);
+    expect(banner.className).toMatch(/to-primary\/80/);
+  });
+
+  it('should render the title with the serif brand typography', () => {
+    render(<UpgradeBanner />);
+
+    const title = screen.getByRole('heading', {
+      name: /Desbloquea interpretaciones personalizadas/i,
+    });
+    expect(title).toHaveClass('font-serif');
   });
 
   it('should have rounded border style', () => {

--- a/frontend/src/components/features/readings/UpgradeBanner.tsx
+++ b/frontend/src/components/features/readings/UpgradeBanner.tsx
@@ -32,7 +32,7 @@ export default function UpgradeBanner() {
   return (
     <div
       data-testid="upgrade-banner"
-      className="from-primary to-primary/80 rounded-lg bg-gradient-to-r p-6 text-white shadow-lg"
+      className="from-primary to-secondary rounded-lg bg-gradient-to-r p-6 text-white shadow-lg"
     >
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-start gap-3">

--- a/frontend/src/components/features/readings/UpgradeBanner.tsx
+++ b/frontend/src/components/features/readings/UpgradeBanner.tsx
@@ -32,13 +32,15 @@ export default function UpgradeBanner() {
   return (
     <div
       data-testid="upgrade-banner"
-      className="rounded-lg bg-gradient-to-r from-purple-500 to-pink-500 p-6 text-white shadow-lg"
+      className="from-primary to-primary/80 rounded-lg bg-gradient-to-r p-6 text-white shadow-lg"
     >
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-start gap-3">
           <Gem className="mt-1 h-6 w-6 flex-shrink-0" />
           <div>
-            <h3 className="mb-1 font-semibold">💎 Desbloquea interpretaciones personalizadas</h3>
+            <h3 className="mb-1 font-serif text-lg font-semibold">
+              💎 Desbloquea interpretaciones personalizadas
+            </h3>
             <p className="text-sm text-white/90">
               Con Premium, obtén análisis detallados, lecturas ilimitadas y acceso a todas las
               tiradas especiales.
@@ -49,7 +51,7 @@ export default function UpgradeBanner() {
           onClick={handleUpgradeClick}
           disabled={isPending}
           variant="secondary"
-          className="flex-shrink-0 bg-white text-purple-600 hover:bg-white/90"
+          className="text-primary flex-shrink-0 bg-white hover:bg-white/90"
         >
           {isPending ? 'Cargando...' : CTA_PREMIUM.UPSELL_SOFT}
         </Button>


### PR DESCRIPTION
## Resumen

Implementa **T-DASH-003** (cubre el hallazgo **DASH-003 — Inconsistencia visual entre widgets**). Unifica el tratamiento de las tarjetas del home para que se lean como un sistema y no como piezas sueltas.

## Cambios

- **Nuevo componente compartido `WidgetCard`** (`components/features/dashboard/WidgetCard.tsx`):
  - `Card` de shadcn + encabezado estandarizado: slot de ícono con **acento dorado** (`text-secondary`), título `font-serif text-xl` (nivel `h2`/`h3` configurable) y acción opcional ("Ver más"/"Ver todo").
  - Reenvía `data-testid` y `className`; solo tokens de marca.
- **Migrados a `WidgetCard`** (sin tocar lógica de datos ni `data-testid`): `NumerologyWidget`, `SacredEventsWidget`, `MyServicesWidget`, `PersonalizedRitualsWidget`, `StatsSection`, `DidYouKnowSection`.
- **Normalización de tipografía:** `NumerologyWidget` y `UpgradeBanner` ahora usan `font-serif` en el título.
- **Tokens + `dark:`:** reemplazados grises/acentos hardcodeados por tokens (`text-foreground`, `text-muted-foreground`, `primary`, `secondary`) y **eliminadas todas las clases `dark:`** del dashboard (`QuickActions`, `DidYouKnowSection`).
- `HoroscopeWidget` / `ChineseHoroscopeWidget` **ya cumplían el canon** (título serif + solo colores semánticos, sin `dark:`): auditados y dejados sin cambios.
- Se **conservan los colores semánticos** de estado (verde confirmado / ámbar pendiente / rojo / rosa en `STATUS_CONFIG` e `IMPORTANCE_INFO`, colores por número de numerología, scores de horóscopo).

## Criterios de aceptación

- [x] Dos widgets cualesquiera comparten el mismo tratamiento (radio, borde, encabezado ícono + título Cormorant + acento dorado) y escala tipográfica.
- [x] Sin clases `dark:` ni grises de marca hardcodeados donde existe un token.
- [x] Ciclo de calidad frontend completo pasa.

## Tests

- Nuevo `WidgetCard.test.tsx` (8 tests: heading serif, nivel `h2`/`h3`, slot dorado del ícono, acción, `data-testid`, `className`).
- Tests de regresión de encabezado serif por widget migrado.
- Suite completa: **404 archivos / 5035 tests** en verde. Coverage de archivos tocados ≥ 85% (WidgetCard/QuickActions/StatsSection/DidYouKnow/UpgradeBanner 100%).

## Validaciones

- [x] `npm run format`
- [x] `npm run lint:fix` (0 errores; 7 warnings preexistentes en archivos no tocados)
- [x] `npm run type-check`
- [x] `npm run test:run` (5035 tests OK)
- [x] `npm run test:coverage` (archivos tocados ≥ 85%)
- [x] `npm run build`
- [x] `node scripts/validate-architecture.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)