### PR TITLE
test(T-PREM-008): a11y del circuito premium (contraste AA, foco, alt, reduced-motion)

### DIFF
--- a/docs/BACKLOG_PREMIUM_REDISENO_2026_07.md
+++ b/docs/BACKLOG_PREMIUM_REDISENO_2026_07.md
@@ -532,18 +532,30 @@ Los prompts de upgrade y el modal de bienvenida usan `text-purple-600/700 dark:t
 **Estimación:** 1.5 puntos
 **Dependencias:** T-PREM-002, T-PREM-003
 **Cubre Hallazgo:** PREM-001, PREM-008 (verificación)
-**Estado:** ⬜ Pendiente
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] Verificar contraste AA con la utilidad `lib/utils/contrast.ts` (getContrastRatio/meetsWcagAA, de T-DASH-007): banda, chips dorados con texto noche, tabla, FAQ.
-- [ ] Foco visible en CTAs/links; `alt` en imágenes nuevas; `prefers-reduced-motion` respetado.
-- [ ] Tests que fijen el contrato de contraste/alt/foco (análogo T-DASH-007).
+- [x] Verificar contraste AA con la utilidad `lib/utils/contrast.ts` (getContrastRatio/meetsWcagAA, de T-DASH-007): banda, chips dorados con texto noche, tabla, FAQ.
+- [x] Foco visible en CTAs/links; `alt` en imágenes nuevas; `prefers-reduced-motion` respetado.
+- [x] Tests que fijen el contrato de contraste/alt/foco (análogo T-DASH-007).
 
 #### 🎯 Criterios de Aceptación
 
-- Todo el circuito premium cumple AA; imágenes con `alt`; foco visible; movimiento reducido respetado.
-- Ciclo de calidad frontend completo pasa.
+- [x] Todo el circuito premium cumple AA; imágenes con `alt`; foco visible; movimiento reducido respetado.
+- [x] Ciclo de calidad frontend completo pasa.
+
+#### 🛠️ Notas de Implementación
+
+- **Verificación (no requirió cambios de código):** el circuito premium ya satisfacía el contrato tras T-PREM-002/003/004. Los ratios de contraste medidos con la fórmula WCAG de `contrast.ts` cumplen AA con holgura: crema sobre banda noche ≈ 17.4:1, chip dorado con texto noche ≈ 7.8:1, crema atenuada del subtítulo/encabezado "Free" ≥ 7.5:1 incluso sobre el punto más claro del gradiente (índigo `#2d1b69`), texto `foreground` de tabla/FAQ sobre superficie blanca ≈ 12:1.
+- **Contrato de contraste (nuevo, análogo T-DASH-007):** `components/features/premium/premium-a11y.test.ts` (8 casos) fija con `getContrastRatio`/`meetsWcagAA` los pares de color que el hero/tabla/activación controlan con hex hardcodeados. Como esas cremas se usan con alfa (`rgba(…, 0.72)`), el test las **compone** sobre el fondo noche y verifica el color resultante (lo que ve el usuario), no el token con transparencia.
+- **Contratos de foco/alt/reduced-motion/aria (verificación de cierre):** añadidos a los tests de componentes reutilizando sus harnesses — `PremiumHero.test.tsx` (overlay/estrellas/luna decorativos `aria-hidden`), `PremiumPage.test.tsx` (foco dorado visible en `cta-hero`/`cta-card`/`cta-bottom`, `aria-label` "Incluido"/"No incluido" en los iconos de la tabla, secciones envueltas en `Reveal` → `prefers-reduced-motion` respetado, `alt` no vacío en la banda), `ActivationPage.test.tsx` (foco dorado del CTA "Intentar de nuevo", iconos de estado `aria-hidden`, `alt` de la banda de éxito).
+- **Motion reducido:** ya garantizado por `Reveal` (deriva estado visible inmediato con `prefers-reduced-motion`) y por `globals.css`, que neutraliza `animate-twinkle`/reveal bajo movimiento reducido sin apagar los spinners informativos.
+- **Suite completa:** 5144 verdes (+18); ciclo de calidad frontend completo pasa (`format` · `lint:fix` 0 errores · `type-check` · `test:run` · `build` · `validate-architecture` ✓).
+
+#### 📁 Archivos involucrados
+
+- `components/features/premium/premium-a11y.test.ts` (nuevo, contrato de contraste) + `PremiumHero.test.tsx` / `PremiumPage.test.tsx` / `ActivationPage.test.tsx` (asserts de foco/alt/reduced-motion/aria). Sin cambios en código de producción (verificación de cierre).
 
 ---
 

