### PR TITLE
feat(T-PREM-003): rediseñar /premium/activacion al canon místico

### DIFF
--- a/docs/BACKLOG_PREMIUM_REDISENO_2026_07.md
+++ b/docs/BACKLOG_PREMIUM_REDISENO_2026_07.md
@@ -395,21 +395,28 @@ Los prompts de upgrade y el modal de bienvenida usan `text-purple-600/700 dark:t
 **Estimación:** 2 puntos
 **Dependencias:** T-PREM-001, T-PREM-002
 **Cubre Hallazgo:** PREM-003
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] Alinear estados (éxito/pendiente/error) con el canon (tokens, dorado, Cormorant, banda si aplica).
-- [ ] Conservar la lógica de activación y los estados existentes.
+- [x] Alinear estados (éxito/pendiente/error) con el canon (tokens, dorado, Cormorant, banda si aplica).
+- [x] Conservar la lógica de activación y los estados existentes.
 
 #### 🎯 Criterios de Aceptación
 
-- La pantalla post-pago luce premium y de marca; contraste AA.
-- Ciclo de calidad frontend completo pasa.
+- [x] La pantalla post-pago luce premium y de marca; contraste AA.
+- [x] Ciclo de calidad frontend completo pasa.
 
 #### 📁 Archivos involucrados
 
 - `ActivationPage.tsx` (+ test).
+
+#### 📝 Notas de implementación
+
+- Estado de **éxito** (`activation-success`): banda mística `PremiumHero` con `premium-activacion.webp` (fallback a gradiente noche/índigo garantizado por el propio hero), badge dorado "¡Pago confirmado!", título Cormorant crema y nota "Redirigiendo…" con tokens.
+- Estados de **carga/pendiente/procesamiento/error**: nuevo `StatusPanel` reutilizable (tarjeta `Card` crema centrada, `Reveal` escalonado, título Cormorant, texto `muted-foreground`). Iconos dorados (`text-secondary`) salvo el error, que usa `text-destructive`.
+- Erradicada la paleta cruda `purple-*`/`gray-*` y las variantes `dark:` del componente; CTA "Intentar de nuevo" con `Button` de marca + foco dorado (`focus-visible:ring-secondary/50`).
+- Lógica de activación (polling, timeout 30s, sanitización de `redirect`, actualización de store/capabilities) **intacta**. Cobertura `ActivationPage.tsx` ≈ 98.7% líneas.
 
 ---
 

--- a/frontend/src/components/features/premium/ActivationPage.test.tsx
+++ b/frontend/src/components/features/premium/ActivationPage.test.tsx
@@ -511,7 +511,7 @@ describe('ActivationPage', () => {
         isLoading: false,
       });
 
-      renderWithProviders(<ActivationPage />);
+      const { container } = renderWithProviders(<ActivationPage />);
 
       await waitFor(() => {
         expect(screen.getByTestId('activation-success')).toBeInTheDocument();
@@ -524,6 +524,11 @@ describe('ActivationPage', () => {
         '/images/premium/premium-activacion.webp'
       );
       expect(screen.getByRole('heading', { level: 1 })).toHaveClass('font-serif');
+
+      // La banda de éxito tampoco usa la paleta cruda púrpura/gris
+      expect(container.querySelector('[class*="purple"]')).toBeNull();
+      expect(container.querySelector('[class*="text-gray-"]')).toBeNull();
+      expect(container.querySelector('[class*="bg-gray-"]')).toBeNull();
     });
 
     it('should not use the raw purple/gray palette in any state', () => {

--- a/frontend/src/components/features/premium/ActivationPage.test.tsx
+++ b/frontend/src/components/features/premium/ActivationPage.test.tsx
@@ -39,6 +39,13 @@ vi.mock('next/link', () => ({
   },
 }));
 
+// Mock next/image (render a plain img so we can assert src/alt of the mystic band)
+vi.mock('next/image', () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} data-testid="next-image" />
+  ),
+}));
+
 // Mock subscription hook
 const mockUseSubscriptionStatus = vi.fn();
 vi.mock('@/hooks/api/useSubscription', () => ({
@@ -481,6 +488,74 @@ describe('ActivationPage', () => {
       expect(mockUseSubscriptionStatus).toHaveBeenCalledWith(
         expect.objectContaining({ refetchInterval: false, enabled: false })
       );
+    });
+  });
+
+  // ============================================================================
+  // Canon visual (T-PREM-003) — banda mística, tokens y sin púrpura/dark
+  // ============================================================================
+
+  describe('Canon visual', () => {
+    it('should show the mystic band with the activation image on success', async () => {
+      mockSearchParams.get.mockImplementation((key: string) => {
+        if (key === 'status') return 'authorized';
+        return null;
+      });
+      mockUseSubscriptionStatus.mockReturnValue({
+        data: {
+          plan: 'premium',
+          subscriptionStatus: 'active',
+          planExpiresAt: '2026-04-01T00:00:00Z',
+          mpPreapprovalId: 'mp_123',
+        },
+        isLoading: false,
+      });
+
+      renderWithProviders(<ActivationPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activation-success')).toBeInTheDocument();
+      });
+
+      // Banda mística del canon con la imagen de activación
+      expect(screen.getByTestId('premium-hero')).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: /mandala dorado/i })).toHaveAttribute(
+        'src',
+        '/images/premium/premium-activacion.webp'
+      );
+      expect(screen.getByRole('heading', { level: 1 })).toHaveClass('font-serif');
+    });
+
+    it('should not use the raw purple/gray palette in any state', () => {
+      const states: Array<string | null> = ['authorized', 'pending', 'failure'];
+
+      for (const status of states) {
+        mockSearchParams.get.mockImplementation((key: string) => {
+          if (key === 'status') return status;
+          return null;
+        });
+
+        const { container, unmount } = renderWithProviders(<ActivationPage />);
+
+        // El canon usa tokens (dorado/crema/noche), nunca la paleta cruda púrpura/gris.
+        expect(container.querySelector('[class*="purple"]')).toBeNull();
+        expect(container.querySelector('[class*="text-gray-"]')).toBeNull();
+        expect(container.querySelector('[class*="bg-gray-"]')).toBeNull();
+
+        unmount();
+      }
+    });
+
+    it('should render the loading title with a serif (Cormorant) heading', () => {
+      mockSearchParams.get.mockImplementation((key: string) => {
+        if (key === 'status') return 'authorized';
+        return null;
+      });
+
+      renderWithProviders(<ActivationPage />);
+
+      expect(screen.getByTestId('activation-loading')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 1 })).toHaveClass('font-serif');
     });
   });
 });

--- a/frontend/src/components/features/premium/ActivationPage.tsx
+++ b/frontend/src/components/features/premium/ActivationPage.tsx
@@ -1,14 +1,19 @@
 'use client';
 
 import { startTransition, useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { CheckCircle, Clock, XCircle, Loader2 } from 'lucide-react';
+import { Clock, XCircle, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Reveal } from '@/components/common/Reveal';
+import { PremiumHero } from './PremiumHero';
 import { useSubscriptionStatus } from '@/hooks/api/useSubscription';
 import { useInvalidateCapabilities } from '@/hooks/api/useUserCapabilities';
 import { useAuthStore } from '@/stores/authStore';
 import { ROUTES } from '@/lib/constants/routes';
+import type { EditorialImage } from '@/lib/data/encyclopedia-editorial.data';
 
 // ============================================================================
 // Constants
@@ -16,6 +21,15 @@ import { ROUTES } from '@/lib/constants/routes';
 
 const POLLING_INTERVAL_MS = 2000;
 const POLLING_TIMEOUT_MS = 30000;
+
+/**
+ * Themed image for the success band (T-PREM-004). `PremiumHero` degrades to its
+ * gradient band if the asset ever fails to load, so contrast never breaks.
+ */
+const ACTIVATION_SUCCESS_IMAGE: EditorialImage = {
+  src: '/images/premium/premium-activacion.webp',
+  alt: 'Mandala dorado de luz floreciendo entre estrellas, en un cielo nocturno violeta con luna creciente',
+};
 
 const VALID_CHECKOUT_STATUSES = ['authorized', 'pending', 'failure'] as const;
 type CheckoutStatus = (typeof VALID_CHECKOUT_STATUSES)[number];
@@ -41,72 +55,111 @@ function sanitizeRedirectPath(raw: string | null): string {
 // Sub-components
 // ============================================================================
 
+interface StatusPanelProps {
+  /** `data-testid` del panel para las pruebas. */
+  testId: string;
+  /** Icono superior (dorado o destructivo según el estado). */
+  icon: ReactNode;
+  /** Título en Cormorant. */
+  title: string;
+  /** Descripción del estado. */
+  description: string;
+  /** Nota secundaria opcional (p. ej. "Redirigiendo..."). */
+  note?: string;
+  /** Acciones opcionales (botones). */
+  children?: ReactNode;
+}
+
+/**
+ * Panel de estado del canon: tarjeta crema centrada con icono dorado, título
+ * Cormorant y texto con tokens. Compartido por los estados de carga, pendiente,
+ * procesamiento y error para mantener una atmósfera de marca coherente.
+ */
+function StatusPanel({ testId, icon, title, description, note, children }: StatusPanelProps) {
+  return (
+    <main className="container mx-auto flex min-h-[60vh] max-w-xl items-center justify-center px-4 py-12">
+      <Reveal index={0} className="w-full">
+        <Card data-testid={testId} className="p-8 text-center sm:p-10">
+          <div className="flex justify-center">{icon}</div>
+          <div>
+            <h1 className="text-card-foreground mb-3 font-serif text-2xl font-bold sm:text-3xl">
+              {title}
+            </h1>
+            <p className="text-muted-foreground leading-relaxed">{description}</p>
+            {note && <p className="text-muted-foreground/80 mt-4 text-sm">{note}</p>}
+          </div>
+          {children && (
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">{children}</div>
+          )}
+        </Card>
+      </Reveal>
+    </main>
+  );
+}
+
 function LoadingState() {
   return (
-    <div data-testid="activation-loading" className="flex flex-col items-center gap-6 text-center">
-      <Loader2 className="h-16 w-16 animate-spin text-purple-600" />
-      <div>
-        <h1 className="mb-2 font-serif text-2xl font-bold text-gray-900">
-          Activando tu plan Premium...
-        </h1>
-        <p className="text-gray-600">
-          Estamos confirmando tu suscripción. Esto puede tomar unos segundos.
-        </p>
-      </div>
-    </div>
+    <StatusPanel
+      testId="activation-loading"
+      icon={<Loader2 className="text-secondary h-14 w-14 animate-spin" aria-hidden="true" />}
+      title="Activando tu plan Premium..."
+      description="Estamos confirmando tu suscripción. Esto puede tomar unos segundos."
+    />
   );
 }
 
 function SuccessState() {
   return (
-    <div data-testid="activation-success" className="flex flex-col items-center gap-6 text-center">
-      <CheckCircle className="h-16 w-16 text-green-500" />
-      <div>
-        <h1 className="mb-2 font-serif text-2xl font-bold text-gray-900">¡Bienvenido a Premium!</h1>
-        <p className="text-gray-600">
-          Tu plan Premium fue activado exitosamente. Ahora tenés acceso a todas las funciones.
-        </p>
-      </div>
-      <p className="text-sm text-gray-500">Redirigiendo en unos segundos...</p>
-    </div>
+    <main
+      data-testid="activation-success"
+      className="container mx-auto max-w-3xl px-4 py-10 sm:py-12"
+    >
+      <Reveal index={0}>
+        <PremiumHero
+          badge="¡Pago confirmado!"
+          title="¡Bienvenido a Premium!"
+          subtitle="Tu plan Premium fue activado exitosamente. Ahora tenés acceso a todas las funciones."
+          image={ACTIVATION_SUCCESS_IMAGE}
+        />
+      </Reveal>
+      <p className="text-muted-foreground mt-6 text-center text-sm">
+        Redirigiendo en unos segundos...
+      </p>
+    </main>
   );
 }
 
 function TimeoutState() {
   return (
-    <div data-testid="activation-timeout" className="flex flex-col items-center gap-6 text-center">
-      <Clock className="h-16 w-16 text-yellow-500" />
-      <div>
-        <h1 className="mb-2 font-serif text-2xl font-bold text-gray-900">Pago en procesamiento</h1>
-        <p className="text-gray-600">
-          Estamos procesando tu pago. Tu plan Premium se activará automáticamente en unos minutos.
-        </p>
-      </div>
+    <StatusPanel
+      testId="activation-timeout"
+      icon={<Clock className="text-secondary h-14 w-14" aria-hidden="true" />}
+      title="Pago en procesamiento"
+      description="Estamos procesando tu pago. Tu plan Premium se activará automáticamente en unos minutos."
+    >
       <div data-testid="btn-go-home-timeout">
-        <Button asChild variant="outline" className="mt-2">
+        <Button asChild variant="outline">
           <Link href={ROUTES.HOME}>Ir al inicio</Link>
         </Button>
       </div>
-    </div>
+    </StatusPanel>
   );
 }
 
 function PendingState() {
   return (
-    <div data-testid="activation-pending" className="flex flex-col items-center gap-6 text-center">
-      <Clock className="h-16 w-16 text-yellow-500" />
-      <div>
-        <h1 className="mb-2 font-serif text-2xl font-bold text-gray-900">Pago en proceso</h1>
-        <p className="text-gray-600">
-          Tu pago está siendo procesado. Te notificaremos cuando se confirme.
-        </p>
-      </div>
+    <StatusPanel
+      testId="activation-pending"
+      icon={<Clock className="text-secondary h-14 w-14" aria-hidden="true" />}
+      title="Pago en proceso"
+      description="Tu pago está siendo procesado. Te notificaremos cuando se confirme."
+    >
       <div data-testid="btn-go-home-pending">
-        <Button asChild variant="outline" className="mt-2">
+        <Button asChild variant="outline">
           <Link href={ROUTES.HOME}>Ir al inicio</Link>
         </Button>
       </div>
-    </div>
+    </StatusPanel>
   );
 }
 
@@ -114,29 +167,25 @@ function FailureState() {
   const router = useRouter();
 
   return (
-    <div data-testid="activation-failure" className="flex flex-col items-center gap-6 text-center">
-      <XCircle className="h-16 w-16 text-red-500" />
-      <div>
-        <h1 className="mb-2 font-serif text-2xl font-bold text-gray-900">Problema con el pago</h1>
-        <p className="text-gray-600">
-          Hubo un problema con tu pago. Por favor, intentá nuevamente.
-        </p>
-      </div>
-      <div className="flex flex-col gap-3 sm:flex-row">
-        <Button
-          data-testid="btn-retry"
-          onClick={() => router.push(ROUTES.PREMIUM)}
-          className="bg-purple-600 text-white hover:bg-purple-700"
-        >
-          Intentar de nuevo
+    <StatusPanel
+      testId="activation-failure"
+      icon={<XCircle className="text-destructive h-14 w-14" aria-hidden="true" />}
+      title="Problema con el pago"
+      description="Hubo un problema con tu pago. Por favor, intentá nuevamente."
+    >
+      <Button
+        data-testid="btn-retry"
+        onClick={() => router.push(ROUTES.PREMIUM)}
+        className="focus-visible:ring-secondary/50"
+      >
+        Intentar de nuevo
+      </Button>
+      <div data-testid="btn-go-home-failure">
+        <Button asChild variant="outline">
+          <Link href={ROUTES.HOME}>Ir al inicio</Link>
         </Button>
-        <div data-testid="btn-go-home-failure">
-          <Button asChild variant="outline">
-            <Link href={ROUTES.HOME}>Ir al inicio</Link>
-          </Button>
-        </div>
       </div>
-    </div>
+    </StatusPanel>
   );
 }
 

--- a/frontend/src/components/features/premium/ActivationPage.tsx
+++ b/frontend/src/components/features/premium/ActivationPage.tsx
@@ -64,8 +64,6 @@ interface StatusPanelProps {
   title: string;
   /** Descripción del estado. */
   description: string;
-  /** Nota secundaria opcional (p. ej. "Redirigiendo..."). */
-  note?: string;
   /** Acciones opcionales (botones). */
   children?: ReactNode;
 }
@@ -74,10 +72,12 @@ interface StatusPanelProps {
  * Panel de estado del canon: tarjeta crema centrada con icono dorado, título
  * Cormorant y texto con tokens. Compartido por los estados de carga, pendiente,
  * procesamiento y error para mantener una atmósfera de marca coherente.
+ *
+ * Usa `<section>` (no `<main>`): el landmark `main` ya lo aporta el root layout.
  */
-function StatusPanel({ testId, icon, title, description, note, children }: StatusPanelProps) {
+function StatusPanel({ testId, icon, title, description, children }: StatusPanelProps) {
   return (
-    <main className="container mx-auto flex min-h-[60vh] max-w-xl items-center justify-center px-4 py-12">
+    <section className="container mx-auto flex min-h-[60vh] max-w-xl items-center justify-center px-4 py-12">
       <Reveal index={0} className="w-full">
         <Card data-testid={testId} className="p-8 text-center sm:p-10">
           <div className="flex justify-center">{icon}</div>
@@ -86,14 +86,13 @@ function StatusPanel({ testId, icon, title, description, note, children }: Statu
               {title}
             </h1>
             <p className="text-muted-foreground leading-relaxed">{description}</p>
-            {note && <p className="text-muted-foreground/80 mt-4 text-sm">{note}</p>}
           </div>
           {children && (
             <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">{children}</div>
           )}
         </Card>
       </Reveal>
-    </main>
+    </section>
   );
 }
 
@@ -110,7 +109,7 @@ function LoadingState() {
 
 function SuccessState() {
   return (
-    <main
+    <section
       data-testid="activation-success"
       className="container mx-auto max-w-3xl px-4 py-10 sm:py-12"
     >
@@ -125,7 +124,7 @@ function SuccessState() {
       <p className="text-muted-foreground mt-6 text-center text-sm">
         Redirigiendo en unos segundos...
       </p>
-    </main>
+    </section>
   );
 }
 
@@ -176,7 +175,7 @@ function FailureState() {
       <Button
         data-testid="btn-retry"
         onClick={() => router.push(ROUTES.PREMIUM)}
-        className="focus-visible:ring-secondary/50"
+        className="focus-visible:ring-secondary focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2"
       >
         Intentar de nuevo
       </Button>


### PR DESCRIPTION
## 🎯 Tarea

**T-PREM-003** — Rediseño de `/premium/activacion` coherente con el canon místico (cubre hallazgo **PREM-003**).

La pantalla post-pago compartía la paleta cruda `purple-*`/`gray-*` y variantes `dark:`, generando baja legibilidad e incoherencia de marca justo en el momento de máxima expectativa del usuario.

## ✨ Cambios

- **Éxito** (`activation-success`): banda mística `PremiumHero` con `premium-activacion.webp` (fallback a gradiente noche/índigo garantizado por el propio hero), badge dorado "¡Pago confirmado!", título Cormorant crema y nota "Redirigiendo…".
- **Carga / pendiente / procesamiento / error**: nuevo `StatusPanel` reutilizable → tarjeta `Card` crema centrada, `Reveal` escalonado, título Cormorant, texto `muted-foreground`. Iconos dorados (`text-secondary`) salvo el error (`text-destructive`).
- Erradicada la paleta `purple-*`/`gray-*` y las variantes `dark:` del componente; CTA "Intentar de nuevo" con `Button` de marca + foco dorado (`focus-visible:ring-secondary/50`).
- **Lógica de activación intacta**: polling (2s), timeout (30s), sanitización de `redirect` (anti open-redirect), actualización de store/capabilities.

## ✅ Validaciones

- [x] TDD: tests del canon añadidos (banda de éxito + guardarraíl anti-`purple`/`gray`) — 23 tests verdes.
- [x] Suite completa: **5103 tests** verdes.
- [x] Cobertura `ActivationPage.tsx` ≈ **98.7%** líneas.
- [x] `lint` (0 errores), `type-check`, `build` y `validate-architecture.js` ✅.
- [x] Backlog actualizado (T-PREM-003 → ✅ COMPLETADA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)