### PR TITLE
feat(dashboard): empty states ilustrados y consistentes (T-DASH-005)

### DIFF
--- a/docs/BACKLOG_DASHBOARD_REDISENO_2026_06.md
+++ b/docs/BACKLOG_DASHBOARD_REDISENO_2026_06.md
@@ -319,7 +319,7 @@ El rediseño introduce fondo oscuro (banda) e imágenes; hay que garantizar cont
 | T-DASH-002 | Banda de bienvenida mística (`DashboardHero`) reutilizando el canon         | Frontend | 🟠 Alta    | 2.5 pts    |
 | T-DASH-003 | Tarjeta de widget común + normalización de tokens (quitar `dark:`/grises)   | Frontend | 🟡 Media   | 2.5 pts    |
 | T-DASH-004 | ✅ Generación y optimización de assets del dashboard (WebP)                 | Assets   | 🟠 Alta    | 2 pts      |
-| T-DASH-005 | Empty states ilustrados y consistentes                                      | Frontend | 🟡 Media   | 2 pts      |
+| T-DASH-005 | ✅ Empty states ilustrados y consistentes                                   | Frontend | 🟡 Media   | 2 pts      |
 | T-DASH-006 | Micro-interacciones + `Reveal` escalonado (componentes compartidos)         | Frontend | 🟢 Baja    | 1.5 pts    |
 | T-DASH-007 | Accesibilidad del home (AA en banda, `alt`, foco, reduced-motion)           | Frontend | 🟡 Media   | 1.5 pts    |
 
@@ -483,24 +483,38 @@ Reemplazar el layout 2/3 + 1/3 de `UserDashboard` por una distribución que use 
 **Estimación:** 2 puntos
 **Dependencias:** T-DASH-003, T-DASH-004
 **Cubre Hallazgo:** DASH-005
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] Sub-componente de empty state reutilizable (ilustración/ícono + título + texto + CTA).
-- [ ] Aplicarlo en Calendario Sagrado, Rituales, Horóscopo (sin fecha) y Numerología (sin perfil).
-- [ ] Conservar condiciones de negocio (loading/error/empty) y CTAs existentes.
-- [ ] Tests (render del empty state + CTA con href correcto + foco).
-- [ ] Coverage ≥ 80%.
+- [x] Sub-componente de empty state reutilizable (ilustración/ícono + título + texto + CTA).
+- [x] Aplicarlo en Calendario Sagrado, Rituales, Horóscopo (sin fecha) y Numerología (sin perfil).
+- [x] Conservar condiciones de negocio (loading/error/empty) y CTAs existentes.
+- [x] Tests (render del empty state + CTA con href correcto + foco).
+- [x] Coverage ≥ 80%.
 
 #### 🎯 Criterios de Aceptación
 
-- Los estados vacíos se ven cuidados y consistentes, con CTA claro y accesible.
-- Ciclo de calidad frontend completo pasa.
+- [x] Los estados vacíos se ven cuidados y consistentes, con CTA claro y accesible.
+- [x] Ciclo de calidad frontend completo pasa.
 
 #### 📁 Archivos involucrados
 
-- widgets afectados + nuevo sub-componente de empty state + tests
+- `frontend/src/components/features/dashboard/WidgetEmptyState.tsx` (nuevo sub-componente)
+- `frontend/src/components/features/dashboard/WidgetEmptyState.test.tsx` (nuevo, 13 tests, 100% cobertura)
+- `frontend/src/components/features/dashboard/index.ts` (export del sub-componente)
+- `frontend/src/components/features/dashboard/SacredEventsWidget.tsx` (empty state → `empty-calendar.webp` + CTA "Explorar rituales")
+- `frontend/src/components/features/dashboard/PersonalizedRitualsWidget.tsx` (empty state → `empty-rituals.webp` + CTA "Hacer una lectura")
+- `frontend/src/components/features/horoscope/HoroscopeWidget.tsx` (sin fecha → ícono dorado + CTA "Configurar")
+- `frontend/src/components/features/numerology/NumerologyWidget.tsx` (sin perfil → ícono dorado + CTA "Configurar")
+- Tests de los 4 widgets actualizados (render del empty state + CTA con href correcto)
+
+#### 📝 Notas de implementación
+
+- **Sub-componente `WidgetEmptyState`:** compone ilustración de marca (asset WebP de T-DASH-004) **o** ícono Lucide con acento dorado (`text-secondary`) cuando no hay ilustración dedicada, + título `font-serif` + mensaje atenuado + CTA opcional como enlace accesible (foco visible heredado de la primitiva `Button`).
+- **Se conservan las condiciones de negocio:** cada widget sigue resolviendo loading/error/empty; solo se enriqueció la presentación de la rama vacía. Se mantuvieron los textos y hrefs existentes (`/perfil` en Horóscopo/Numerología).
+- **Assets:** Calendario → `empty-calendar.webp`; Rituales → `empty-rituals.webp`. Horóscopo y Numerología usan íconos Lucide (`Sparkles`/`Hash`) con acento dorado (no había asset dedicado).
+- **A11y:** `alt` en español por ilustración; CTA con foco visible. Prepara terreno para T-DASH-007.
 
 ---
 

