### PR TITLE
feat(T-PREM-006): /contacto al canon místico

### DIFF
--- a/docs/BACKLOG_PREMIUM_REDISENO_2026_07.md
+++ b/docs/BACKLOG_PREMIUM_REDISENO_2026_07.md
@@ -480,15 +480,23 @@ Los prompts de upgrade y el modal de bienvenida usan `text-purple-600/700 dark:t
 **Estimación:** 1 punto
 **Dependencias:** T-PREM-001
 **Cubre Hallazgo:** PREM-006
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] CTA y acentos de marca; caja de nota como callout del canon; tokens.
+- [x] CTA y acentos de marca; caja de nota como callout del canon; tokens.
 
 #### 🎯 Criterios de Aceptación
 
-- `/contacto` coherente con la marca; contraste AA.
+- [x] `/contacto` coherente con la marca; contraste AA.
+
+#### 🛠️ Notas de Implementación
+
+- **Cabecera al canon:** acento dorado `Sparkles` (`text-secondary`), título Cormorant con `text-primary` y subtítulo con `text-muted-foreground`; secciones envueltas en `Reveal` escalonado (index 0/1/2).
+- **Caja de nota → callout dorado de marca:** `bg-purple-50` reemplazado por `border-secondary/40 bg-secondary/10` con icono `Mail` dorado; texto migrado a tokens (`text-foreground`/`text-muted-foreground`).
+- **CTA `Enviar Mensaje`:** foco dorado visible `focus-visible:ring-secondary/50` (patrón hermano de T-PREM-005). El botón mantiene el `bg-primary` de marca.
+- **Tokenización:** errores inline del formulario de `text-red-600` crudo a `text-destructive`.
+- **Tests:** actualizados a canon (`page.test.tsx` verifica callout dorado, ausencia de púrpura crudo, título `text-primary` y acento; `ContactForm.test.tsx` fija el foco dorado). 26/26 verdes.
 
 ---
 

--- a/frontend/src/app/contacto/page.test.tsx
+++ b/frontend/src/app/contacto/page.test.tsx
@@ -51,14 +51,14 @@ describe('ContactoPage', () => {
 
   it('should style the alternative contact section as a gold canon callout', () => {
     render(<ContactoPage />);
-    const altContactSection = screen.getByText('Otras formas de contacto').closest('div');
-    expect(altContactSection?.className).toContain('bg-secondary/10');
-    expect(altContactSection?.className).toContain('border-secondary');
+    const callout = screen.getByTestId('contact-callout');
+    expect(callout.className).toContain('bg-secondary/10');
+    expect(callout.className).toContain('border-secondary');
   });
 
   it('should NOT use raw purple palette (off-canon)', () => {
     const { container } = render(<ContactoPage />);
-    expect(container.querySelector('.bg-purple-50')).not.toBeInTheDocument();
+    expect(container.querySelector('[class*="purple"]')).not.toBeInTheDocument();
   });
 
   it('should render the disclaimer banner', () => {

--- a/frontend/src/app/contacto/page.test.tsx
+++ b/frontend/src/app/contacto/page.test.tsx
@@ -49,10 +49,16 @@ describe('ContactoPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('should have proper styling for alternative contact section', () => {
+  it('should style the alternative contact section as a gold canon callout', () => {
+    render(<ContactoPage />);
+    const altContactSection = screen.getByText('Otras formas de contacto').closest('div');
+    expect(altContactSection?.className).toContain('bg-secondary/10');
+    expect(altContactSection?.className).toContain('border-secondary');
+  });
+
+  it('should NOT use raw purple palette (off-canon)', () => {
     const { container } = render(<ContactoPage />);
-    const altContactSection = container.querySelector('.bg-purple-50');
-    expect(altContactSection).toBeInTheDocument();
+    expect(container.querySelector('.bg-purple-50')).not.toBeInTheDocument();
   });
 
   it('should render the disclaimer banner', () => {
@@ -63,5 +69,19 @@ describe('ContactoPage', () => {
   it('should render submit button from ContactForm', () => {
     render(<ContactoPage />);
     expect(screen.getByRole('button', { name: /enviar mensaje/i })).toBeInTheDocument();
+  });
+
+  describe('Canon styling', () => {
+    it('should render the title with the Cormorant serif and brand primary tokens', () => {
+      render(<ContactoPage />);
+      const title = screen.getByRole('heading', { name: 'Contacto', level: 1 });
+      expect(title).toHaveClass('font-serif');
+      expect(title.className).toContain('text-primary');
+    });
+
+    it('should render a gold accent icon in the header', () => {
+      render(<ContactoPage />);
+      expect(screen.getByTestId('contact-accent')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/app/contacto/page.tsx
+++ b/frontend/src/app/contacto/page.tsx
@@ -42,7 +42,10 @@ export default function ContactoPage() {
 
         {/* Alternative Contact Info — callout dorado de marca */}
         <Reveal index={2}>
-          <div className="border-secondary/40 bg-secondary/10 rounded-lg border p-6">
+          <div
+            className="border-secondary/40 bg-secondary/10 rounded-lg border p-6"
+            data-testid="contact-callout"
+          >
             <h2 className="text-foreground mb-3 flex items-center gap-2 font-semibold">
               <Mail className="text-secondary h-4 w-4" aria-hidden="true" />
               Otras formas de contacto

--- a/frontend/src/app/contacto/page.tsx
+++ b/frontend/src/app/contacto/page.tsx
@@ -1,11 +1,16 @@
+import { Mail, Sparkles } from 'lucide-react';
+
 import { DisclaimerBanner } from '@/components/ui/disclaimer-banner';
+import { Reveal } from '@/components/common/Reveal';
 import { ContactForm } from '@/components/features/contact/ContactForm';
 
 /**
  * Página de Contacto
  *
- * Layout para el formulario de contacto.
- * La lógica del formulario está en ContactForm component siguiendo arquitectura feature-based.
+ * Layout místico (canon premium) para el formulario de contacto:
+ * cabecera con acento dorado + Cormorant, tarjeta de formulario y la nota de
+ * contacto como callout dorado de marca. La lógica del formulario vive en
+ * `ContactForm` siguiendo la arquitectura feature-based.
  *
  * TODO: Implementar envío real de correo o integración con backend.
  */
@@ -14,30 +19,44 @@ export default function ContactoPage() {
     <div className="container py-8">
       <div className="mx-auto max-w-2xl space-y-6">
         {/* Header */}
-        <div className="space-y-2 text-center">
-          <h1 className="text-text-primary font-serif text-4xl font-bold">Contacto</h1>
-          <p className="text-text-muted text-lg">
-            ¿Tienes preguntas o sugerencias? Nos encantaría escucharte
-          </p>
-        </div>
-
-        {/* Form */}
-        <div className="bg-card rounded-lg border p-6">
-          <ContactForm />
-        </div>
-
-        {/* Alternative Contact Info */}
-        <div className="rounded-lg bg-purple-50 p-6">
-          <h2 className="text-text-primary mb-3 font-semibold">Otras formas de contacto</h2>
-          <div className="text-text-secondary space-y-2 text-sm">
-            <p>
-              <strong>Email:</strong> contacto@auguria.com
-            </p>
-            <p className="text-text-muted">
-              Respondemos todos los mensajes en un plazo de 24-48 horas.
+        <Reveal index={0}>
+          <div className="space-y-2 text-center">
+            <Sparkles
+              className="text-secondary mx-auto h-8 w-8"
+              aria-hidden="true"
+              data-testid="contact-accent"
+            />
+            <h1 className="text-primary font-serif text-4xl font-bold">Contacto</h1>
+            <p className="text-muted-foreground text-lg">
+              ¿Tienes preguntas o sugerencias? Nos encantaría escucharte
             </p>
           </div>
-        </div>
+        </Reveal>
+
+        {/* Form */}
+        <Reveal index={1}>
+          <div className="bg-card rounded-lg border p-6">
+            <ContactForm />
+          </div>
+        </Reveal>
+
+        {/* Alternative Contact Info — callout dorado de marca */}
+        <Reveal index={2}>
+          <div className="border-secondary/40 bg-secondary/10 rounded-lg border p-6">
+            <h2 className="text-foreground mb-3 flex items-center gap-2 font-semibold">
+              <Mail className="text-secondary h-4 w-4" aria-hidden="true" />
+              Otras formas de contacto
+            </h2>
+            <div className="text-foreground space-y-2 text-sm">
+              <p>
+                <strong>Email:</strong> contacto@auguria.com
+              </p>
+              <p className="text-muted-foreground">
+                Respondemos todos los mensajes en un plazo de 24-48 horas.
+              </p>
+            </div>
+          </div>
+        </Reveal>
 
         {/* Disclaimer */}
         <DisclaimerBanner message="Este formulario es funcional pero el envío de correos aún no está implementado. Los mensajes se muestran en la consola del navegador." />

--- a/frontend/src/components/features/contact/ContactForm.test.tsx
+++ b/frontend/src/components/features/contact/ContactForm.test.tsx
@@ -73,6 +73,14 @@ describe('ContactForm', () => {
     });
   });
 
+  describe('Canon styling', () => {
+    it('should give the submit CTA a visible gold focus ring', () => {
+      render(<ContactForm />);
+      const submitButton = screen.getByRole('button', { name: /enviar mensaje/i });
+      expect(submitButton.className).toContain('focus-visible:ring-secondary');
+    });
+  });
+
   describe('Form Structure', () => {
     it('should use React Hook Form integration', () => {
       render(<ContactForm />);

--- a/frontend/src/components/features/contact/ContactForm.tsx
+++ b/frontend/src/components/features/contact/ContactForm.tsx
@@ -82,7 +82,7 @@ export function ContactForm() {
           disabled={isSubmitting}
           {...register('name')}
         />
-        {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
+        {errors.name && <p className="text-destructive text-sm">{errors.name.message}</p>}
       </div>
 
       {/* Email */}
@@ -98,7 +98,7 @@ export function ContactForm() {
           disabled={isSubmitting}
           {...register('email')}
         />
-        {errors.email && <p className="text-sm text-red-600">{errors.email.message}</p>}
+        {errors.email && <p className="text-destructive text-sm">{errors.email.message}</p>}
       </div>
 
       {/* Subject */}
@@ -114,7 +114,7 @@ export function ContactForm() {
           disabled={isSubmitting}
           {...register('subject')}
         />
-        {errors.subject && <p className="text-sm text-red-600">{errors.subject.message}</p>}
+        {errors.subject && <p className="text-destructive text-sm">{errors.subject.message}</p>}
       </div>
 
       {/* Message */}
@@ -127,11 +127,16 @@ export function ContactForm() {
           disabled={isSubmitting}
           {...register('message')}
         />
-        {errors.message && <p className="text-sm text-red-600">{errors.message.message}</p>}
+        {errors.message && <p className="text-destructive text-sm">{errors.message.message}</p>}
       </div>
 
       {/* Submit Button */}
-      <Button type="submit" className="w-full" disabled={isSubmitting} size="lg">
+      <Button
+        type="submit"
+        className="focus-visible:ring-secondary/50 w-full"
+        disabled={isSubmitting}
+        size="lg"
+      >
         {isSubmitting ? 'Enviando...' : 'Enviar Mensaje'}
       </Button>
 


### PR DESCRIPTION
## 🎯 Objetivo

T-PREM-006 (Hallazgo PREM-006): llevar `/contacto` al **canon místico premium**. La página era legible pero off-canon (CTA/caja de nota en púrpura crudo). Ahora usa acentos dorados de marca y tokens del sistema.

## ✨ Cambios

- **Cabecera al canon:** acento dorado `Sparkles` (`text-secondary`), título Cormorant con `text-primary`, subtítulo con `text-muted-foreground`; secciones envueltas en `Reveal` con reveal escalonado.
- **Caja de nota → callout dorado de marca:** se reemplaza `bg-purple-50` por `border-secondary/40 bg-secondary/10` con icono `Mail` dorado; textos migrados a tokens (`text-foreground`/`text-muted-foreground`).
- **CTA `Enviar Mensaje`:** foco dorado visible `focus-visible:ring-secondary/50` (patrón hermano de T-PREM-005). El botón mantiene el `bg-primary` de marca.
- **Tokenización:** errores inline del formulario de `text-red-600` crudo a `text-destructive`.

## ✅ Criterios de Aceptación

- [x] `/contacto` coherente con la marca (dorado/primario del sistema + tokens); caja de nota como callout del canon.
- [x] Sin `purple-*` crudo; contraste AA (tokens de marca).

## 🧪 Calidad

- [x] TDD: tests actualizados al canon primero (RED → GREEN). **26/26 verdes** en `/contacto`.
- [x] `npm run test:run` — suite completa verde (el único "error" es un warning de hidratación **preexistente** en `admin/UsersTable`, ajeno a este cambio).
- [x] `lint:fix` sin errores · `type-check` limpio · `build` OK · `validate-architecture` OK.
- [x] Backlog actualizado (T-PREM-006 → ✅ COMPLETADA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)