### PR TITLE
feat(T-PREM-002): rediseñar /premium al canon místico

### DIFF
--- a/docs/BACKLOG_PREMIUM_REDISENO_2026_07.md
+++ b/docs/BACKLOG_PREMIUM_REDISENO_2026_07.md
@@ -367,16 +367,16 @@ Los prompts de upgrade y el modal de bienvenida usan `text-purple-600/700 dark:t
 **Estimación:** 3.5 puntos
 **Dependencias:** T-PREM-001, T-PREM-004 (asset opcional; con fallback a gradiente puede ir antes)
 **Cubre Hallazgo:** PREM-002
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] Banda mística `PremiumHero` (gradiente noche, imagen opcional + overlay, estrellas/luna, filete dorado, título Cormorant crema, subtítulo con precio en dorado).
-- [ ] Tarjetas de plan con `Card`/`WidgetCard` del canon; "Recomendado" como chip dorado con `text-bg-hero`.
-- [ ] Tabla comparativa legible: encabezado noche + crema, filas con `text-foreground`, check dorado / cruz atenuada.
-- [ ] Secciones "Sin compromiso" y FAQ con tokens y (opcional) callouts del canon.
-- [ ] CTAs con botón de marca + foco visible; `Reveal` escalonado; `prefers-reduced-motion` respetado.
-- [ ] No romper `usePublicPlans`/`useCreatePreapproval`/gates por plan ni los `data-testid` (`cta-hero`, `plan-comparison`, `faq-section`, etc.).
+- [x] Banda mística `PremiumHero` (gradiente noche, imagen opcional + overlay, estrellas/luna, filete dorado, título Cormorant crema, subtítulo con precio en dorado).
+- [x] Tarjetas de plan con `Card`/`WidgetCard` del canon; "Recomendado" como chip dorado con `text-bg-hero`.
+- [x] Tabla comparativa legible: encabezado noche + crema, filas con `text-foreground`, check dorado / cruz atenuada.
+- [x] Secciones "Sin compromiso" y FAQ con tokens y (opcional) callouts del canon.
+- [x] CTAs con botón de marca + foco visible; `Reveal` escalonado; `prefers-reduced-motion` respetado.
+- [x] No romper `usePublicPlans`/`useCreatePreapproval`/gates por plan ni los `data-testid` (`cta-hero`, `plan-comparison`, `faq-section`, etc.).
 
 #### 🎯 Criterios de Aceptación
 

--- a/frontend/src/components/features/premium/PremiumHero.test.tsx
+++ b/frontend/src/components/features/premium/PremiumHero.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { PremiumHero } from './PremiumHero';
+
+// Mock next/image (render a plain img so we can assert src/alt)
+vi.mock('next/image', () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} data-testid="next-image" />
+  ),
+}));
+
+describe('PremiumHero', () => {
+  it('should render with data-testid', () => {
+    render(<PremiumHero title="Desbloquea el Tarot" />);
+
+    expect(screen.getByTestId('premium-hero')).toBeInTheDocument();
+  });
+
+  it('should render the title as the page h1', () => {
+    render(<PremiumHero title="Desbloquea el Tarot" />);
+
+    const h1 = screen.getByRole('heading', { level: 1 });
+    expect(h1).toHaveTextContent('Desbloquea el Tarot');
+    // Cormorant (serif) cream título del canon
+    expect(h1).toHaveClass('font-serif');
+  });
+
+  it('should render the badge chip when provided', () => {
+    render(<PremiumHero title="Tarot" badge="Plan Premium" />);
+
+    expect(screen.getByTestId('premium-hero-badge')).toHaveTextContent('Plan Premium');
+  });
+
+  it('should not render the badge chip when no badge is provided', () => {
+    render(<PremiumHero title="Tarot" />);
+
+    expect(screen.queryByTestId('premium-hero-badge')).not.toBeInTheDocument();
+  });
+
+  it('should render the subtitle when provided', () => {
+    render(<PremiumHero title="Tarot" subtitle={<span>Todo por $7.000/mes</span>} />);
+
+    expect(screen.getByText('Todo por $7.000/mes')).toBeInTheDocument();
+  });
+
+  it('should not render the subtitle paragraph when no subtitle is provided', () => {
+    render(<PremiumHero title="Tarot" />);
+
+    expect(screen.queryByTestId('premium-hero-subtitle')).not.toBeInTheDocument();
+  });
+
+  it('should render the CTA slot (children)', () => {
+    render(
+      <PremiumHero title="Tarot">
+        <button data-testid="cta-hero">Comenzar Premium</button>
+      </PremiumHero>
+    );
+
+    expect(screen.getByTestId('cta-hero')).toBeInTheDocument();
+  });
+
+  it('should render the hero image with its alt when an image is provided', () => {
+    render(
+      <PremiumHero
+        title="Tarot"
+        image={{ src: '/images/premium/premium-hero.webp', alt: 'Llave dorada abriendo una carta' }}
+      />
+    );
+
+    const img = screen.getByTestId('next-image');
+    expect(img).toHaveAttribute('src', '/images/premium/premium-hero.webp');
+    expect(img).toHaveAttribute('alt', 'Llave dorada abriendo una carta');
+  });
+
+  it('should fall back to the gradient band (no image) when no image is provided', () => {
+    render(<PremiumHero title="Tarot" />);
+
+    expect(screen.queryByTestId('next-image')).not.toBeInTheDocument();
+    // The hero still renders (fallback band)
+    expect(screen.getByTestId('premium-hero')).toBeInTheDocument();
+  });
+
+  it('should apply additional className', () => {
+    render(<PremiumHero title="Tarot" className="extra-test-class" />);
+
+    expect(screen.getByTestId('premium-hero')).toHaveClass('extra-test-class');
+  });
+
+  // Accesibilidad (canon T-PREM-002 / PREM-002)
+  describe('Accesibilidad', () => {
+    it('should use dark night text on the gold badge chip for AA contrast', () => {
+      render(<PremiumHero title="Tarot" badge="Plan Premium" />);
+
+      const chip = screen.getByTestId('premium-hero-badge');
+      // Texto noche (#1a0a2e) sobre dorado (#d69e2e) ≈ 7:1 (AA); blanco falla.
+      expect(chip).toHaveClass('text-bg-hero');
+      expect(chip).not.toHaveClass('text-white');
+    });
+  });
+});

--- a/frontend/src/components/features/premium/PremiumHero.tsx
+++ b/frontend/src/components/features/premium/PremiumHero.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+// 1. React & Next.js
+import Image from 'next/image';
+import type { ReactNode } from 'react';
+// 2. Utils & types
+import { cn } from '@/lib/utils';
+import type { EditorialImage } from '@/lib/data/encyclopedia-editorial.data';
+
+// ─── Constants ──────────────────────────────────────────────────────────────────
+
+/**
+ * Brand-night gradient used as the hero band background and as the image overlay
+ * (kept in sync with `DashboardHero`/`ArticleHero` and the `--color-bg-hero` tokens).
+ */
+const HERO_GRADIENT = 'linear-gradient(160deg, #1a0a2e 0%, #2d1b69 55%, #1a0a2e 100%)';
+const IMAGE_OVERLAY =
+  'linear-gradient(160deg, rgba(26, 10, 46, 0.78) 0%, rgba(45, 27, 105, 0.62) 45%, rgba(26, 10, 46, 0.88) 100%), radial-gradient(ellipse at bottom right, rgba(214, 158, 46, 0.18) 0%, transparent 55%)';
+const CREAM = '#f9f7f2';
+const CREAM_MUTED = 'rgba(249, 247, 242, 0.72)';
+
+// Decorative star positions — purely visual, no logic.
+const DECORATIVE_STARS = [
+  { top: '20%', left: '9%', size: 3, delay: '0s', duration: '2.8s' },
+  { top: '32%', left: '89%', size: 2, delay: '0.6s', duration: '3.2s' },
+  { top: '66%', left: '12%', size: 2, delay: '1s', duration: '2.5s' },
+  { top: '26%', left: '55%', size: 2, delay: '1.3s', duration: '3.4s' },
+];
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface PremiumHeroProps {
+  /** Title rendered as the page <h1> in Cormorant cream. */
+  title: string;
+  /** Optional gold chip label above the title (e.g. "Plan Premium"). */
+  badge?: string;
+  /** Optional subtitle below the title (may contain the gold price span). */
+  subtitle?: ReactNode;
+  /** Optional header image; when absent, the gradient band is shown alone. */
+  image?: EditorialImage;
+  /** CTA slot rendered below the subtitle (kept as a slot so the hero stays presentational). */
+  children?: ReactNode;
+  /** Additional CSS classes. */
+  className?: string;
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+/**
+ * PremiumHero Component
+ *
+ * Mystic welcome band for `/premium`, coherent with the Encyclopedia/Dashboard
+ * canon (`ArticleHero`/`DashboardHero`): a brand-night gradient, optionally fronted
+ * by a themed image with a legibility overlay, decorative twinkling stars, a CSS
+ * crescent moon and a bottom gold filet.
+ *
+ * Presentational only: the CTA (which needs auth/router hooks) is passed as
+ * `children` so this component owns no business logic. The image is optional —
+ * when omitted the gradient band renders on its own, so the component degrades
+ * gracefully if the asset ever fails to load.
+ *
+ * @example
+ * ```tsx
+ * <PremiumHero
+ *   badge="Plan Premium"
+ *   title="Desbloquea todo el potencial del Tarot"
+ *   subtitle={<>Interpretaciones con IA por <span className="text-secondary">$7.000/mes</span></>}
+ *   image={{ src: '/images/premium/premium-hero.webp', alt: '…' }}
+ * >
+ *   <PremiumCtaButton testId="cta-hero" />
+ * </PremiumHero>
+ * ```
+ */
+export function PremiumHero({
+  title,
+  badge,
+  subtitle,
+  image,
+  children,
+  className,
+}: PremiumHeroProps) {
+  return (
+    <header
+      data-testid="premium-hero"
+      className={cn('relative overflow-hidden rounded-2xl', className)}
+      style={{ background: HERO_GRADIENT }}
+    >
+      {/* Imagen de cabecera (opcional) con overlay para legibilidad */}
+      {image && (
+        <>
+          <Image
+            src={image.src}
+            alt={image.alt}
+            fill
+            priority
+            sizes="(max-width: 1280px) 100vw, 1280px"
+            className="object-cover"
+          />
+          <div
+            className="absolute inset-0"
+            style={{ background: IMAGE_OVERLAY }}
+            aria-hidden="true"
+          />
+        </>
+      )}
+
+      {/* Estrellas decorativas */}
+      {DECORATIVE_STARS.map((star, i) => (
+        <span
+          key={i}
+          className="animate-twinkle absolute rounded-full bg-amber-200/80"
+          style={{
+            top: star.top,
+            left: star.left,
+            width: `${star.size}px`,
+            height: `${star.size}px`,
+            animationDelay: star.delay,
+            animationDuration: star.duration,
+          }}
+          aria-hidden="true"
+        />
+      ))}
+
+      {/* Luna creciente decorativa (solo CSS) */}
+      <div
+        className="absolute top-6 right-8 z-0 opacity-30"
+        style={{
+          width: '72px',
+          height: '72px',
+          borderRadius: '50%',
+          boxShadow: 'inset -18px -6px 0 0 #d69e2e',
+          filter: 'blur(1px)',
+        }}
+        aria-hidden="true"
+      />
+
+      {/* Contenido */}
+      <div className="relative z-10 flex flex-col items-center px-6 py-14 text-center sm:px-10 sm:py-20">
+        {/* Chip dorado */}
+        {badge && (
+          <span
+            data-testid="premium-hero-badge"
+            className="bg-secondary text-bg-hero mb-5 inline-block rounded-full px-3 py-1 text-xs font-semibold tracking-[0.08em] uppercase"
+          >
+            {badge}
+          </span>
+        )}
+
+        {/* Título */}
+        <h1
+          className="max-w-3xl font-serif text-4xl leading-tight font-bold sm:text-5xl lg:text-6xl"
+          style={{ color: CREAM }}
+        >
+          {title}
+        </h1>
+
+        {/* Subtítulo (puede incluir el precio en dorado) */}
+        {subtitle && (
+          <p
+            data-testid="premium-hero-subtitle"
+            className="mt-5 max-w-2xl text-lg leading-relaxed sm:text-xl"
+            style={{ color: CREAM_MUTED }}
+          >
+            {subtitle}
+          </p>
+        )}
+
+        {/* CTA */}
+        {children && <div className="mt-8 w-full max-w-xs">{children}</div>}
+      </div>
+
+      {/* Filete dorado inferior */}
+      <div
+        className="absolute inset-x-0 bottom-0 h-0.5"
+        style={{ background: 'linear-gradient(90deg, transparent, #d69e2e, transparent)' }}
+        aria-hidden="true"
+      />
+    </header>
+  );
+}

--- a/frontend/src/components/features/premium/PremiumPage.test.tsx
+++ b/frontend/src/components/features/premium/PremiumPage.test.tsx
@@ -23,6 +23,13 @@ vi.mock('next/link', () => ({
   },
 }));
 
+// Mock Next.js Image (PremiumHero uses next/image for the mystic band asset)
+vi.mock('next/image', () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} data-testid="next-image" />
+  ),
+}));
+
 // Mock toast
 vi.mock('@/hooks/utils/useToast', () => ({
   toast: {
@@ -165,6 +172,36 @@ describe('PremiumPage', () => {
       renderWithProviders(<PremiumPage />);
 
       expect(screen.getByText(/cancelá cuando quieras/i)).toBeInTheDocument();
+    });
+
+    // Canon visual (T-PREM-002 / PREM-002)
+    it('should render the mystic premium hero band', () => {
+      mockAuthStore.mockReturnValue({ user: null, isAuthenticated: false });
+
+      renderWithProviders(<PremiumPage />);
+
+      expect(screen.getByTestId('premium-hero')).toBeInTheDocument();
+    });
+
+    it('should render the "Recomendado" chip with night text on gold for AA contrast', () => {
+      mockAuthStore.mockReturnValue({ user: null, isAuthenticated: false });
+
+      renderWithProviders(<PremiumPage />);
+
+      const chip = screen.getByText('Recomendado');
+      // Texto noche (#1a0a2e) sobre dorado (#d69e2e) ≈ 7:1 (AA); blanco falla.
+      expect(chip).toHaveClass('text-bg-hero');
+      expect(chip).not.toHaveClass('text-white');
+    });
+
+    it('should not use raw purple/gray utility classes (brand canon, only tokens)', () => {
+      mockAuthStore.mockReturnValue({ user: null, isAuthenticated: false });
+
+      const { container } = renderWithProviders(<PremiumPage />);
+
+      expect(container.querySelector('[class*="purple"]')).toBeNull();
+      expect(container.querySelector('[class*="text-gray-"]')).toBeNull();
+      expect(container.querySelector('[class*="bg-gray-"]')).toBeNull();
     });
   });
 

--- a/frontend/src/components/features/premium/PremiumPage.tsx
+++ b/frontend/src/components/features/premium/PremiumPage.tsx
@@ -164,7 +164,7 @@ function PremiumCtaButton({ premiumPlan, testId, onDark = false }: PremiumCtaBut
       disabled={isPending}
       size="lg"
       data-testid={testId}
-      className="focus-visible:ring-secondary w-full"
+      className="focus-visible:ring-secondary/50 w-full"
     >
       {isPending ? 'Redirigiendo...' : CTA_PREMIUM.PURCHASE}
       {premiumPlan && !isPending && (

--- a/frontend/src/components/features/premium/PremiumPage.tsx
+++ b/frontend/src/components/features/premium/PremiumPage.tsx
@@ -1,24 +1,49 @@
 'use client';
 
+// 1. React & Next.js
 import { useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { Check, X, Shield, Star, Zap, HelpCircle } from 'lucide-react';
+// 2. Icons
+import { Check, X, Shield, Star, HelpCircle } from 'lucide-react';
+// 5. Components (ui → features)
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Reveal } from '@/components/common/Reveal';
+import { PremiumHero } from './PremiumHero';
+// 4. Custom hooks
 import { usePublicPlans } from '@/hooks/api/usePublicPlans';
 import { useCreatePreapproval } from '@/hooks/api/useSubscription';
 import { useAuthStore } from '@/stores/authStore';
+// 6. Utils & types
 import { ROUTES } from '@/lib/constants/routes';
 import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 import { formatPriceArs } from '@/lib/utils/format';
+import { cn } from '@/lib/utils';
+import type { EditorialImage } from '@/lib/data/encyclopedia-editorial.data';
 import type { PlanConfig } from '@/types/admin.types';
 
 // ============================================================================
 // Constants
 // ============================================================================
+
+/**
+ * Brand-night gradient reused as the comparison table header background, kept in
+ * sync with `PremiumHero`/`DashboardHero` and the `--color-bg-hero` tokens.
+ */
+const HERO_GRADIENT = 'linear-gradient(160deg, #1a0a2e 0%, #2d1b69 55%, #1a0a2e 100%)';
+const CREAM = '#f9f7f2';
+const CREAM_MUTED = 'rgba(249, 247, 242, 0.72)';
+
+/**
+ * Themed header image for the mystic welcome band (T-PREM-004). `PremiumHero`
+ * degrades to its gradient band if the asset ever fails to load.
+ */
+const PREMIUM_HERO_IMAGE: EditorialImage = {
+  src: '/images/premium/premium-hero.webp',
+  alt: 'Llave dorada abriendo una carta de tarot con geometría sagrada, bajo un cielo nocturno violeta con luna creciente y estrellas',
+};
 
 interface PlanFeature {
   text: string;
@@ -68,12 +93,12 @@ const FAQ_ITEMS = [
 
 function PremiumPageSkeleton() {
   return (
-    <div data-testid="premium-page-loading" className="container mx-auto px-4 py-12">
-      <Skeleton className="mx-auto mb-4 h-12 w-2/3" />
-      <Skeleton className="mx-auto mb-12 h-6 w-1/2" />
-      <div className="grid gap-8 md:grid-cols-3">
-        {[1, 2, 3].map((i) => (
-          <Skeleton key={i} className="h-96 rounded-xl" />
+    <div data-testid="premium-page-loading" className="container mx-auto max-w-5xl px-4 py-10">
+      <Skeleton className="mb-8 h-64 w-full rounded-2xl" />
+      <Skeleton className="mx-auto mb-10 h-8 w-2/3" />
+      <div className="mx-auto grid max-w-3xl gap-8 md:grid-cols-2">
+        {[1, 2].map((i) => (
+          <Skeleton key={i} className="h-80 rounded-xl" />
         ))}
       </div>
     </div>
@@ -83,9 +108,11 @@ function PremiumPageSkeleton() {
 interface PremiumCtaButtonProps {
   premiumPlan: PlanConfig | undefined;
   testId?: string;
+  /** When rendered over the dark hero band, adapt the "already premium" text to cream. */
+  onDark?: boolean;
 }
 
-function PremiumCtaButton({ premiumPlan, testId }: PremiumCtaButtonProps) {
+function PremiumCtaButton({ premiumPlan, testId, onDark = false }: PremiumCtaButtonProps) {
   const router = useRouter();
   const { user, isAuthenticated } = useAuthStore();
   const { mutate: createPreapproval, isPending } = useCreatePreapproval();
@@ -108,11 +135,23 @@ function PremiumCtaButton({ premiumPlan, testId }: PremiumCtaButtonProps) {
   if (user?.plan === 'premium') {
     return (
       <div className="flex flex-col items-center gap-2" data-testid={testId}>
-        <div className="flex items-center gap-2 text-purple-600">
-          <Star className="h-5 w-5" />
-          <span className="font-semibold">Ya tenés Premium</span>
+        <div
+          className={cn('flex items-center gap-2 font-semibold', !onDark && 'text-foreground')}
+          style={onDark ? { color: CREAM } : undefined}
+        >
+          <Star className="text-secondary h-5 w-5" aria-hidden="true" />
+          <span>Ya tenés Premium</span>
         </div>
-        <Link href={ROUTES.PERFIL} className="text-sm text-gray-500 underline hover:text-gray-700">
+        <Link
+          href={ROUTES.PERFIL}
+          className={cn(
+            'focus-visible:ring-secondary rounded-sm text-sm underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+            onDark
+              ? 'focus-visible:ring-offset-bg-hero'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+          style={onDark ? { color: CREAM_MUTED } : undefined}
+        >
           Ver mi cuenta
         </Link>
       </div>
@@ -125,7 +164,7 @@ function PremiumCtaButton({ premiumPlan, testId }: PremiumCtaButtonProps) {
       disabled={isPending}
       size="lg"
       data-testid={testId}
-      className="w-full bg-purple-600 text-white hover:bg-purple-700"
+      className="focus-visible:ring-secondary w-full"
     >
       {isPending ? 'Redirigiendo...' : CTA_PREMIUM.PURCHASE}
       {premiumPlan && !isPending && (
@@ -149,160 +188,196 @@ export function PremiumPage() {
   const freePlan = plans?.find((p) => p.planType === 'free');
   const premiumPlan = plans?.find((p) => p.planType === 'premium');
 
+  const heroSubtitle = (
+    <>
+      Interpretaciones personalizadas con IA, tiradas avanzadas, historial completo y mucho más
+      {premiumPlan ? (
+        <>
+          {' '}
+          por{' '}
+          <span className="text-secondary font-bold">{formatPriceArs(premiumPlan.price)}/mes</span>
+        </>
+      ) : (
+        ' por un precio accesible'
+      )}
+    </>
+  );
+
   return (
-    <main className="min-h-screen">
-      {/* Hero Section */}
-      <section className="bg-gradient-to-b from-purple-50 to-white px-4 py-16 text-center">
-        <div className="container mx-auto max-w-3xl">
-          <Badge className="mb-4 bg-purple-100 text-purple-700">
-            <Zap className="mr-1 h-3 w-3" />
-            Plan Premium
-          </Badge>
-          <h1 className="mb-6 font-serif text-4xl font-bold text-gray-900 md:text-5xl lg:text-6xl">
-            Desbloquea todo el potencial del Tarot
-          </h1>
-          <p className="mb-8 text-xl text-gray-600">
-            Interpretaciones personalizadas con IA, tiradas avanzadas, historial completo y mucho
-            más por{' '}
-            {premiumPlan ? (
-              <span className="font-bold text-purple-600">
-                {formatPriceArs(premiumPlan.price)}/mes
+    <main className="container mx-auto max-w-5xl px-4 py-8 sm:py-10">
+      {/* Banda mística de bienvenida */}
+      <Reveal index={0}>
+        <PremiumHero
+          badge="Plan Premium"
+          title="Desbloquea todo el potencial del Tarot"
+          subtitle={heroSubtitle}
+          image={PREMIUM_HERO_IMAGE}
+        >
+          <PremiumCtaButton premiumPlan={premiumPlan} testId="cta-hero" onDark />
+        </PremiumHero>
+      </Reveal>
+
+      {/* Comparativa de planes */}
+      <Reveal index={1}>
+        <section data-testid="plan-comparison" className="py-14 sm:py-16">
+          <h2 className="text-foreground mb-12 text-center font-serif text-3xl font-bold">
+            ¿Qué plan se adapta a ti?
+          </h2>
+
+          {/* Tarjetas de plan */}
+          <div className="mb-16 grid items-stretch gap-8 md:grid-cols-2 lg:mx-auto lg:max-w-3xl">
+            {/* Plan Free */}
+            <Card className="flex flex-col">
+              <CardHeader className="text-center">
+                <h3 className="text-card-foreground mb-2 font-serif text-2xl font-bold">
+                  {freePlan?.name ?? 'Free'}
+                </h3>
+                <p className="text-foreground mb-4 text-4xl font-bold">Gratis</p>
+                <p className="text-muted-foreground text-sm">
+                  {freePlan?.description ?? 'Empieza tu viaje espiritual'}
+                </p>
+              </CardHeader>
+              <CardContent className="mt-auto">
+                <Button asChild variant="outline" className="w-full" size="lg">
+                  <Link href={ROUTES.REGISTER}>Registrarse gratis</Link>
+                </Button>
+              </CardContent>
+            </Card>
+
+            {/* Plan Premium (destacado) */}
+            <Card className="border-secondary relative flex flex-col shadow-[var(--shadow-soft)]">
+              <span className="bg-secondary text-bg-hero absolute -top-3 left-1/2 -translate-x-1/2 rounded-full px-4 py-1 text-xs font-semibold tracking-[0.08em] uppercase">
+                Recomendado
               </span>
-            ) : (
-              'un precio accesible'
-            )}
-          </p>
-          <PremiumCtaButton premiumPlan={premiumPlan} testId="cta-hero" />
-        </div>
-      </section>
+              <CardHeader className="text-center">
+                <h3 className="text-card-foreground mb-2 font-serif text-2xl font-bold">
+                  {premiumPlan?.name ?? 'Premium'}
+                </h3>
+                <p className="text-foreground mb-4 text-4xl font-bold">
+                  {premiumPlan ? formatPriceArs(premiumPlan.price) : '---'}
+                  <span className="text-muted-foreground text-lg font-normal">/mes</span>
+                </p>
+                <p className="text-muted-foreground text-sm">
+                  {premiumPlan?.description ?? 'Desbloquea todo el potencial'}
+                </p>
+              </CardHeader>
+              <CardContent className="mt-auto">
+                <PremiumCtaButton premiumPlan={premiumPlan} testId="cta-card" />
+              </CardContent>
+            </Card>
+          </div>
 
-      {/* Plan Comparison Section */}
-      <section data-testid="plan-comparison" className="container mx-auto px-4 py-16">
-        <h2 className="mb-12 text-center font-serif text-3xl font-bold text-gray-900">
-          ¿Qué plan se adapta a ti?
-        </h2>
-
-        {/* Plan Cards */}
-        <div className="mb-16 grid gap-8 md:grid-cols-2 lg:mx-auto lg:max-w-3xl">
-          {/* Free Plan Card */}
-          <Card className="border-gray-200">
-            <CardHeader className="text-center">
-              <h3 className="mb-2 font-serif text-2xl font-bold text-gray-900">
-                {freePlan?.name ?? 'Free'}
-              </h3>
-              <p className="mb-4 text-4xl font-bold text-gray-600">Gratis</p>
-              <p className="text-sm text-gray-500">
-                {freePlan?.description ?? 'Empieza tu viaje espiritual'}
-              </p>
-            </CardHeader>
-            <CardContent>
-              <Button asChild variant="outline" className="w-full" size="lg">
-                <Link href={ROUTES.REGISTER}>Registrarse gratis</Link>
-              </Button>
-            </CardContent>
-          </Card>
-
-          {/* Premium Plan Card */}
-          <Card className="relative border-purple-300 shadow-lg">
-            <Badge className="absolute -top-3 left-1/2 -translate-x-1/2 transform bg-purple-600 px-4 py-1">
-              Recomendado
-            </Badge>
-            <CardHeader className="text-center">
-              <h3 className="mb-2 font-serif text-2xl font-bold text-gray-900">
-                {premiumPlan?.name ?? 'Premium'}
-              </h3>
-              <p className="mb-4 text-4xl font-bold text-purple-600">
-                {premiumPlan ? formatPriceArs(premiumPlan.price) : '---'}
-                <span className="text-lg font-normal">/mes</span>
-              </p>
-              <p className="text-sm text-gray-500">
-                {premiumPlan?.description ?? 'Desbloquea todo el potencial'}
-              </p>
-            </CardHeader>
-            <CardContent>
-              <PremiumCtaButton premiumPlan={premiumPlan} testId="cta-card" />
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Feature Comparison Table */}
-        <div className="mx-auto max-w-2xl overflow-hidden rounded-xl border border-gray-200">
-          <table className="w-full">
-            <thead>
-              <tr className="bg-gray-50">
-                <th className="px-6 py-4 text-left text-sm font-semibold text-gray-600">
-                  Característica
-                </th>
-                <th className="px-4 py-4 text-center text-sm font-semibold text-gray-600">Free</th>
-                <th className="px-4 py-4 text-center text-sm font-semibold text-purple-600">
-                  Premium
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {COMPARISON_FEATURES.map((feature) => (
-                <tr key={feature.text} className="hover:bg-gray-50">
-                  <td className="px-6 py-3 text-sm text-gray-700">{feature.text}</td>
-                  <td className="px-4 py-3 text-center">
-                    {feature.free ? (
-                      <Check className="mx-auto h-5 w-5 text-green-600" />
-                    ) : (
-                      <X className="mx-auto h-5 w-5 text-gray-300" />
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-center">
-                    {feature.premium ? (
-                      <Check className="mx-auto h-5 w-5 text-purple-600" />
-                    ) : (
-                      <X className="mx-auto h-5 w-5 text-gray-300" />
-                    )}
-                  </td>
+          {/* Tabla comparativa */}
+          <div className="border-border mx-auto max-w-2xl overflow-hidden rounded-xl border">
+            <table className="w-full">
+              <thead>
+                <tr style={{ background: HERO_GRADIENT }}>
+                  <th
+                    className="px-6 py-4 text-left text-sm font-semibold"
+                    style={{ color: CREAM }}
+                  >
+                    Característica
+                  </th>
+                  <th
+                    className="px-4 py-4 text-center text-sm font-semibold"
+                    style={{ color: CREAM_MUTED }}
+                  >
+                    Free
+                  </th>
+                  <th
+                    className="px-4 py-4 text-center text-sm font-semibold"
+                    style={{ color: CREAM }}
+                  >
+                    Premium
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
+              </thead>
+              <tbody className="divide-border divide-y">
+                {COMPARISON_FEATURES.map((feature) => (
+                  <tr key={feature.text} className="hover:bg-muted/40">
+                    <td className="text-foreground px-6 py-3 text-sm">{feature.text}</td>
+                    <td className="px-4 py-3 text-center">
+                      {feature.free ? (
+                        <Check className="text-secondary mx-auto h-5 w-5" aria-label="Incluido" />
+                      ) : (
+                        <X
+                          className="text-muted-foreground mx-auto h-5 w-5"
+                          aria-label="No incluido"
+                        />
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      {feature.premium ? (
+                        <Check className="text-secondary mx-auto h-5 w-5" aria-label="Incluido" />
+                      ) : (
+                        <X
+                          className="text-muted-foreground mx-auto h-5 w-5"
+                          aria-label="No incluido"
+                        />
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </Reveal>
 
-      {/* Guarantee Section */}
-      <section className="bg-purple-50 px-4 py-12 text-center">
-        <div className="container mx-auto max-w-xl">
-          <Shield className="mx-auto mb-4 h-12 w-12 text-purple-600" />
-          <h2 className="mb-3 font-serif text-2xl font-bold text-gray-900">Sin compromiso</h2>
-          <p className="text-gray-600">
-            Cancelá cuando quieras, sin compromiso ni cargos adicionales. Tu historial y lecturas se
-            conservan siempre.
+      {/* Sin compromiso */}
+      <Reveal index={2}>
+        <section className="pb-14">
+          <Card className="mx-auto max-w-xl p-8 text-center">
+            <Shield className="text-secondary mx-auto mb-4 h-12 w-12" aria-hidden="true" />
+            <h2 className="text-card-foreground mb-3 font-serif text-2xl font-bold">
+              Sin compromiso
+            </h2>
+            <p className="text-muted-foreground">
+              Cancelá cuando quieras, sin compromiso ni cargos adicionales. Tu historial y lecturas
+              se conservan siempre.
+            </p>
+          </Card>
+        </section>
+      </Reveal>
+
+      {/* Preguntas frecuentes */}
+      <Reveal index={3}>
+        <section data-testid="faq-section" className="mx-auto max-w-2xl pb-14">
+          <h2 className="text-foreground mb-10 text-center font-serif text-3xl font-bold">
+            Preguntas frecuentes
+          </h2>
+          <div className="space-y-4">
+            {FAQ_ITEMS.map((item) => (
+              <Card key={item.question} className="p-6">
+                <div className="mb-2 flex items-start gap-3">
+                  <HelpCircle
+                    className="text-secondary mt-0.5 h-5 w-5 flex-shrink-0"
+                    aria-hidden="true"
+                  />
+                  <h3 className="text-card-foreground font-semibold">{item.question}</h3>
+                </div>
+                <p className="text-muted-foreground pl-8">{item.answer}</p>
+              </Card>
+            ))}
+          </div>
+        </section>
+      </Reveal>
+
+      {/* CTA final */}
+      <Reveal index={4}>
+        <section className="mx-auto max-w-xl pb-8 text-center">
+          <h2 className="text-foreground mb-4 font-serif text-2xl font-bold">
+            ¿Listo para comenzar?
+          </h2>
+          <p className="text-muted-foreground mb-8">
+            Únete a nuestra comunidad y descubre el poder del tarot con interpretaciones
+            personalizadas.
           </p>
-        </div>
-      </section>
-
-      {/* FAQ Section */}
-      <section data-testid="faq-section" className="container mx-auto max-w-2xl px-4 py-16">
-        <h2 className="mb-10 text-center font-serif text-3xl font-bold text-gray-900">
-          Preguntas frecuentes
-        </h2>
-        <div className="space-y-6">
-          {FAQ_ITEMS.map((item) => (
-            <div key={item.question} className="rounded-xl border border-gray-200 p-6">
-              <div className="mb-3 flex items-start gap-3">
-                <HelpCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-purple-600" />
-                <h3 className="font-semibold text-gray-900">{item.question}</h3>
-              </div>
-              <p className="pl-8 text-gray-600">{item.answer}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* Bottom CTA */}
-      <section className="container mx-auto max-w-xl px-4 pb-16 text-center">
-        <h2 className="mb-4 font-serif text-2xl font-bold text-gray-900">¿Listo para comenzar?</h2>
-        <p className="mb-8 text-gray-600">
-          Únete a nuestra comunidad y descubre el poder del tarot con interpretaciones
-          personalizadas.
-        </p>
-        <PremiumCtaButton premiumPlan={premiumPlan} testId="cta-bottom" />
-      </section>
+          <div className="mx-auto max-w-xs">
+            <PremiumCtaButton premiumPlan={premiumPlan} testId="cta-bottom" />
+          </div>
+        </section>
+      </Reveal>
     </main>
   );
 }

--- a/frontend/src/test/no-ghost-dark-mode.test.ts
+++ b/frontend/src/test/no-ghost-dark-mode.test.ts
@@ -28,6 +28,7 @@ const DARK_VARIANT = /dark:[a-zA-Z[]/;
 // Archivos de features purgados en T-PREM-001 (inventario del backlog).
 const PURGED_FILES = [
   'components/features/premium/PremiumPage.tsx',
+  'components/features/premium/PremiumHero.tsx',
   'components/features/premium/ActivationPage.tsx',
   'app/registro/page.tsx',
   'components/features/notifications/NotificationItem.tsx',


### PR DESCRIPTION
## 🎯 Qué resuelve

**T-PREM-002 / hallazgo PREM-002:** `/premium` estaba construida con paleta cruda púrpura/gris (violeta eléctrico) y cabecera plana, sin identidad de marca. Este PR la lleva al **canon** (noche/índigo + dorado, Cormorant, tokens), coherente con el Dashboard y la Enciclopedia.

> Depende de T-PREM-001 (purga `dark:`, ya mergeada) y T-PREM-004 (assets WebP, ya mergeados).

## 🛠️ Cómo

- **Nuevo `PremiumHero`** (presentacional, patrón de `DashboardHero`/`ArticleHero`): banda noche con `premium-hero.webp` opcional + overlay y **fallback a gradiente**, estrellas/luna decorativas, filete dorado, chip dorado con `text-bg-hero`, título Cormorant crema, subtítulo con **precio en dorado** y slot de CTA.
- **`PremiumPage`** migra a **solo tokens de marca**:
  - Tarjetas `Card` con "Recomendado" como chip dorado (`bg-secondary text-bg-hero`), Premium destacada con acento dorado.
  - Tabla comparativa legible: encabezado **noche + crema**, filas `text-foreground`, check dorado / cruz atenuada, con `aria-label` en los íconos.
  - "Sin compromiso" y FAQ en tokens; CTAs con **botón de marca** y `focus-visible:ring-secondary`.
  - Secciones envueltas en `Reveal` (fade-up escalonado, respeta `prefers-reduced-motion`).
- **Sin cambios de contrato:** se conservan `usePublicPlans`/`useCreatePreapproval`, los gates por plan y todos los `data-testid` (`cta-hero`, `cta-card`, `cta-bottom`, `plan-comparison`, `faq-section`, `premium-page-loading`).

## ✅ Qué se probó

- **`PremiumHero.test.tsx`** (nuevo, 11 casos) + aserciones de canon en **`PremiumPage.test.tsx`** (hero presente, chip "Recomendado" con `text-bg-hero` para AA, sin `purple`/`gray-` crudos).
- `PremiumHero.tsx` sumado al guard **`no-ghost-dark-mode`** (contrato PREM-001).
- Ciclo de calidad frontend completo: `format` · `lint:fix` (0 errores) · `type-check` · `test:run` (**5099 tests**, 0 fallos) · `build` · `validate-architecture` ✅.
- Revisor local: **APROBADO**; se aplicó su único hallazgo válido (cobertura del guard para el nuevo hero).

### 🔎 E2E manual sugerido (Delta)
Con el stack levantado, en `/premium` verificar en **SO en modo oscuro y claro**:
1. La banda mística se ve de marca (noche + dorado + Cormorant); si `premium-hero.webp` no cargara, degrada a gradiente sin romper contraste.
2. Título/tabla/FAQ **legibles** (fin del "texto claro sobre fondo claro").
3. CTA como usuario no autenticado (→ `/registro`), free (→ MercadoPago) y premium ("Ya tenés Premium").

🤖 Generated with [Claude Code](https://claude.com/claude-code)