--- a/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.test.tsx
+++ b/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.test.tsx
@@ -110,6 +110,23 @@ describe('PersonalizedRitualsWidget', () => {
       ).toBeInTheDocument();
     });
 
+    it('should render an illustrated empty state with an accessible CTA (T-DASH-005)', () => {
+      mockAuthStore('premium');
+      mockRecommendationsHook({ hasRecommendations: false, recommendations: [] });
+
+      render(<PersonalizedRitualsWidget />, { wrapper });
+
+      // Título del estado vacío + ilustración de marca con alt en español
+      expect(screen.getByText('Aún no hay recomendaciones')).toBeInTheDocument();
+      expect(
+        screen.getByAltText('Altar ritual con velas y elementos místicos en tonos violeta y dorado')
+      ).toBeInTheDocument();
+
+      // CTA claro con href correcto
+      const cta = screen.getByRole('link', { name: /hacer una lectura/i });
+      expect(cta).toHaveAttribute('href', '/tarot');
+    });
+
     it('should render recommendations correctly', () => {
       mockAuthStore('premium');
       mockRecommendationsHook({

--- a/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.tsx
+++ b/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.tsx
@@ -3,11 +3,13 @@
 import { Sparkles, Heart, DollarSign, Shield, Brain } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { WidgetCard } from './WidgetCard';
+import { WidgetEmptyState } from './WidgetEmptyState';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useRitualRecommendations } from '@/hooks/api/useRitualRecommendations';
 import { useAuthStore } from '@/stores/authStore';
 import Link from 'next/link';
+import { ROUTES } from '@/lib/constants/routes';
 import type { RecommendationPattern } from '@/types';
 
 const PATTERN_ICONS: Record<RecommendationPattern, React.ComponentType<{ className?: string }>> = {
@@ -106,10 +108,15 @@ export function PersonalizedRitualsWidget() {
         icon={<Sparkles className="h-5 w-5" />}
         data-testid="personalized-rituals-widget"
       >
-        <p className="text-muted-foreground text-sm">
-          Realiza algunas lecturas más para que podamos analizar tu energía y recomendarte rituales
-          personalizados.
-        </p>
+        <WidgetEmptyState
+          illustration={{
+            src: '/images/dashboard/empty-rituals.webp',
+            alt: 'Altar ritual con velas y elementos místicos en tonos violeta y dorado',
+          }}
+          title="Aún no hay recomendaciones"
+          message="Realiza algunas lecturas más para que podamos analizar tu energía y recomendarte rituales personalizados."
+          cta={{ label: 'Hacer una lectura', href: ROUTES.TAROT }}
+        />
       </WidgetCard>
     );
   }

--- a/frontend/src/components/features/dashboard/SacredEventsWidget.test.tsx
+++ b/frontend/src/components/features/dashboard/SacredEventsWidget.test.tsx
@@ -374,6 +374,34 @@ describe('SacredEventsWidget', () => {
         screen.getByText('No hay eventos próximos en el calendario sagrado.')
       ).toBeInTheDocument();
     });
+
+    it('should render an illustrated empty state with an accessible CTA (T-DASH-005)', () => {
+      vi.spyOn(useSacredCalendarHook, 'useTodayEvents').mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      vi.spyOn(useSacredCalendarHook, 'useUpcomingEvents').mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      renderComponent();
+
+      // Título del estado vacío + ilustración de marca con alt en español
+      expect(screen.getByText('Sin eventos próximos')).toBeInTheDocument();
+      expect(
+        screen.getByAltText('Rueda del año y fases lunares sobre un fondo violeta etéreo')
+      ).toBeInTheDocument();
+
+      // CTA claro con href correcto
+      const cta = screen.getByRole('link', { name: /explorar rituales/i });
+      expect(cta).toHaveAttribute('href', '/rituales');
+    });
   });
 
   describe('Links & Navigation', () => {

--- a/frontend/src/components/features/dashboard/SacredEventsWidget.test.tsx
+++ b/frontend/src/components/features/dashboard/SacredEventsWidget.test.tsx
@@ -376,20 +376,8 @@ describe('SacredEventsWidget', () => {
     });
 
     it('should render an illustrated empty state with an accessible CTA (T-DASH-005)', () => {
-      vi.spyOn(useSacredCalendarHook, 'useTodayEvents').mockReturnValue({
-        data: [],
-        isLoading: false,
-        error: null,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-
-      vi.spyOn(useSacredCalendarHook, 'useUpcomingEvents').mockReturnValue({
-        data: [],
-        isLoading: false,
-        error: null,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-
+      // El beforeEach ya mockea usuario free + data vacía en ambos hooks,
+      // por lo que el empty state se renderiza por defecto.
       renderComponent();
 
       // Título del estado vacío + ilustración de marca con alt en español

--- a/frontend/src/components/features/dashboard/SacredEventsWidget.tsx
+++ b/frontend/src/components/features/dashboard/SacredEventsWidget.tsx
@@ -2,10 +2,11 @@
 
 import { CalendarHeart, Moon, Sun, Sparkles, ChevronRight } from 'lucide-react';
 import { WidgetCard } from './WidgetCard';
+import { WidgetEmptyState } from './WidgetEmptyState';
 import { Badge } from '@/components/ui/badge';
 import { Spinner } from '@/components/ui/spinner';
-import { EmptyState } from '@/components/ui/empty-state';
 import { ErrorDisplay } from '@/components/ui/error-display';
+import { ROUTES } from '@/lib/constants/routes';
 import { PremiumUpsellCard } from '@/components/ui/premium-upsell-card';
 import { useTodayEvents, useUpcomingEvents } from '@/hooks/api/useSacredCalendar';
 import { useAuthStore } from '@/stores/authStore';
@@ -154,9 +155,14 @@ export function SacredEventsWidget() {
 
       {/* Empty State */}
       {!isLoading && !hasError && !hasAnyEvents && (
-        <EmptyState
+        <WidgetEmptyState
+          illustration={{
+            src: '/images/dashboard/empty-calendar.webp',
+            alt: 'Rueda del año y fases lunares sobre un fondo violeta etéreo',
+          }}
           title="Sin eventos próximos"
           message="No hay eventos próximos en el calendario sagrado."
+          cta={{ label: 'Explorar rituales', href: ROUTES.RITUALES }}
           className="py-4"
         />
       )}

--- a/frontend/src/components/features/dashboard/WidgetEmptyState.test.tsx
+++ b/frontend/src/components/features/dashboard/WidgetEmptyState.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Sparkles } from 'lucide-react';
+import { WidgetEmptyState } from './WidgetEmptyState';
+
+// Next.js Image se reemplaza por un <img> plano para poder inspeccionar `src`/`alt`.
+vi.mock('next/image', () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
+}));
+
+// Next.js Link se reemplaza por un <a> plano que conserva `href` y clases.
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('WidgetEmptyState', () => {
+  describe('Renderizado básico', () => {
+    it('muestra el título y el mensaje', () => {
+      render(<WidgetEmptyState title="Sin datos" message="Todavía no hay nada por aquí." />);
+
+      expect(screen.getByText('Sin datos')).toBeInTheDocument();
+      expect(screen.getByText('Todavía no hay nada por aquí.')).toBeInTheDocument();
+    });
+
+    it('renderiza el título con tipografía serif de marca', () => {
+      render(<WidgetEmptyState title="Sin datos" message="Mensaje" />);
+
+      expect(screen.getByText('Sin datos')).toHaveClass('font-serif');
+    });
+
+    it('aplica color atenuado al mensaje', () => {
+      render(<WidgetEmptyState title="Sin datos" message="Mensaje" />);
+
+      expect(screen.getByText('Mensaje')).toHaveClass('text-muted-foreground');
+    });
+
+    it('centra el contenido en columna', () => {
+      const { container } = render(<WidgetEmptyState title="Sin datos" message="Mensaje" />);
+
+      const wrapper = container.firstChild;
+      expect(wrapper).toHaveClass('flex');
+      expect(wrapper).toHaveClass('flex-col');
+      expect(wrapper).toHaveClass('items-center');
+      expect(wrapper).toHaveClass('text-center');
+    });
+
+    it('reenvía data-testid y className al contenedor', () => {
+      render(
+        <WidgetEmptyState
+          title="Sin datos"
+          message="Mensaje"
+          className="custom-class"
+          data-testid="mi-empty"
+        />
+      );
+
+      const wrapper = screen.getByTestId('mi-empty');
+      expect(wrapper).toBeInTheDocument();
+      expect(wrapper).toHaveClass('custom-class');
+    });
+  });
+
+  describe('Ilustración e ícono', () => {
+    it('renderiza la ilustración con su texto alternativo cuando se provee', () => {
+      render(
+        <WidgetEmptyState
+          title="Sin datos"
+          message="Mensaje"
+          illustration={{ src: '/images/dashboard/empty-calendar.webp', alt: 'Rueda del año' }}
+        />
+      );
+
+      const img = screen.getByRole('img', { name: 'Rueda del año' });
+      expect(img).toHaveAttribute('src', '/images/dashboard/empty-calendar.webp');
+    });
+
+    it('renderiza el ícono con acento dorado cuando no hay ilustración', () => {
+      render(
+        <WidgetEmptyState
+          title="Sin datos"
+          message="Mensaje"
+          icon={<Sparkles data-testid="empty-icon" />}
+        />
+      );
+
+      expect(screen.getByTestId('empty-icon')).toBeInTheDocument();
+      const iconWrapper = screen.getByTestId('widget-empty-state-icon');
+      expect(iconWrapper).toHaveClass('text-secondary');
+    });
+
+    it('prioriza la ilustración sobre el ícono cuando se proveen ambos', () => {
+      render(
+        <WidgetEmptyState
+          title="Sin datos"
+          message="Mensaje"
+          illustration={{ src: '/images/dashboard/empty-rituals.webp', alt: 'Altar ritual' }}
+          icon={<Sparkles data-testid="empty-icon" />}
+        />
+      );
+
+      expect(screen.getByRole('img', { name: 'Altar ritual' })).toBeInTheDocument();
+      expect(screen.queryByTestId('empty-icon')).not.toBeInTheDocument();
+    });
+
+    it('no renderiza contenedor de ícono ni imagen cuando no se proveen', () => {
+      render(<WidgetEmptyState title="Sin datos" message="Mensaje" />);
+
+      expect(screen.queryByTestId('widget-empty-state-icon')).not.toBeInTheDocument();
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('CTA', () => {
+    it('no renderiza CTA cuando no se provee', () => {
+      render(<WidgetEmptyState title="Sin datos" message="Mensaje" />);
+
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('renderiza el CTA como enlace con el href correcto', () => {
+      render(
+        <WidgetEmptyState
+          title="Sin datos"
+          message="Mensaje"
+          cta={{ label: 'Configurar', href: '/perfil' }}
+        />
+      );
+
+      const link = screen.getByRole('link', { name: /configurar/i });
+      expect(link).toHaveAttribute('href', '/perfil');
+    });
+
+    it('el CTA es enfocable y expone estilos de foco visible', () => {
+      render(
+        <WidgetEmptyState
+          title="Sin datos"
+          message="Mensaje"
+          cta={{ label: 'Configurar', href: '/perfil' }}
+        />
+      );
+
+      const link = screen.getByRole('link', { name: /configurar/i });
+      // Estilo de foco visible heredado de la primitiva Button (focus-visible ring).
+      expect(link.className).toMatch(/focus-visible:ring/);
+
+      link.focus();
+      expect(link).toHaveFocus();
+    });
+
+    it('renderiza el ícono opcional dentro del CTA', () => {
+      render(
+        <WidgetEmptyState
+          title="Sin datos"
+          message="Mensaje"
+          cta={{ label: 'Configurar', href: '/perfil', icon: <Sparkles data-testid="cta-icon" /> }}
+        />
+      );
+
+      expect(screen.getByTestId('cta-icon')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/features/dashboard/WidgetEmptyState.tsx
+++ b/frontend/src/components/features/dashboard/WidgetEmptyState.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+// 1. React & Next.js
+import * as React from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+// 2. Components (ui → features)
+import { Button } from '@/components/ui/button';
+// 3. Utils & types
+import { cn } from '@/lib/utils';
+
+/**
+ * WidgetEmptyState — estado vacío ilustrado y consistente para los widgets del home (T-DASH-005).
+ *
+ * Unifica la presentación de los estados sin datos del dashboard (hallazgo DASH-005),
+ * que hoy caen en "solo texto". Estandariza una composición reutilizable:
+ *
+ * - **Ilustración** de marca (asset WebP de T-DASH-004) **o**, en su defecto, un
+ *   **ícono Lucide con acento dorado** (`text-secondary`) cuando el widget no tiene
+ *   ilustración dedicada.
+ * - **Título** en `font-serif` (Cormorant) + **mensaje** atenuado.
+ * - **CTA** opcional como enlace accesible (foco visible heredado de la primitiva
+ *   `Button`), coherente con los demás widgets.
+ *
+ * No decide las condiciones de negocio (loading/error/empty): los widgets siguen
+ * resolviéndolas y montan este sub-componente únicamente en su rama "vacía".
+ *
+ * @example
+ * ```tsx
+ * <WidgetEmptyState
+ *   illustration={{ src: '/images/dashboard/empty-calendar.webp', alt: 'Rueda del año' }}
+ *   title="Sin eventos próximos"
+ *   message="No hay eventos próximos en el calendario sagrado."
+ *   cta={{ label: 'Explorar rituales', href: '/rituales' }}
+ * />
+ * ```
+ */
+export interface WidgetEmptyStateIllustration {
+  /** Ruta del asset (WebP en `public/images/dashboard/`). */
+  src: string;
+  /** Texto alternativo en español (a11y). */
+  alt: string;
+}
+
+export interface WidgetEmptyStateCta {
+  /** Texto del botón (español, user-facing). */
+  label: string;
+  /** Destino del enlace (usar `ROUTES` centralizadas). */
+  href: string;
+  /** Ícono opcional que precede al texto del CTA. */
+  icon?: React.ReactNode;
+}
+
+export interface WidgetEmptyStateProps {
+  /** Ilustración de marca; tiene prioridad sobre `icon` si se proveen ambos. */
+  illustration?: WidgetEmptyStateIllustration;
+  /** Ícono Lucide (sin clase de color: hereda el acento dorado). */
+  icon?: React.ReactNode;
+  /** Título del estado vacío (se renderiza con `font-serif`). */
+  title: string;
+  /** Mensaje descriptivo (atenuado). */
+  message: string;
+  /** Acción principal opcional, renderizada como enlace accesible. */
+  cta?: WidgetEmptyStateCta;
+  /** Clases adicionales para el contenedor. */
+  className?: string;
+  /** Identificador para tests. */
+  'data-testid'?: string;
+}
+
+export function WidgetEmptyState({
+  illustration,
+  icon,
+  title,
+  message,
+  cta,
+  className,
+  'data-testid': dataTestId,
+}: WidgetEmptyStateProps) {
+  return (
+    <div
+      data-testid={dataTestId}
+      className={cn(
+        'flex flex-col items-center justify-center gap-4 px-4 py-8 text-center',
+        className
+      )}
+    >
+      {illustration ? (
+        <div className="ring-secondary/25 relative h-24 w-24 overflow-hidden rounded-full shadow-sm ring-1">
+          <Image
+            src={illustration.src}
+            alt={illustration.alt}
+            fill
+            sizes="96px"
+            className="object-cover"
+          />
+        </div>
+      ) : (
+        icon && (
+          <div
+            data-testid="widget-empty-state-icon"
+            className="bg-secondary/10 text-secondary flex h-16 w-16 items-center justify-center rounded-full [&>svg]:h-7 [&>svg]:w-7"
+          >
+            {icon}
+          </div>
+        )
+      )}
+
+      <div className="space-y-1.5">
+        <h4 className="text-card-foreground font-serif text-lg font-semibold">{title}</h4>
+        <p className="text-muted-foreground mx-auto max-w-xs text-sm">{message}</p>
+      </div>
+
+      {cta && (
+        <Button asChild size="sm" className="mt-1">
+          <Link href={cta.href}>
+            {cta.icon}
+            {cta.label}
+          </Link>
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/features/dashboard/index.ts
+++ b/frontend/src/components/features/dashboard/index.ts
@@ -7,6 +7,8 @@
 export { DashboardHero } from './DashboardHero';
 export { WidgetCard } from './WidgetCard';
 export type { WidgetCardProps } from './WidgetCard';
+export { WidgetEmptyState } from './WidgetEmptyState';
+export type { WidgetEmptyStateProps } from './WidgetEmptyState';
 export { QuickActions } from './QuickActions';
 export { DidYouKnowSection } from './DidYouKnowSection';
 export { StatsSection } from './StatsSection';

--- a/frontend/src/components/features/horoscope/HoroscopeWidget.test.tsx
+++ b/frontend/src/components/features/horoscope/HoroscopeWidget.test.tsx
@@ -102,6 +102,18 @@ describe('HoroscopeWidget', () => {
       expect(screen.getByRole('link', { name: /configurar/i })).toHaveAttribute('href', '/perfil');
     });
 
+    it('should render the illustrated empty state title (T-DASH-005)', () => {
+      mockHook({
+        isError: true,
+        errorState: 'no-birthdate',
+        error: new Error('birthDate required'),
+      });
+
+      render(<HoroscopeWidget />);
+
+      expect(screen.getByText('Tu horóscopo te espera')).toBeInTheDocument();
+    });
+
     it('should NOT show the "not-generated" message', () => {
       mockHook({
         isError: true,

--- a/frontend/src/components/features/horoscope/HoroscopeWidget.tsx
+++ b/frontend/src/components/features/horoscope/HoroscopeWidget.tsx
@@ -50,6 +50,7 @@ export function HoroscopeWidget() {
   if (errorState === 'no-birthdate') {
     return (
       <Card className="p-6" data-testid="horoscope-widget-no-birthdate">
+        <h2 className="mb-2 font-serif text-xl">Tu Horóscopo</h2>
         <WidgetEmptyState
           icon={<Sparkles />}
           title="Tu horóscopo te espera"

--- a/frontend/src/components/features/horoscope/HoroscopeWidget.tsx
+++ b/frontend/src/components/features/horoscope/HoroscopeWidget.tsx
@@ -2,13 +2,15 @@
 
 import * as React from 'react';
 import Link from 'next/link';
-import { AlertCircle, ArrowRight, Clock, RefreshCw, Settings } from 'lucide-react';
+import { AlertCircle, ArrowRight, Clock, RefreshCw, Settings, Sparkles } from 'lucide-react';
 
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { WidgetEmptyState } from '@/components/features/dashboard';
 import { useMySignHoroscope } from '@/hooks/api/useHoroscope';
 import { ZODIAC_SIGNS_INFO } from '@/lib/utils/zodiac';
+import { ROUTES } from '@/lib/constants/routes';
 
 import { ZodiacSymbol } from './ZodiacSymbol';
 
@@ -48,16 +50,16 @@ export function HoroscopeWidget() {
   if (errorState === 'no-birthdate') {
     return (
       <Card className="p-6" data-testid="horoscope-widget-no-birthdate">
-        <h2 className="mb-2 font-serif text-xl">Tu Horóscopo</h2>
-        <p className="text-muted-foreground mb-4 text-sm">
-          Configura tu fecha de nacimiento para ver tu horóscopo personalizado
-        </p>
-        <Button asChild variant="outline" size="sm">
-          <Link href="/perfil">
-            <Settings className="mr-2 h-4 w-4" />
-            Configurar
-          </Link>
-        </Button>
+        <WidgetEmptyState
+          icon={<Sparkles />}
+          title="Tu horóscopo te espera"
+          message="Configura tu fecha de nacimiento para ver tu horóscopo personalizado"
+          cta={{
+            label: 'Configurar',
+            href: ROUTES.PERFIL,
+            icon: <Settings className="h-4 w-4" />,
+          }}
+        />
       </Card>
     );
   }

--- a/frontend/src/components/features/numerology/NumerologyWidget.test.tsx
+++ b/frontend/src/components/features/numerology/NumerologyWidget.test.tsx
@@ -138,6 +138,23 @@ describe('NumerologyWidget', () => {
       expect(screen.getByText(/configura tu fecha de nacimiento/i)).toBeInTheDocument();
     });
 
+    it('should render the illustrated empty state title (T-DASH-005)', () => {
+      mockUseMyNumerologyProfile.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: null,
+      });
+      mockUseDayNumber.mockReturnValue({
+        data: createMockDayNumber(),
+        isLoading: false,
+        error: null,
+      });
+
+      render(<NumerologyWidget />);
+
+      expect(screen.getByText('Descubre tu numerología')).toBeInTheDocument();
+    });
+
     it('should render link to profile page in no data state', () => {
       mockUseMyNumerologyProfile.mockReturnValue({
         data: null,

--- a/frontend/src/components/features/numerology/NumerologyWidget.tsx
+++ b/frontend/src/components/features/numerology/NumerologyWidget.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { WidgetCard } from '@/components/features/dashboard/WidgetCard';
+import { WidgetEmptyState } from '@/components/features/dashboard/WidgetEmptyState';
 import { useMyNumerologyProfile, useDayNumber } from '@/hooks/api/useNumerology';
 import { NUMEROLOGY_NUMBERS_INFO } from '@/lib/utils/numerology';
 import { cn } from '@/lib/utils';
@@ -39,17 +40,17 @@ export function NumerologyWidget() {
         title="Tu Numerología"
         icon={<Hash className="h-5 w-5" />}
         data-testid="numerology-widget-no-data"
-        contentClassName="py-8 text-center"
       >
-        <p className="text-muted-foreground mb-4">
-          Configura tu fecha de nacimiento para ver tu perfil numerológico
-        </p>
-        <Button asChild size="sm">
-          <Link href={ROUTES.PERFIL}>
-            <Settings className="mr-2 h-4 w-4" />
-            Configurar
-          </Link>
-        </Button>
+        <WidgetEmptyState
+          icon={<Hash />}
+          title="Descubre tu numerología"
+          message="Configura tu fecha de nacimiento para ver tu perfil numerológico"
+          cta={{
+            label: 'Configurar',
+            href: ROUTES.PERFIL,
+            icon: <Settings className="h-4 w-4" />,
+          }}
+        />
       </WidgetCard>
     );
   }


### PR DESCRIPTION
## Resumen

Implementa **T-DASH-005** (hallazgo DASH-005): empty states ilustrados y consistentes en los widgets del home, que hoy caían en estados **solo-texto**.

Se crea un sub-componente reutilizable `WidgetEmptyState` y se aplica a los cuatro widgets afectados, **conservando las condiciones de negocio** (loading/error/empty) y los textos/hrefs existentes.

## Cambios

- **`WidgetEmptyState` (nuevo)**: ilustración de marca (asset WebP de T-DASH-004) **o** ícono Lucide con acento dorado (`text-secondary`) cuando no hay ilustración dedicada + título `font-serif` + mensaje atenuado + **CTA opcional como enlace accesible** (foco visible heredado de `Button`).
- **Calendario Sagrado** (`SacredEventsWidget`): empty → `empty-calendar.webp` + CTA "Explorar rituales" → `/rituales`.
- **Rituales** (`PersonalizedRitualsWidget`): sin recomendaciones → `empty-rituals.webp` + CTA "Hacer una lectura" → `/tarot`.
- **Horóscopo** (sin fecha): ícono dorado + CTA "Configurar" → `/perfil`.
- **Numerología** (sin perfil): ícono dorado + CTA "Configurar" → `/perfil`.

## Tests

- 13 tests nuevos para `WidgetEmptyState` (**100% cobertura**): render, ilustración/ícono, CTA con href correcto y foco.
- Tests de los 4 widgets ampliados: render del empty state ilustrado + CTA con href correcto.

## Checklist de calidad

- [x] `npm run format`
- [x] `npm run lint:fix` (0 errores; warnings preexistentes ajenos)
- [x] `npm run type-check`
- [x] `npm run test:run` (5053 passed)
- [x] Coverage ≥ 80% (WidgetEmptyState 100%)
- [x] `npm run build`
- [x] `node scripts/validate-architecture.js`
- [x] Backlog actualizado (T-DASH-005 ✅ COMPLETADA)

Ref: T-DASH-005

🤖 Generated with [Claude Code](https://claude.com/claude-code)