--- a/frontend/src/components/features/premium/ActivationPage.test.tsx
+++ b/frontend/src/components/features/premium/ActivationPage.test.tsx
@@ -563,4 +563,60 @@ describe('ActivationPage', () => {
       expect(screen.getByRole('heading', { level: 1 })).toHaveClass('font-serif');
     });
   });
+
+  // ============================================================================
+  // Accesibilidad — cierre del circuito premium (T-PREM-008)
+  // ============================================================================
+
+  describe('Accesibilidad (T-PREM-008)', () => {
+    it('should give the failure retry CTA a visible focus ring (foco visible)', () => {
+      mockSearchParams.get.mockImplementation((key: string) => {
+        if (key === 'status') return 'failure';
+        return null;
+      });
+
+      renderWithProviders(<ActivationPage />);
+
+      const retryBtn = screen.getByTestId('btn-retry');
+      expect(retryBtn.className).toMatch(/focus-visible:ring-secondary/);
+    });
+
+    it('should mark the state icons as decorative (aria-hidden)', () => {
+      mockSearchParams.get.mockImplementation((key: string) => {
+        if (key === 'status') return 'failure';
+        return null;
+      });
+
+      const { container } = renderWithProviders(<ActivationPage />);
+
+      // El icono de estado (XCircle) es decorativo: el título ya comunica el estado.
+      expect(container.querySelectorAll('[aria-hidden="true"]').length).toBeGreaterThan(0);
+    });
+
+    it('should render the success band asset with a non-empty Spanish alt (imagen con alt)', async () => {
+      mockSearchParams.get.mockImplementation((key: string) => {
+        if (key === 'status') return 'authorized';
+        return null;
+      });
+      mockUseSubscriptionStatus.mockReturnValue({
+        data: {
+          plan: 'premium',
+          subscriptionStatus: 'active',
+          planExpiresAt: '2026-04-01T00:00:00Z',
+          mpPreapprovalId: 'mp_123',
+        },
+        isLoading: false,
+      });
+
+      renderWithProviders(<ActivationPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activation-success')).toBeInTheDocument();
+      });
+
+      const bandImage = screen.getByTestId('next-image');
+      expect(bandImage).toHaveAttribute('alt');
+      expect(bandImage.getAttribute('alt')?.trim().length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/frontend/src/components/features/premium/ActivationPage.test.tsx
+++ b/frontend/src/components/features/premium/ActivationPage.test.tsx
@@ -581,7 +581,7 @@ describe('ActivationPage', () => {
       expect(retryBtn.className).toMatch(/focus-visible:ring-secondary/);
     });
 
-    it('should mark the state icons as decorative (aria-hidden)', () => {
+    it('should mark the state icon as decorative (aria-hidden)', () => {
       mockSearchParams.get.mockImplementation((key: string) => {
         if (key === 'status') return 'failure';
         return null;
@@ -589,8 +589,11 @@ describe('ActivationPage', () => {
 
       const { container } = renderWithProviders(<ActivationPage />);
 
-      // El icono de estado (XCircle) es decorativo: el título ya comunica el estado.
-      expect(container.querySelectorAll('[aria-hidden="true"]').length).toBeGreaterThan(0);
+      // El icono de estado (XCircle, `text-destructive`) es decorativo: el título
+      // "Problema con el pago" ya comunica el estado a lectores de pantalla.
+      const stateIcon = container.querySelector('.text-destructive');
+      expect(stateIcon).not.toBeNull();
+      expect(stateIcon).toHaveAttribute('aria-hidden', 'true');
     });
 
     it('should render the success band asset with a non-empty Spanish alt (imagen con alt)', async () => {

--- a/frontend/src/components/features/premium/PremiumHero.test.tsx
+++ b/frontend/src/components/features/premium/PremiumHero.test.tsx
@@ -87,7 +87,7 @@ describe('PremiumHero', () => {
     expect(screen.getByTestId('premium-hero')).toHaveClass('extra-test-class');
   });
 
-  // Accesibilidad (canon T-PREM-002 / PREM-002)
+  // Accesibilidad (canon T-PREM-002 / PREM-002 · cierre T-PREM-008)
   describe('Accesibilidad', () => {
     it('should use dark night text on the gold badge chip for AA contrast', () => {
       render(<PremiumHero title="Tarot" badge="Plan Premium" />);
@@ -96,6 +96,28 @@ describe('PremiumHero', () => {
       // Texto noche (#1a0a2e) sobre dorado (#d69e2e) ≈ 7:1 (AA); blanco falla.
       expect(chip).toHaveClass('text-bg-hero');
       expect(chip).not.toHaveClass('text-white');
+    });
+
+    it('should hide the decorative image overlay from assistive tech (T-PREM-008)', () => {
+      const { container } = render(
+        <PremiumHero
+          title="Tarot"
+          image={{ src: '/images/premium/premium-hero.webp', alt: 'Llave dorada' }}
+        />
+      );
+
+      // El overlay de legibilidad es puramente decorativo → aria-hidden.
+      const decorative = container.querySelectorAll('[aria-hidden="true"]');
+      expect(decorative.length).toBeGreaterThan(0);
+    });
+
+    it('should mark twinkling stars and crescent moon as aria-hidden (decorativos)', () => {
+      const { container } = render(<PremiumHero title="Tarot" />);
+
+      // Las estrellas animadas no aportan información: no deben leerse.
+      const stars = container.querySelectorAll('.animate-twinkle');
+      expect(stars.length).toBeGreaterThan(0);
+      stars.forEach((star) => expect(star).toHaveAttribute('aria-hidden', 'true'));
     });
   });
 });

--- a/frontend/src/components/features/premium/PremiumHero.test.tsx
+++ b/frontend/src/components/features/premium/PremiumHero.test.tsx
@@ -106,9 +106,12 @@ describe('PremiumHero', () => {
         />
       );
 
-      // El overlay de legibilidad es puramente decorativo → aria-hidden.
-      const decorative = container.querySelectorAll('[aria-hidden="true"]');
-      expect(decorative.length).toBeGreaterThan(0);
+      // La imagen SÍ es significativa (tiene alt) y no debe ocultarse…
+      expect(screen.getByTestId('next-image')).not.toHaveAttribute('aria-hidden', 'true');
+      // …pero el overlay de legibilidad (`.inset-0`) es decorativo → aria-hidden.
+      const overlay = container.querySelector('.inset-0');
+      expect(overlay).not.toBeNull();
+      expect(overlay).toHaveAttribute('aria-hidden', 'true');
     });
 
     it('should mark twinkling stars and crescent moon as aria-hidden (decorativos)', () => {

--- a/frontend/src/components/features/premium/PremiumPage.test.tsx
+++ b/frontend/src/components/features/premium/PremiumPage.test.tsx
@@ -203,6 +203,46 @@ describe('PremiumPage', () => {
       expect(container.querySelector('[class*="text-gray-"]')).toBeNull();
       expect(container.querySelector('[class*="bg-gray-"]')).toBeNull();
     });
+
+    // Accesibilidad — cierre del circuito premium (T-PREM-008)
+    describe('Accesibilidad (T-PREM-008)', () => {
+      beforeEach(() => {
+        mockAuthStore.mockReturnValue({ user: null, isAuthenticated: false });
+      });
+
+      it('should render a visible focus ring on every plan CTA (foco visible)', () => {
+        renderWithProviders(<PremiumPage />);
+
+        for (const testId of ['cta-hero', 'cta-card', 'cta-bottom']) {
+          const cta = screen.getByTestId(testId);
+          expect(cta.className).toMatch(/focus-visible:ring-secondary/);
+        }
+      });
+
+      it('should label the comparison table check/cross icons for screen readers', () => {
+        renderWithProviders(<PremiumPage />);
+
+        // Cada fila aporta un icono por columna (Free/Premium) con etiqueta textual.
+        expect(screen.getAllByLabelText('Incluido').length).toBeGreaterThan(0);
+        expect(screen.getAllByLabelText('No incluido').length).toBeGreaterThan(0);
+      });
+
+      it('should wrap sections in Reveal so prefers-reduced-motion is respected', () => {
+        const { container } = renderWithProviders(<PremiumPage />);
+
+        // `Reveal` marca sus contenedores con `data-reveal`; su lógica ya deriva
+        // el estado visible inmediato bajo movimiento reducido (ver Reveal.tsx).
+        expect(container.querySelectorAll('[data-reveal]').length).toBeGreaterThan(0);
+      });
+
+      it('should render the hero band asset with a Spanish alt (imagen con alt)', () => {
+        renderWithProviders(<PremiumPage />);
+
+        const heroImage = screen.getByTestId('next-image');
+        expect(heroImage).toHaveAttribute('alt');
+        expect(heroImage.getAttribute('alt')?.trim().length).toBeGreaterThan(0);
+      });
+    });
   });
 
   describe('CTA - Unauthenticated user', () => {

--- a/frontend/src/components/features/premium/PremiumPage.test.tsx
+++ b/frontend/src/components/features/premium/PremiumPage.test.tsx
@@ -16,10 +16,22 @@ vi.mock('next/navigation', () => ({
   }),
 }));
 
-// Mock Next.js Link
+// Mock Next.js Link (forward className so focus-ring assertions can inspect it)
 vi.mock('next/link', () => ({
-  default: function MockLink({ href, children }: { href: string; children: React.ReactNode }) {
-    return <a href={href}>{children}</a>;
+  default: function MockLink({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) {
+    return (
+      <a href={href} className={className}>
+        {children}
+      </a>
+    );
   },
 }));
 
@@ -219,6 +231,22 @@ describe('PremiumPage', () => {
         }
       });
 
+      it('should render a visible focus ring on the "Ver mi cuenta" link for premium users (foco en links)', () => {
+        // Usuario premium: el CTA se convierte en el link "Ver mi cuenta".
+        mockAuthStore.mockReturnValue({
+          user: { id: 1, email: 'test@test.com', plan: 'premium' },
+          isAuthenticated: true,
+        });
+
+        renderWithProviders(<PremiumPage />);
+
+        const accountLinks = screen.getAllByRole('link', { name: /ver mi cuenta/i });
+        expect(accountLinks.length).toBeGreaterThan(0);
+        accountLinks.forEach((link) =>
+          expect(link.className).toMatch(/focus-visible:ring-secondary/)
+        );
+      });
+
       it('should label the comparison table check/cross icons for screen readers', () => {
         renderWithProviders(<PremiumPage />);
 
@@ -227,11 +255,12 @@ describe('PremiumPage', () => {
         expect(screen.getAllByLabelText('No incluido').length).toBeGreaterThan(0);
       });
 
-      it('should wrap sections in Reveal so prefers-reduced-motion is respected', () => {
+      it('should wrap sections in Reveal (base para respetar prefers-reduced-motion)', () => {
         const { container } = renderWithProviders(<PremiumPage />);
 
-        // `Reveal` marca sus contenedores con `data-reveal`; su lógica ya deriva
-        // el estado visible inmediato bajo movimiento reducido (ver Reveal.tsx).
+        // Las secciones se envuelven en `Reveal` (marcado con `data-reveal`). La
+        // lógica de movimiento reducido en sí está testeada en `Reveal.test`/
+        // `useReducedMotion.test`; aquí solo se fija que las secciones la usen.
         expect(container.querySelectorAll('[data-reveal]').length).toBeGreaterThan(0);
       });
 

--- a/frontend/src/components/features/premium/premium-a11y.test.ts
+++ b/frontend/src/components/features/premium/premium-a11y.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+
+import { getContrastRatio, meetsWcagAA } from '@/lib/utils/contrast';
+
+/**
+ * Contrato de contraste WCAG del circuito premium (T-PREM-008 / hallazgos
+ * PREM-001, PREM-008 — verificación de cierre).
+ *
+ * Análogo a `lib/utils/contrast.test.ts` (T-DASH-007): fija con la fórmula de
+ * luminancia WCAG que los pares de color que la banda mística `PremiumHero`, la
+ * tabla comparativa de `/premium` y la pantalla de activación controlan de forma
+ * directa (hex hardcodeados en esos componentes) cumplen AA. Si alguien regresa
+ * el dorado a texto blanco, aclara la banda noche o baja el tono de la crema
+ * atenuada, este contrato falla antes de llegar a producción.
+ *
+ * Colores de marca (sincronizados con `globals.css`, `PremiumHero.tsx` y
+ * `PremiumPage.tsx`):
+ */
+const NIGHT = '#1a0a2e'; // --color-bg-hero — banda noche profunda (extremos del gradiente)
+const NIGHT_MID = '#2d1b69'; // --color-bg-hero-mid — punto más claro del gradiente noche
+const CREAM = '#f9f7f2'; // texto crema sobre la banda / --background
+const GOLD = '#d69e2e'; // --color-secondary — chips dorados
+const WHITE = '#ffffff'; // --card
+const FOREGROUND = '#2d3748'; // --foreground / --card-foreground — texto de tabla y FAQ
+
+/**
+ * Crema atenuada usada en el hero (subtítulo) y en el encabezado "Free" de la
+ * tabla: `rgba(249, 247, 242, 0.72)`. El navegador la compone sobre la banda
+ * noche, así que verificamos el color RESULTANTE (no el token con alfa), que es
+ * lo que realmente ve el usuario.
+ */
+const CREAM_MUTED_ALPHA = 0.72;
+
+/** Compone un color con alfa sobre un fondo opaco y devuelve el hex resultante. */
+function composite(foreground: string, alpha: number, background: string): string {
+  const hex = (value: string): [number, number, number] => {
+    const n = parseInt(value.replace(/^#/, ''), 16);
+    return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+  };
+  const [fr, fg, fb] = hex(foreground);
+  const [br, bg, bb] = hex(background);
+  const mix = (f: number, b: number) => Math.round(f * alpha + b * (1 - alpha));
+  return (
+    '#' +
+    [mix(fr, br), mix(fg, bg), mix(fb, bb)].map((c) => c.toString(16).padStart(2, '0')).join('')
+  );
+}
+
+describe('Contrato de contraste del circuito premium (T-PREM-008)', () => {
+  describe('Banda mística (PremiumHero)', () => {
+    it('el título crema sobre la banda noche cumple AA', () => {
+      const ratio = getContrastRatio(CREAM, NIGHT);
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+      expect(meetsWcagAA(ratio)).toBe(true);
+    });
+
+    it('el subtítulo crema atenuado cumple AA incluso sobre el punto más claro del gradiente', () => {
+      // Peor caso: la crema atenuada compuesta sobre el índigo medio del gradiente.
+      const composited = composite(CREAM, CREAM_MUTED_ALPHA, NIGHT_MID);
+      const ratio = getContrastRatio(composited, NIGHT_MID);
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+      expect(meetsWcagAA(ratio)).toBe(true);
+    });
+
+    it('el chip dorado usa texto noche (no blanco) para cumplir AA', () => {
+      const ratioNight = getContrastRatio(GOLD, NIGHT);
+      expect(ratioNight).toBeGreaterThanOrEqual(4.5);
+      expect(meetsWcagAA(ratioNight)).toBe(true);
+
+      // El texto blanco sobre el dorado NO cumpliría: por eso el chip es `text-bg-hero`.
+      const ratioWhite = getContrastRatio(GOLD, WHITE);
+      expect(ratioWhite).toBeLessThan(4.5);
+      expect(meetsWcagAA(ratioWhite)).toBe(false);
+    });
+  });
+
+  describe('Tabla comparativa (/premium)', () => {
+    it('el encabezado "Premium" (crema) sobre la banda noche cumple AA', () => {
+      const ratio = getContrastRatio(CREAM, NIGHT);
+      expect(meetsWcagAA(ratio)).toBe(true);
+    });
+
+    it('el encabezado "Free" (crema atenuada) cumple AA sobre todo el gradiente', () => {
+      for (const bg of [NIGHT, NIGHT_MID]) {
+        const composited = composite(CREAM, CREAM_MUTED_ALPHA, bg);
+        expect(meetsWcagAA(getContrastRatio(composited, bg))).toBe(true);
+      }
+    });
+
+    it('el texto de las filas (foreground) sobre la superficie blanca cumple AA', () => {
+      const ratio = getContrastRatio(FOREGROUND, WHITE);
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+      expect(meetsWcagAA(ratio)).toBe(true);
+    });
+  });
+
+  describe('FAQ y tarjetas de plan (/premium)', () => {
+    it('los títulos de pregunta y de plan (card-foreground) cumplen AA sobre la tarjeta', () => {
+      const ratio = getContrastRatio(FOREGROUND, WHITE);
+      expect(meetsWcagAA(ratio)).toBe(true);
+    });
+
+    it('el chip "Recomendado" dorado usa texto noche para cumplir AA', () => {
+      const ratio = getContrastRatio(GOLD, NIGHT);
+      expect(meetsWcagAA(ratio)).toBe(true);
+    });
+  });
+});

--- a/frontend/src/components/features/premium/premium-a11y.test.ts
+++ b/frontend/src/components/features/premium/premium-a11y.test.ts
@@ -6,12 +6,15 @@ import { getContrastRatio, meetsWcagAA } from '@/lib/utils/contrast';
  * Contrato de contraste WCAG del circuito premium (T-PREM-008 / hallazgos
  * PREM-001, PREM-008 — verificación de cierre).
  *
- * Análogo a `lib/utils/contrast.test.ts` (T-DASH-007): fija con la fórmula de
- * luminancia WCAG que los pares de color que la banda mística `PremiumHero`, la
- * tabla comparativa de `/premium` y la pantalla de activación controlan de forma
- * directa (hex hardcodeados en esos componentes) cumplen AA. Si alguien regresa
- * el dorado a texto blanco, aclara la banda noche o baja el tono de la crema
- * atenuada, este contrato falla antes de llegar a producción.
+ * Análogo a `lib/utils/contrast.test.ts` (T-DASH-007): fija, con la fórmula de
+ * luminancia WCAG, el INVARIANTE DE DISEÑO del circuito — que la paleta elegida
+ * (crema sobre banda noche, dorado con texto noche, `foreground` sobre blanco)
+ * cumple AA. Sirve para no regresar la paleta al diseñar variantes futuras.
+ *
+ * Alcance: verifica los PARES DE COLOR, no qué clase aplica cada componente. La
+ * garantía de que el chip use `text-bg-hero` (y no `text-white`) vive en los
+ * tests de componente (`PremiumHero.test.tsx` / `PremiumPage.test.tsx`), que sí
+ * fallan si alguien cambia la clase.
  *
  * Colores de marca (sincronizados con `globals.css`, `PremiumHero.tsx` y
  * `PremiumPage.tsx`):


### PR DESCRIPTION
## T-PREM-008 · A11y del Circuito Premium (cierre)

Cierre de accesibilidad del circuito premium. Es una **verificación**: el circuito ya cumplía el contrato tras T-PREM-002/003/004, por lo que **no hay cambios en código de producción**, solo el contrato de tests que lo fija contra regresiones.

### Qué se hizo

- **`premium-a11y.test.ts` (nuevo, análogo a T-DASH-007):** contrato de contraste WCAG que fija con `getContrastRatio`/`meetsWcagAA` (de `lib/utils/contrast.ts`) los pares de color que el hero / tabla comparativa / activación controlan con hex hardcodeados. Como las cremas se usan con alfa (`rgba(…, 0.72)`), el test las **compone** sobre la banda noche y verifica el color resultante (lo que ve el usuario).
- **Asserts de foco / alt / reduced-motion / aria** añadidos a `PremiumHero.test.tsx`, `PremiumPage.test.tsx` y `ActivationPage.test.tsx`, reutilizando sus harnesses.

### Ratios medidos (todos AA con holgura)

| Par | Ratio | Umbral AA |
| --- | --- | --- |
| Crema sobre banda noche | ≈ 17.4:1 | 4.5:1 |
| Chip dorado + texto noche | ≈ 7.8:1 | 4.5:1 |
| Crema atenuada (subtítulo/"Free") sobre el punto más claro del gradiente | ≥ 7.5:1 | 4.5:1 |
| `foreground` de tabla/FAQ sobre superficie blanca | ≈ 12:1 | 4.5:1 |

### Cobertura a11y fijada

- **Foco visible:** CTAs (`cta-hero`/`cta-card`/`cta-bottom`) y "Intentar de nuevo" con anillo dorado.
- **`alt`:** banda de `/premium` y banda de éxito de activación con `alt` en español no vacío.
- **Decorativos `aria-hidden`:** overlay, estrellas, luna del hero; iconos de estado de activación.
- **`aria-label`:** iconos ✓/✗ de la tabla ("Incluido"/"No incluido").
- **`prefers-reduced-motion`:** secciones envueltas en `Reveal` (estado visible inmediato) + neutralización de animaciones decorativas en `globals.css`.

### Validaciones

- `format` ✅ · `lint:fix` (0 errores) ✅ · `type-check` ✅ · `test:run` **5144 verdes (+18)** ✅ · `build` ✅ · `validate-architecture` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)