### PR TITLE
fix(dashboard): masonry por columnas para eliminar huecos entre widgets (T-DASH-001)

### DIFF
--- a/docs/BACKLOG_DASHBOARD_REDISENO_2026_06.md
+++ b/docs/BACKLOG_DASHBOARD_REDISENO_2026_06.md
@@ -356,6 +356,13 @@ Reemplazar el layout 2/3 + 1/3 de `UserDashboard` por una distribución que use 
 - **Verificación visual con Playwright** (sesiones reales `free@test.com` / `premium@test.com`, build de producción en `localhost:3001`): el vacío blanco lateral desapareció; en PREMIUM la página pasó de ~2.046 px a ~1.290 px de alto con los 6 widgets visibles en una grilla 3×2; en FREE los 5 widgets se distribuyen en 3 columnas con el banner de upgrade full-width al pie.
 - Ciclo de calidad frontend completo en verde: `format`, `lint:fix` (0 errores), `type-check`, `test:run` (403 archivos / 5017 tests), `build` y `validate-architecture.js`.
 
+#### 🔧 Ajuste posterior — Opción B → Opción A (masonry) · rama `fix/T-DASH-001-masonry-widgets-home`
+
+- **Motivo:** en QA visual (Playwright, `premium@test.com`/`free@test.com`, 1440×900) se confirmó que la Opción B (`grid … items-start`) dejaba **huecos verticales grandes** bajo las tarjetas cortas (p. ej. "Tu Horóscopo" ~166 px junto a "Tu Numerología" ~442 px → ~276 px de vacío), porque la fila 2 no arranca hasta pasar la tarjeta más alta de la fila 1. Es exactamente la contra que el hallazgo DASH-001 anticipaba para la Opción B.
+- **Cambio:** la grilla pasó a **masonry por columnas CSS** — la Opción A que el hallazgo marcaba como recomendada: `columns-1 sm:columns-2 xl:columns-3 gap-6` con `[&>*]:mb-6 [&>*]:break-inside-avoid`. Cada columna fluye densa (estilo Pinterest) y las tarjetas cortas dejan de generar huecos.
+- **Accesibilidad:** el orden DOM (y por tanto lectura por teclado/lector de pantalla) se conserva; solo cambia el flujo visual a por-columnas. El reveal escalonado sigue usando el `index` de cada widget.
+- **Tests:** el contrato de `UserDashboard.test.tsx` se actualizó (`columns-1`/`sm:columns-2`/`xl:columns-3` + `break-inside-avoid`). 19/19 del archivo en verde; suite completa 5073 tests.
+
 #### 🎯 Criterios de Aceptación
 
 - Los widgets ocupan el ancho disponible; sin columna casi vacía ni tira angosta desbordando hacia abajo.

