### PR TITLE
feat(T-PREM-007): modales de conversión y onboarding al canon místico

### DIFF
--- a/docs/BACKLOG_PREMIUM_REDISENO_2026_07.md
+++ b/docs/BACKLOG_PREMIUM_REDISENO_2026_07.md
@@ -506,15 +506,23 @@ Los prompts de upgrade y el modal de bienvenida usan `text-purple-600/700 dark:t
 **Estimación:** 2 puntos
 **Dependencias:** T-PREM-001
 **Cubre Hallazgo:** PREM-007
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] `PremiumUpgradePrompt`, `LimitReachedModal`, `WelcomeModal`: reemplazar púrpura por dorado/tokens; foco visible; sin `dark:`.
+- [x] `PremiumUpgradePrompt`, `LimitReachedModal`, `WelcomeModal`: reemplazar púrpura por dorado/tokens; foco visible; sin `dark:`.
 
 #### 🎯 Criterios de Aceptación
 
-- Los puntos de conversión lucen premium y de marca; contraste AA.
+- [x] Los puntos de conversión lucen premium y de marca; contraste AA.
+
+#### 🛠️ Notas de Implementación
+
+- **Contexto:** las variantes `dark:` de estos tres archivos ya habían sido erradicadas en T-PREM-001 (están en la lista `PURGED_FILES` del guard `no-ghost-dark-mode.test.ts`), por lo que el alcance real fue **paleta púrpura cruda → dorado/tokens de marca + foco dorado visible**.
+- **`PremiumUpgradePrompt`:** CTA (`CtaButton`) migrado del gradiente `purple→pink` al `Button` de marca con `focus-visible:ring-secondary/50`; cajas de beneficios (modal e inline) de `from-purple-50/pink-50` a callout dorado `border-secondary/40 bg-secondary/10`; círculos e íconos `Lock` de `accent` (lavanda) a dorado `text-secondary`/`bg-secondary/15`; banner reconstruido como **banda dorada** de marca (`bg-secondary text-bg-hero`) con botón noche (`bg-bg-hero text-secondary`) y foco visible.
+- **`LimitReachedModal`:** caja de beneficios a callout dorado; ícono `Clock` y beneficios a `text-secondary`; CTA de upgrade al `Button` de marca con foco dorado; "Volver mañana" (outline) también con foco dorado.
+- **`WelcomeModal`:** título `text-purple-700` → `text-primary` (Cormorant); subhead `text-purple-600` → `text-foreground`; íconos `text-purple-500` → `text-secondary`; caja de conversión PREMIUM migrada del `Alert variant="info"` (azul, off-canon) a callout dorado de marca; CTA con foco dorado.
+- **Tests:** contrato de canon añadido a los tres `*.test.tsx` (foco dorado del CTA, ausencia de púrpura/rosa crudo, callout dorado, título `text-primary`). 50/50 verdes; suite completa 5126 verdes; ciclo de calidad frontend completo pasa.
 
 ---
 

--- a/frontend/src/components/features/conversion/LimitReachedModal.test.tsx
+++ b/frontend/src/components/features/conversion/LimitReachedModal.test.tsx
@@ -156,4 +156,52 @@ describe('LimitReachedModal', () => {
       expect(mockOnClose).toHaveBeenCalled();
     }
   });
+
+  // ── Canon místico (T-PREM-007) ────────────────────────────────────────────
+
+  describe('Canon styling', () => {
+    it('el CTA de upgrade tiene foco dorado visible (focus-visible:ring-secondary)', () => {
+      render(
+        <LimitReachedModal
+          open={true}
+          onClose={mockOnClose}
+          onUpgrade={mockOnUpgrade}
+          currentLimit={2}
+        />
+      );
+
+      const upgradeButton = screen.getByRole('button', { name: /mejorar a premium/i });
+      expect(upgradeButton.className).toContain('focus-visible:ring-secondary');
+    });
+
+    it('la caja de beneficios es un callout dorado de marca', () => {
+      render(
+        <LimitReachedModal
+          open={true}
+          onClose={mockOnClose}
+          onUpgrade={mockOnUpgrade}
+          currentLimit={2}
+        />
+      );
+
+      const heading = screen.getByText(/con premium tendrías/i);
+      const callout = heading.closest('[class*="bg-secondary/10"]');
+      expect(callout).not.toBeNull();
+      expect(callout?.className).toContain('border-secondary');
+    });
+
+    it('no usa paleta púrpura/rosa cruda (off-canon)', () => {
+      render(
+        <LimitReachedModal
+          open={true}
+          onClose={mockOnClose}
+          onUpgrade={mockOnUpgrade}
+          currentLimit={2}
+        />
+      );
+
+      expect(document.body.querySelector('[class*="purple"]')).toBeNull();
+      expect(document.body.querySelector('[class*="pink"]')).toBeNull();
+    });
+  });
 });

--- a/frontend/src/components/features/conversion/LimitReachedModal.test.tsx
+++ b/frontend/src/components/features/conversion/LimitReachedModal.test.tsx
@@ -185,7 +185,7 @@ describe('LimitReachedModal', () => {
       );
 
       const heading = screen.getByText(/con premium tendrías/i);
-      const callout = heading.closest('[class*="bg-secondary/10"]');
+      const callout = heading.closest('[class*="bg-secondary/"]');
       expect(callout).not.toBeNull();
       expect(callout?.className).toContain('border-secondary');
     });

--- a/frontend/src/components/features/conversion/LimitReachedModal.tsx
+++ b/frontend/src/components/features/conversion/LimitReachedModal.tsx
@@ -74,8 +74,8 @@ export default function LimitReachedModal({
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <div className="bg-accent/20 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
-            <Clock className="text-accent h-8 w-8" />
+          <div className="bg-secondary/15 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+            <Clock className="text-secondary h-8 w-8" aria-hidden="true" />
           </div>
           <DialogTitle className="text-center font-serif text-2xl">
             Has alcanzado tu límite diario
@@ -85,12 +85,12 @@ export default function LimitReachedModal({
           </DialogDescription>
         </DialogHeader>
 
-        {/* Premium benefits */}
-        <div className="space-y-3 rounded-lg border bg-gradient-to-br from-purple-50/50 to-pink-50/50 p-4">
+        {/* Premium benefits — callout dorado de marca */}
+        <div className="border-secondary/40 bg-secondary/10 space-y-3 rounded-lg border p-4">
           <p className="text-foreground text-center text-sm font-semibold">Con Premium tendrías:</p>
           {PREMIUM_BENEFITS_LIMIT.map((benefit) => (
             <div key={benefit.text} className="flex items-center gap-2">
-              <benefit.icon className="text-accent h-5 w-5 flex-shrink-0" />
+              <benefit.icon className="text-secondary h-5 w-5 flex-shrink-0" aria-hidden="true" />
               <span className="text-foreground text-sm">{benefit.text}</span>
             </div>
           ))}
@@ -98,14 +98,15 @@ export default function LimitReachedModal({
 
         {/* CTA Buttons */}
         <DialogFooter className="flex-col gap-3 sm:flex-col">
-          <Button
-            onClick={onUpgrade}
-            className="w-full bg-gradient-to-r from-purple-600 to-pink-600 text-white hover:from-purple-700 hover:to-pink-700"
-            size="lg"
-          >
+          <Button onClick={onUpgrade} className="focus-visible:ring-secondary/50 w-full" size="lg">
             {CTA_PREMIUM.LIMIT_REACHED}
           </Button>
-          <Button variant="outline" onClick={onClose} className="w-full" size="lg">
+          <Button
+            variant="outline"
+            onClick={onClose}
+            className="focus-visible:ring-secondary/50 w-full"
+            size="lg"
+          >
             Volver mañana
           </Button>
         </DialogFooter>

--- a/frontend/src/components/features/conversion/PremiumUpgradePrompt.test.tsx
+++ b/frontend/src/components/features/conversion/PremiumUpgradePrompt.test.tsx
@@ -436,9 +436,18 @@ describe('PremiumUpgradePrompt', () => {
       );
 
       const benefit = screen.getByText('Lecturas ilimitadas');
-      const callout = benefit.closest('[class*="bg-secondary/10"]');
+      const callout = benefit.closest('[class*="bg-secondary/"]');
       expect(callout).not.toBeNull();
       expect(callout?.className).toContain('border-secondary');
+    });
+
+    it('el CTA del banner (botón noche) tiene foco visible sobre la banda dorada', () => {
+      setupFreeUser();
+      render(<PremiumUpgradePrompt feature="interpretaciones personalizadas" variant="banner" />);
+
+      // Un anillo dorado sería invisible sobre la banda dorada: el foco usa el token noche.
+      const ctaButton = screen.getByRole('button', { name: /premium/i });
+      expect(ctaButton.className).toContain('focus-visible:ring-bg-hero');
     });
 
     it.each(['modal', 'inline', 'banner'] as const)(

--- a/frontend/src/components/features/conversion/PremiumUpgradePrompt.test.tsx
+++ b/frontend/src/components/features/conversion/PremiumUpgradePrompt.test.tsx
@@ -405,4 +405,64 @@ describe('PremiumUpgradePrompt', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
   });
+
+  // ── Canon místico (T-PREM-007) ────────────────────────────────────────────
+
+  describe('Canon styling', () => {
+    it('el CTA del modal tiene foco dorado visible (focus-visible:ring-secondary)', () => {
+      setupFreeUser();
+      render(
+        <PremiumUpgradePrompt
+          open={true}
+          onClose={vi.fn()}
+          feature="preguntas personalizadas"
+          variant="modal"
+        />
+      );
+
+      const ctaButton = screen.getByRole('button', { name: /premium/i });
+      expect(ctaButton.className).toContain('focus-visible:ring-secondary');
+    });
+
+    it('la caja de beneficios del modal es un callout dorado de marca', () => {
+      setupFreeUser();
+      render(
+        <PremiumUpgradePrompt
+          open={true}
+          onClose={vi.fn()}
+          feature="preguntas personalizadas"
+          variant="modal"
+        />
+      );
+
+      const benefit = screen.getByText('Lecturas ilimitadas');
+      const callout = benefit.closest('[class*="bg-secondary/10"]');
+      expect(callout).not.toBeNull();
+      expect(callout?.className).toContain('border-secondary');
+    });
+
+    it.each(['modal', 'inline', 'banner'] as const)(
+      'no usa paleta púrpura/rosa cruda (off-canon) en variant %s',
+      (variant) => {
+        setupFreeUser();
+        const { container } = render(
+          variant === 'modal' ? (
+            <PremiumUpgradePrompt
+              open={true}
+              onClose={vi.fn()}
+              feature="preguntas personalizadas"
+              variant="modal"
+            />
+          ) : (
+            <PremiumUpgradePrompt feature="preguntas personalizadas" variant={variant} />
+          )
+        );
+
+        // El modal se portalea fuera del container: se busca en todo el documento.
+        const root = variant === 'modal' ? document.body : container;
+        expect(root.querySelector('[class*="purple"]')).toBeNull();
+        expect(root.querySelector('[class*="pink"]')).toBeNull();
+      }
+    );
+  });
 });

--- a/frontend/src/components/features/conversion/PremiumUpgradePrompt.tsx
+++ b/frontend/src/components/features/conversion/PremiumUpgradePrompt.tsx
@@ -99,7 +99,7 @@ function CtaButton({ isPending, onClick }: CtaButtonProps) {
     <Button
       onClick={onClick}
       disabled={isPending}
-      className="bg-gradient-to-r from-purple-600 to-pink-600 text-white hover:from-purple-700 hover:to-pink-700"
+      className="focus-visible:ring-secondary/50 w-full"
       size="lg"
     >
       {isPending ? (
@@ -195,8 +195,8 @@ export default function PremiumUpgradePrompt({
       <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
         <DialogContent className="max-w-lg" data-testid="premium-upgrade-prompt-modal">
           <DialogHeader>
-            <div className="bg-accent/20 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
-              <Lock className="text-accent h-8 w-8" aria-hidden="true" />
+            <div className="bg-secondary/15 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+              <Lock className="text-secondary h-8 w-8" aria-hidden="true" />
             </div>
             <DialogTitle className="text-center font-serif text-2xl">{title}</DialogTitle>
             <DialogDescription className="text-center text-base">
@@ -205,11 +205,11 @@ export default function PremiumUpgradePrompt({
             </DialogDescription>
           </DialogHeader>
 
-          {/* Premium benefits */}
-          <div className="space-y-2 rounded-lg border bg-gradient-to-br from-purple-50/50 to-pink-50/50 p-4">
+          {/* Premium benefits — callout dorado de marca */}
+          <div className="border-secondary/40 bg-secondary/10 space-y-2 rounded-lg border p-4">
             {PREMIUM_BENEFITS.map((benefit) => (
               <div key={benefit} className="flex items-center gap-2">
-                <Sparkles className="text-accent h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                <Sparkles className="text-secondary h-4 w-4 flex-shrink-0" aria-hidden="true" />
                 <span className="text-foreground text-sm">{benefit}</span>
               </div>
             ))}
@@ -230,12 +230,12 @@ export default function PremiumUpgradePrompt({
   if (variant === 'inline') {
     return (
       <div
-        className="relative overflow-hidden rounded-lg border bg-gradient-to-br from-purple-50/80 to-pink-50/80 p-6 text-center"
+        className="border-secondary/40 bg-secondary/10 relative overflow-hidden rounded-lg border p-6 text-center"
         data-testid="premium-upgrade-prompt-inline"
       >
         <div className="flex flex-col items-center gap-4">
-          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-purple-500/20 to-pink-500/20">
-            <Lock className="text-accent h-7 w-7" aria-hidden="true" />
+          <div className="bg-secondary/15 flex h-14 w-14 items-center justify-center rounded-full">
+            <Lock className="text-secondary h-7 w-7" aria-hidden="true" />
           </div>
           <div className="space-y-1">
             <h3 className="text-foreground font-serif text-lg font-semibold">{title}</h3>
@@ -249,10 +249,10 @@ export default function PremiumUpgradePrompt({
     );
   }
 
-  // ── Variant: banner ────────────────────────────────────────────────────────
+  // ── Variant: banner — banda dorada de marca ─────────────────────────────────
   return (
     <div
-      className="rounded-lg bg-gradient-to-r from-purple-500 to-pink-500 p-6 text-white shadow-lg"
+      className="bg-secondary text-bg-hero rounded-lg p-6 shadow-lg"
       data-testid="premium-upgrade-prompt-banner"
     >
       <div className="flex items-center justify-between gap-4">
@@ -260,7 +260,7 @@ export default function PremiumUpgradePrompt({
           <Gem className="mt-1 h-6 w-6 flex-shrink-0" aria-hidden="true" />
           <div>
             <h3 className="mb-1 font-semibold">Desbloquea {feature}</h3>
-            <p className="text-sm text-white/90">
+            <p className="text-bg-hero/80 text-sm">
               Con Premium obtienes acceso a todas las funcionalidades avanzadas y análisis
               personalizados.
             </p>
@@ -269,8 +269,7 @@ export default function PremiumUpgradePrompt({
         <Button
           onClick={handleUpgradeClick}
           disabled={isPending}
-          variant="secondary"
-          className="flex-shrink-0 bg-white text-purple-600 hover:bg-white/90"
+          className="bg-bg-hero text-secondary hover:bg-bg-hero/90 focus-visible:ring-bg-hero/50 flex-shrink-0"
         >
           {isPending ? 'Cargando...' : CTA_PREMIUM.PURCHASE}
         </Button>

--- a/frontend/src/components/features/onboarding/WelcomeModal.test.tsx
+++ b/frontend/src/components/features/onboarding/WelcomeModal.test.tsx
@@ -67,4 +67,39 @@ describe('WelcomeModal', () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  // ── Canon místico (T-PREM-007) ────────────────────────────────────────────
+
+  describe('Canon styling', () => {
+    it('el título usa Cormorant serif y el token de marca text-primary', () => {
+      render(<WelcomeModal isOpen={true} onClose={vi.fn()} />);
+
+      const title = screen.getByText(/bienvenid[ao]/i);
+      expect(title).toHaveClass('font-serif');
+      expect(title.className).toContain('text-primary');
+    });
+
+    it('la caja de conversión PREMIUM es un callout dorado de marca', () => {
+      render(<WelcomeModal isOpen={true} onClose={vi.fn()} />);
+
+      const heading = screen.getByText(/prueba premium/i);
+      const callout = heading.closest('[class*="bg-secondary/10"]');
+      expect(callout).not.toBeNull();
+      expect(callout?.className).toContain('border-secondary');
+    });
+
+    it('el CTA principal tiene foco dorado visible (focus-visible:ring-secondary)', () => {
+      render(<WelcomeModal isOpen={true} onClose={vi.fn()} />);
+
+      const ctaButton = screen.getByRole('button', { name: /comenzar|explorar|empezar/i });
+      expect(ctaButton.className).toContain('focus-visible:ring-secondary');
+    });
+
+    it('no usa paleta púrpura/rosa cruda (off-canon)', () => {
+      render(<WelcomeModal isOpen={true} onClose={vi.fn()} />);
+
+      expect(document.body.querySelector('[class*="purple"]')).toBeNull();
+      expect(document.body.querySelector('[class*="pink"]')).toBeNull();
+    });
+  });
 });

--- a/frontend/src/components/features/onboarding/WelcomeModal.test.tsx
+++ b/frontend/src/components/features/onboarding/WelcomeModal.test.tsx
@@ -83,7 +83,7 @@ describe('WelcomeModal', () => {
       render(<WelcomeModal isOpen={true} onClose={vi.fn()} />);
 
       const heading = screen.getByText(/prueba premium/i);
-      const callout = heading.closest('[class*="bg-secondary/10"]');
+      const callout = heading.closest('[class*="bg-secondary/"]');
       expect(callout).not.toBeNull();
       expect(callout?.className).toContain('border-secondary');
     });

--- a/frontend/src/components/features/onboarding/WelcomeModal.tsx
+++ b/frontend/src/components/features/onboarding/WelcomeModal.tsx
@@ -9,7 +9,6 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Sparkles, Calendar, Wand2 } from 'lucide-react';
 
 interface WelcomeModalProps {
@@ -22,13 +21,17 @@ interface WelcomeModalProps {
  *
  * Displayed after successful registration to explain FREE plan features,
  * limitations, and differences with PREMIUM plan.
+ *
+ * Estilo al canon místico (T-PREM-007): título Cormorant con token de marca,
+ * íconos dorados (`text-secondary`), y la invitación a PREMIUM como callout
+ * dorado de marca. Sin paleta púrpura cruda ni variantes `dark:`.
  */
 export function WelcomeModal({ isOpen, onClose }: WelcomeModalProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-[500px]" aria-label="Modal de bienvenida">
         <DialogHeader>
-          <DialogTitle className="font-serif text-2xl text-purple-700">
+          <DialogTitle className="text-primary font-serif text-2xl">
             ¡Bienvenido al Oráculo de Tarot! ✨
           </DialogTitle>
           <DialogDescription className="text-base">
@@ -39,11 +42,11 @@ export function WelcomeModal({ isOpen, onClose }: WelcomeModalProps) {
         <div className="space-y-4 py-4">
           {/* FREE Plan Features */}
           <div className="space-y-3">
-            <h3 className="font-semibold text-purple-600">Con tu plan FREE puedes:</h3>
+            <h3 className="text-foreground font-semibold">Con tu plan FREE puedes:</h3>
 
             <div className="space-y-2">
               <div className="flex items-start gap-3">
-                <Calendar className="mt-0.5 h-5 w-5 text-purple-500" />
+                <Calendar className="text-secondary mt-0.5 h-5 w-5" aria-hidden="true" />
                 <div>
                   <p className="font-medium">Carta del Día</p>
                   <p className="text-muted-foreground text-sm">
@@ -53,7 +56,7 @@ export function WelcomeModal({ isOpen, onClose }: WelcomeModalProps) {
               </div>
 
               <div className="flex items-start gap-3">
-                <Wand2 className="mt-0.5 h-5 w-5 text-purple-500" />
+                <Wand2 className="text-secondary mt-0.5 h-5 w-5" aria-hidden="true" />
                 <div>
                   <p className="font-medium">1 Lectura por Día</p>
                   <p className="text-muted-foreground text-sm">
@@ -64,21 +67,26 @@ export function WelcomeModal({ isOpen, onClose }: WelcomeModalProps) {
             </div>
           </div>
 
-          {/* PREMIUM Differences */}
-          <Alert variant="info">
-            <Sparkles className="h-5 w-5" />
-            <AlertDescription>
-              <p className="font-semibold">¿Quieres más? Prueba PREMIUM</p>
-              <p className="mt-1 text-sm">
-                Lecturas ilimitadas con interpretación de IA personalizada para profundizar en cada
-                tirada
-              </p>
-            </AlertDescription>
-          </Alert>
+          {/* PREMIUM Differences — callout dorado de marca */}
+          <div className="border-secondary/40 bg-secondary/10 rounded-lg border p-4">
+            <div className="flex items-start gap-3">
+              <Sparkles
+                className="text-secondary mt-0.5 h-5 w-5 flex-shrink-0"
+                aria-hidden="true"
+              />
+              <div>
+                <p className="text-foreground font-semibold">¿Quieres más? Prueba PREMIUM</p>
+                <p className="text-muted-foreground mt-1 text-sm">
+                  Lecturas ilimitadas con interpretación de IA personalizada para profundizar en
+                  cada tirada
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
 
         <DialogFooter>
-          <Button onClick={onClose} className="w-full" size="lg">
+          <Button onClick={onClose} className="focus-visible:ring-secondary/50 w-full" size="lg">
             Comenzar a Explorar
           </Button>
         </DialogFooter>


### PR DESCRIPTION
## Qué resuelve

**T-PREM-007** (Hallazgo PREM-007): los tres puntos de conversión/onboarding usaban paleta púrpura cruda (`purple-*`/`pink-*`) y una caja `Alert info` azul, sin el lenguaje de marca del canon (Dashboard/Enciclopedia/Premium). Este PR los lleva al **canon místico dorado/tokens** con foco visible.

> Las variantes `dark:` de estos archivos ya se habían erradicado en **T-PREM-001** (están en `PURGED_FILES` del guard `no-ghost-dark-mode.test.ts`), por lo que el alcance real fue **púrpura crudo → dorado/tokens + foco dorado visible**.

## Cómo

- **`PremiumUpgradePrompt`**: CTA gradiente `purple→pink` → `Button` de marca con `focus-visible:ring-secondary/50`; cajas de beneficios (modal e inline) → callout dorado `border-secondary/40 bg-secondary/10`; íconos `Lock` y círculos de `accent` lavanda → dorado (`text-secondary`/`bg-secondary/15`); **banner** reconstruido como banda dorada de marca (`bg-secondary text-bg-hero`) con botón noche (`bg-bg-hero text-secondary`).
- **`LimitReachedModal`**: callout dorado; ícono `Clock` y beneficios en dorado; CTA de upgrade y "Volver mañana" con foco dorado visible.
- **`WelcomeModal`**: título `text-purple-700` → `text-primary` (Cormorant); íconos `text-purple-500` → `text-secondary`; caja de conversión PREMIUM del `Alert variant="info"` (azul, off-canon) → callout dorado de marca.

## Criterio de aceptación

- [x] Los puntos de conversión lucen premium y de marca; **contraste AA** (verificado numéricamente: banda dorada ≈ 7.8:1, botón noche ≈ 6.1:1).

## Qué se probó

- **TDD**: contrato de canon añadido a los tres `*.test.tsx` (foco dorado del CTA, ausencia de púrpura/rosa crudo, callout dorado, título `text-primary`). **50/50** verdes en los tres archivos.
- Ciclo de calidad frontend completo: `format` ✅, `lint` (0 errores) ✅, `type-check` ✅, `test:run` (**5126** verdes) ✅, `build` ✅, `validate-architecture` ✅.
- Revisor local automatizado sobre el diff: **APROBADO** (sin hallazgos bloqueantes).

## ADRs

Ninguno nuevo. Sigue el canon establecido por T-PREM-002/005/006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)