--- a/frontend/src/components/features/dashboard/UserDashboard.test.tsx
+++ b/frontend/src/components/features/dashboard/UserDashboard.test.tsx
@@ -949,11 +949,14 @@ describe('UserDashboard', () => {
 
     const grid = screen.getByTestId('dashboard-widget-grid');
     expect(grid).toBeInTheDocument();
-    // Full-width contract: widgets spread across columns (1 → 2 on tablet → 3 on
-    // wide desktop), never collapsed into a single narrow 1/3 column.
-    expect(grid.className).toContain('grid-cols-1');
-    expect(grid.className).toContain('sm:grid-cols-2');
-    expect(grid.className).toContain('xl:grid-cols-3');
+    // Full-width contract: masonry por columnas CSS (1 → 2 on tablet → 3 on wide
+    // desktop) que empaqueta densamente y evita los huecos verticales que dejaba
+    // el grid con alturas dispares. Nunca colapsa a una única columna estrecha.
+    expect(grid.className).toContain('columns-1');
+    expect(grid.className).toContain('sm:columns-2');
+    expect(grid.className).toContain('xl:columns-3');
+    // Cada tarjeta no debe partirse entre columnas (break-inside-avoid).
+    expect(grid.className).toContain('break-inside-avoid');
     // Themed widgets live inside the grid (not in a separate side column).
     expect(within(grid).getByTestId('horoscope-widget')).toBeInTheDocument();
     expect(within(grid).getByTestId('numerology-widget')).toBeInTheDocument();

--- a/frontend/src/components/features/dashboard/UserDashboard.tsx
+++ b/frontend/src/components/features/dashboard/UserDashboard.tsx
@@ -45,14 +45,20 @@ const DASHBOARD_HERO_IMAGE: EditorialImage = {
  * - Stats section (Premium only)
  * - Upgrade banner (Free users only)
  *
- * Layout (T-DASH-001): the themed widgets are laid out in a single full-width
- * responsive grid (1 col on mobile, 2 on tablet via `sm`, 3 on wide desktop via
- * `xl` — kept at `xl` to avoid 3 cramped columns on smaller laptops) so the user
- * can scan all of them "at a glance" instead of having them stacked in a narrow
- * 1/3 side column with a large empty area beside it. `items-start` keeps each
- * card at its natural height. Plan-gated widgets (Stats / Upgrade banner) and
- * the self-hiding `MyServicesWidget` simply occupy (or free) a grid slot, so
- * the grid stays balanced for both FREE and PREMIUM users.
+ * Layout (T-DASH-001): the themed widgets are laid out full-width across columns
+ * (1 on mobile, 2 on tablet via `sm`, 3 on wide desktop via `xl` — kept at `xl`
+ * to avoid 3 cramped columns on smaller laptops) so the user can scan them "at a
+ * glance" instead of having them stacked in a narrow 1/3 side column.
+ *
+ * It uses a **CSS multi-column masonry** (`columns-*` + `break-inside-avoid`)
+ * rather than a `grid`: with widgets of very different heights a grid with
+ * `items-start` left large vertical holes under the shorter cards (a short
+ * Horóscopo next to a tall Numerología). The masonry packs each column densely
+ * (Pinterest-style), so short cards no longer leave gaps. Plan-gated widgets
+ * (Stats / Upgrade banner) and the self-hiding `MyServicesWidget` simply add or
+ * free a column item, keeping the layout balanced for FREE and PREMIUM users.
+ * Reading/keyboard order follows the DOM order (unaffected by the visual
+ * column flow); the reveal stagger keeps using each widget's `index`.
  *
  * @example
  * ```tsx
@@ -91,7 +97,7 @@ export function UserDashboard() {
         */}
         <section
           data-testid="dashboard-widget-grid"
-          className="grid grid-cols-1 items-start gap-6 sm:grid-cols-2 xl:grid-cols-3"
+          className="columns-1 gap-6 sm:columns-2 xl:columns-3 [&>*]:mb-6 [&>*]:break-inside-avoid"
         >
           {/* Horoscope Widget (Western) - For all users */}
           <RevealWidget index={0}>


### PR DESCRIPTION
## Problema

QA visual del home autenticado (reportado por Ariel + reproducido con Playwright sobre `premium@test.com`/`free@test.com`, 1440×900) mostró un **layout desordenado**: la grilla de widgets dejaba **huecos verticales grandes** bajo las tarjetas cortas.

**Causa:** la grilla usaba `grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 items-start`. Con alturas muy dispares (p. ej. "Tu Horóscopo" ~166px junto a "Tu Numerología" ~442px), la fila 2 no arranca hasta pasar la tarjeta más alta de la fila 1 → ~276px de vacío bajo el Horóscopo. Es exactamente la contra que el hallazgo **DASH-001** anticipaba para la **Opción B**.

## Solución

Cambio a **masonry por columnas CSS** — la **Opción A** que el hallazgo DASH-001 marcaba como *recomendada*:

```
columns-1 gap-6 sm:columns-2 xl:columns-3 [&>*]:mb-6 [&>*]:break-inside-avoid
```

Cada columna fluye densa (estilo Pinterest); las tarjetas cortas dejan de generar huecos. Cambio localizado en `UserDashboard.tsx` (el selector `[&>*]` estiliza los `Reveal` que son los hijos directos del grid, sin tocar `RevealWidget`/`Reveal`).

- **Accesibilidad:** el orden DOM (lectura por teclado / lector de pantalla) se conserva; solo cambia el flujo visual a por-columnas. El reveal escalonado sigue usando el `index` de cada widget.

## Validaciones

- [x] `npm run format` · `npm run lint:fix` (0 errores) · `npm run type-check`
- [x] `npm run test:run` — 5073 tests OK (contrato de grid actualizado a `columns-*` + `break-inside-avoid`)
- [x] `npm run build` · `node scripts/validate-architecture.js`
- [x] Bug **antes** reproducido en vivo con Playwright (evidencia de geometría de celdas)

> ⚠️ Verificación **después** en vivo: el front en `localhost:3001` corre como build de producción (`npm run start`) y el backend restringe CORS a ese origen, así que no pude autenticar en un preview en otro puerto. Para ver el fix en vivo hay que reconstruir y reiniciar el server de :3001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)