### PR TITLE
feat(T-FBK-004): erradicar "IA" del texto user-facing (front + back + emails + migración)

### DIFF
--- a/backend/tarot-app/src/database/migrations/1776700000000-RemoveAiMentionFromPremiumPlanDescription.ts
+++ b/backend/tarot-app/src/database/migrations/1776700000000-RemoveAiMentionFromPremiumPlanDescription.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * T-FBK-004 (Hallazgo FBK-003): la descripción del plan Premium se renderiza en
+ * `/premium` desde la tabla `plans`. El seed ya se actualizó, pero las filas
+ * existentes siguen mencionando "IA". Esta migración de datos reformula la
+ * descripción en las filas ya persistidas (regla dura: sin "IA" en texto user-facing).
+ */
+const OLD_DESCRIPTION =
+  'Plan completo con 1 carta del día + 3 tiradas diarias, interpretaciones con IA y preguntas personalizadas';
+const NEW_DESCRIPTION =
+  'Plan completo con 1 carta del día + 3 tiradas diarias, interpretaciones profundas y preguntas personalizadas';
+
+export class RemoveAiMentionFromPremiumPlanDescription1776700000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "plans" SET "description" = $1 WHERE "planType" = 'premium' AND "description" = $2`,
+      [NEW_DESCRIPTION, OLD_DESCRIPTION],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "plans" SET "description" = $1 WHERE "planType" = 'premium' AND "description" = $2`,
+      [OLD_DESCRIPTION, NEW_DESCRIPTION],
+    );
+  }
+}

--- a/backend/tarot-app/src/database/seeds/plans.seeder.ts
+++ b/backend/tarot-app/src/database/seeds/plans.seeder.ts
@@ -70,7 +70,7 @@ export async function seedPlans(
       planType: UserPlan.PREMIUM,
       name: 'Plan Premium',
       description:
-        'Plan completo con 1 carta del día + 3 tiradas diarias, interpretaciones con IA y preguntas personalizadas',
+        'Plan completo con 1 carta del día + 3 tiradas diarias, interpretaciones profundas y preguntas personalizadas',
       price: 7000,
       readingsLimit: 4, // DEPRECATED: Use dailyCardLimit + tarotReadingsLimit (1 + 3)
       dailyCardLimit: 1, // 1 daily card per day (same as FREE, but with AI interpretation)

--- a/backend/tarot-app/src/modules/ai-usage/constants/ai-usage.constants.ts
+++ b/backend/tarot-app/src/modules/ai-usage/constants/ai-usage.constants.ts
@@ -38,7 +38,7 @@ export const AI_MONTHLY_QUOTAS: Record<UserPlan, QuotaConfig> = {
 };
 
 export const QUOTA_WARNING_MESSAGE =
-  'Has usado el {percentage}% de tu cuota mensual de {maxRequests} interpretaciones de IA. Actualiza a Premium para interpretaciones ilimitadas.';
+  'Has usado el {percentage}% de tu cuota mensual de {maxRequests} interpretaciones personalizadas. Actualiza a Premium para interpretaciones ilimitadas.';
 
 export const QUOTA_LIMIT_REACHED_MESSAGE =
-  'Has alcanzado tu límite mensual de {maxRequests} interpretaciones de IA. Tu cuota se renovará el {resetDate}. Actualiza a Premium para interpretaciones ilimitadas.';
+  'Has alcanzado tu límite mensual de {maxRequests} interpretaciones personalizadas. Tu cuota se renovará el {resetDate}. Actualiza a Premium para interpretaciones ilimitadas.';

--- a/backend/tarot-app/src/modules/ai-usage/infrastructure/guards/ai-quota.guard.ts
+++ b/backend/tarot-app/src/modules/ai-usage/infrastructure/guards/ai-quota.guard.ts
@@ -54,7 +54,7 @@ export class AIQuotaGuard implements CanActivate {
       // la IA es exclusiva de Premium. Mensaje coherente con la nueva semántica.
       if (quotaInfo.quotaLimit === 0) {
         throw new ForbiddenException(
-          'Las interpretaciones con IA son exclusivas de Premium. ' +
+          'Las interpretaciones personalizadas son exclusivas de Premium. ' +
             'Actualiza tu plan para desbloquearlas.',
         );
       }
@@ -64,7 +64,7 @@ export class AIQuotaGuard implements CanActivate {
       });
 
       throw new ForbiddenException(
-        `Has alcanzado tu límite mensual de ${quotaInfo.quotaLimit} interpretaciones de IA. ` +
+        `Has alcanzado tu límite mensual de ${quotaInfo.quotaLimit} interpretaciones personalizadas. ` +
           `Tu cuota se renovará el ${resetDateFormatted}. ` +
           `Actualiza a Premium para interpretaciones ilimitadas.`,
       );

--- a/backend/tarot-app/src/modules/email/email.service.ts
+++ b/backend/tarot-app/src/modules/email/email.service.ts
@@ -142,7 +142,8 @@ export class EmailService {
     try {
       await this.mailerService.sendMail({
         to,
-        subject: '⚠️ Has usado el 80% de tu cuota mensual de IA',
+        subject:
+          '⚠️ Has usado el 80% de tu cuota mensual de interpretaciones personalizadas',
         template: 'quota-warning-80',
         context: quotaData,
       });
@@ -170,7 +171,7 @@ export class EmailService {
       await this.mailerService.sendMail({
         to,
         subject:
-          '🚫 Has alcanzado tu límite mensual de interpretaciones con IA',
+          '🚫 Has alcanzado tu límite mensual de interpretaciones personalizadas',
         template: 'quota-limit-reached',
         context: quotaData,
       });

--- a/backend/tarot-app/src/modules/email/templates/plan-change.hbs
+++ b/backend/tarot-app/src/modules/email/templates/plan-change.hbs
@@ -166,7 +166,7 @@
         <ul class='benefits-list'>
           <li>Lecturas ilimitadas de tarot</li>
           <li>Acceso a tiradas premium exclusivas</li>
-          <li>Interpretaciones más profundas con IA avanzada</li>
+          <li>Interpretaciones más profundas y personalizadas</li>
           <li>Historial completo de tus lecturas</li>
           <li>Soporte prioritario</li>
           <li>Sin publicidad</li>

--- a/backend/tarot-app/src/modules/email/templates/quota-limit-reached.hbs
+++ b/backend/tarot-app/src/modules/email/templates/quota-limit-reached.hbs
@@ -2,7 +2,7 @@
   <head>
     <meta charset='utf-8' />
     <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-    <title>Cuota de IA Alcanzada - TarotFlavia</title>
+    <title>Cuota de Interpretaciones Alcanzada - TarotFlavia</title>
     <style>
       body {
         font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -122,7 +122,7 @@
         <div class='alert-box'>
           <p style='margin: 0; font-size: 16px;'>
             <strong>Has alcanzado el límite de tu cuota mensual de
-              interpretaciones con IA.</strong>
+              interpretaciones personalizadas.</strong>
           </p>
         </div>
 

--- a/backend/tarot-app/src/modules/email/templates/quota-warning-80.hbs
+++ b/backend/tarot-app/src/modules/email/templates/quota-warning-80.hbs
@@ -2,7 +2,7 @@
   <head>
     <meta charset='utf-8' />
     <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-    <title>Advertencia de Cuota de IA - TarotFlavia</title>
+    <title>Advertencia de Cuota de Interpretaciones - TarotFlavia</title>
     <style>
       body {
         font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -106,7 +106,7 @@
   <body>
     <div class='container'>
       <div class='header'>
-        <h1>⚠️ Advertencia de Cuota de IA</h1>
+        <h1>⚠️ Advertencia de Cuota de Interpretaciones</h1>
       </div>
 
       <div class='content'>
@@ -114,8 +114,8 @@
 
         <div class='warning-box'>
           <p style='margin: 0; font-size: 16px;'>
-            <strong>Has usado el 80% de tu cuota mensual de interpretaciones con
-              IA.</strong>
+            <strong>Has usado el 80% de tu cuota mensual de interpretaciones
+              personalizadas.</strong>
           </p>
         </div>
 
@@ -177,7 +177,7 @@
           Con el plan Premium disfrutarás de:
         </p>
         <ul style='font-size: 14px; color: #6c757d;'>
-          <li>✅ Interpretaciones ilimitadas con IA</li>
+          <li>✅ Interpretaciones personalizadas ilimitadas</li>
           <li>✅ Preguntas personalizadas</li>
           <li>✅ Regeneración de interpretaciones</li>
           <li>✅ Soporte prioritario</li>

--- a/backend/tarot-app/src/modules/email/templates/welcome.hbs
+++ b/backend/tarot-app/src/modules/email/templates/welcome.hbs
@@ -114,7 +114,7 @@
       <div class='highlight-box'>
         <h2>¿Qué puedes hacer con Tarot App?</h2>
         <ul class='features'>
-          <li>Realizar lecturas de tarot personalizadas con IA</li>
+          <li>Realizar lecturas de tarot con interpretaciones personalizadas</li>
           <li>Explorar diferentes tipos de tiradas</li>
           <li>Guardar y compartir tus lecturas</li>
           <li>Acceder a interpretaciones profundas y significativas</li>

--- a/backend/tarot-app/src/modules/horoscope/application/services/chinese-horoscope.service.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/chinese-horoscope.service.ts
@@ -493,7 +493,7 @@ export class ChineseHoroscopeService {
       this.logger.error('Error parsing AI response:', error);
       this.logger.error('Content received:', content);
       throw new InternalServerErrorException(
-        'Error al procesar la respuesta de la IA',
+        'Error al procesar la interpretación. Por favor intenta de nuevo.',
       );
     }
   }

--- a/backend/tarot-app/src/modules/horoscope/application/services/horoscope-generation.service.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/horoscope-generation.service.ts
@@ -267,7 +267,7 @@ export class HoroscopeGenerationService {
       this.logger.error('Error parsing AI response:', error);
       this.logger.error('Content received:', content);
       throw new InternalServerErrorException(
-        'Error al procesar la respuesta de la IA',
+        'Error al procesar la interpretación. Por favor intenta de nuevo.',
       );
     }
   }

--- a/backend/tarot-app/src/modules/numerology/guards/requires-premium-for-numerology-ai.guard.spec.ts
+++ b/backend/tarot-app/src/modules/numerology/guards/requires-premium-for-numerology-ai.guard.spec.ts
@@ -33,7 +33,7 @@ describe('RequiresPremiumForNumerologyAIGuard', () => {
 
       expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
       expect(() => guard.canActivate(mockContext)).toThrow(
-        'Las interpretaciones numerológicas con IA están disponibles solo para usuarios Premium. ' +
+        'Las interpretaciones numerológicas personalizadas están disponibles solo para usuarios Premium. ' +
           'Actualiza tu plan para desbloquear esta funcionalidad.',
       );
     });
@@ -49,7 +49,7 @@ describe('RequiresPremiumForNumerologyAIGuard', () => {
 
       expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
       expect(() => guard.canActivate(mockContext)).toThrow(
-        'Las interpretaciones numerológicas con IA están disponibles solo para usuarios Premium. ' +
+        'Las interpretaciones numerológicas personalizadas están disponibles solo para usuarios Premium. ' +
           'Actualiza tu plan para desbloquear esta funcionalidad.',
       );
     });

--- a/backend/tarot-app/src/modules/numerology/guards/requires-premium-for-numerology-ai.guard.ts
+++ b/backend/tarot-app/src/modules/numerology/guards/requires-premium-for-numerology-ai.guard.ts
@@ -33,7 +33,7 @@ export class RequiresPremiumForNumerologyAIGuard implements CanActivate {
     // Solo usuarios PREMIUM pueden generar interpretación IA
     if (user.plan !== UserPlan.PREMIUM) {
       throw new ForbiddenException(
-        'Las interpretaciones numerológicas con IA están disponibles solo para usuarios Premium. ' +
+        'Las interpretaciones numerológicas personalizadas están disponibles solo para usuarios Premium. ' +
           'Actualiza tu plan para desbloquear esta funcionalidad.',
       );
     }

--- a/backend/tarot-app/src/modules/tarot/readings/dto/create-reading.dto.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/dto/create-reading.dto.ts
@@ -50,7 +50,7 @@ export class HasQuestionConstraint implements ValidatorConstraintInterface {
   }
 
   defaultMessage(): string {
-    return 'Debes proporcionar una pregunta predefinida o una pregunta personalizada cuando se solicita interpretación con IA';
+    return 'Debes proporcionar una pregunta predefinida o una pregunta personalizada cuando se solicita una interpretación personalizada';
   }
 }
 

--- a/backend/tarot-app/src/modules/tarot/readings/guards/requires-premium-for-ai.guard.spec.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/guards/requires-premium-for-ai.guard.spec.ts
@@ -35,7 +35,7 @@ describe('RequiresPremiumForAIGuard', () => {
 
       expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
       expect(() => guard.canActivate(mockContext)).toThrow(
-        'Las funciones con IA están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
+        'Las funciones personalizadas están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
       );
     });
 
@@ -51,7 +51,7 @@ describe('RequiresPremiumForAIGuard', () => {
 
       expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
       expect(() => guard.canActivate(mockContext)).toThrow(
-        'Las funciones con IA están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
+        'Las funciones personalizadas están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
       );
     });
 
@@ -160,7 +160,7 @@ describe('RequiresPremiumForAIGuard', () => {
 
       expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
       expect(() => guard.canActivate(mockContext)).toThrow(
-        'Las funciones con IA están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
+        'Las funciones personalizadas están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
       );
     });
 
@@ -190,7 +190,7 @@ describe('RequiresPremiumForAIGuard', () => {
 
       expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
       expect(() => guard.canActivate(mockContext)).toThrow(
-        'Las funciones con IA están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
+        'Las funciones personalizadas están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
       );
     });
 
@@ -247,7 +247,7 @@ describe('RequiresPremiumForAIGuard', () => {
 
       expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
       expect(() => guard.canActivate(mockContext)).toThrow(
-        'Las interpretaciones con IA están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
+        'Las interpretaciones personalizadas están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
       );
     });
 
@@ -263,7 +263,7 @@ describe('RequiresPremiumForAIGuard', () => {
 
       expect(() => guard.canActivate(mockContext)).toThrow(ForbiddenException);
       expect(() => guard.canActivate(mockContext)).toThrow(
-        'Las interpretaciones con IA están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
+        'Las interpretaciones personalizadas están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
       );
     });
 

--- a/backend/tarot-app/src/modules/tarot/readings/guards/requires-premium-for-ai.guard.ts
+++ b/backend/tarot-app/src/modules/tarot/readings/guards/requires-premium-for-ai.guard.ts
@@ -40,7 +40,7 @@ export class RequiresPremiumForAIGuard implements CanActivate {
       if (body.useAI === true) {
         if (user.plan !== UserPlan.PREMIUM) {
           throw new ForbiddenException(
-            'Las funciones con IA están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
+            'Las funciones personalizadas están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
           );
         }
         return true;
@@ -56,7 +56,7 @@ export class RequiresPremiumForAIGuard implements CanActivate {
     if (body.generateInterpretation === true) {
       if (user.plan !== UserPlan.PREMIUM) {
         throw new ForbiddenException(
-          'Las interpretaciones con IA están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
+          'Las interpretaciones personalizadas están disponibles solo para usuarios Premium. Actualiza tu plan para desbloquear esta funcionalidad.',
         );
       }
       return true;

--- a/backend/tarot-app/src/no-ia-user-facing.spec.ts
+++ b/backend/tarot-app/src/no-ia-user-facing.spec.ts
@@ -1,0 +1,155 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Guardarraíl T-FBK-004 (Hallazgo FBK-003): el texto de cara al usuario NO debe
+ * mencionar "IA" / "inteligencia artificial". Debe usarse el glosario de marca
+ * ("interpretaciones personalizadas", "análisis profundo", etc.).
+ *
+ * Este test escanea las superficies user-facing conocidas del backend (mensajes
+ * de guards, validaciones de DTO, asuntos de email, plantillas .hbs, descripción
+ * del plan en el seed y las constantes de mensajes) y falla si reaparece el token.
+ *
+ * NO cuentan como violación (por decisión de producto — ver FBK-003):
+ *  - Documentación Swagger (@ApiOperation/@ApiProperty/.addTag) y sus strings.
+ *  - Comentarios y JSDoc.
+ *  - Nombres de variables/clases/archivos (AISynthesis, aiQuota, OPENAI_*, etc.).
+ *  - Panel de admin (solo lo ven administradores).
+ *  - El error interno de infraestructura "no hay proveedor de IA configurado"
+ *    (ai-provider.service.ts) NO es copy de feature: no está en el set escaneado.
+ *
+ * Si en el futuro se agrega una NUEVA superficie user-facing, añadirla al set.
+ */
+
+const SRC = __dirname;
+const IA_WORD = /\bIA\b/;
+const IA_PHRASE = /inteligencia artificial/i;
+
+/** Reemplaza un tramo por espacios preservando los saltos de línea (líneas exactas). */
+function blankKeepNewlines(match: string): string {
+  return match.replace(/[^\n]/g, ' ');
+}
+
+/** Elimina spans balanceados de @Api...(...) y .addTag(...) (metadata Swagger), respetando strings. */
+function stripSwagger(src: string): string {
+  const triggers = [/@Api\w+\(/g, /\.addTag\(/g];
+  for (const rx of triggers) {
+    let m: RegExpExecArray | null;
+    while ((m = rx.exec(src))) {
+      const openParen = m.index + m[0].length - 1;
+      let depth = 0;
+      let i = openParen;
+      let str: string | null = null;
+      for (; i < src.length; i++) {
+        const c = src[i];
+        if (str) {
+          if (c === '\\') {
+            i++;
+            continue;
+          }
+          if (c === str) str = null;
+          continue;
+        }
+        if (c === '"' || c === "'" || c === '`') {
+          str = c;
+          continue;
+        }
+        if (c === '(') depth++;
+        else if (c === ')') {
+          depth--;
+          if (depth === 0) {
+            i++;
+            break;
+          }
+        }
+      }
+      src =
+        src.slice(0, m.index) +
+        blankKeepNewlines(src.slice(m.index, i)) +
+        src.slice(i);
+      rx.lastIndex = 0;
+    }
+  }
+  return src;
+}
+
+function stripTsComments(src: string): string {
+  let out = src.replace(/\/\*[\s\S]*?\*\//g, blankKeepNewlines);
+  out = out
+    .split('\n')
+    .map((l) => l.replace(/([^:"'`])\/\/.*$/, '$1').replace(/^\s*\/\/.*$/, ''))
+    .join('\n');
+  return out;
+}
+
+function stripHbsComments(src: string): string {
+  return src
+    .replace(/<!--[\s\S]*?-->/g, blankKeepNewlines)
+    .replace(/\{\{!--[\s\S]*?--\}\}/g, blankKeepNewlines)
+    .replace(/\{\{![\s\S]*?\}\}/g, blankKeepNewlines);
+}
+
+function walk(
+  dir: string,
+  pred: (p: string) => boolean,
+  acc: string[] = [],
+): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, pred, acc);
+    else if (pred(p)) acc.push(p);
+  }
+  return acc;
+}
+
+const isAdmin = (p: string): boolean =>
+  /\/admin\//.test(p) || /admin/i.test(path.basename(p));
+
+/** Superficies runtime que ve el usuario final. */
+const explicitFiles = [
+  'modules/email/email.service.ts',
+  'modules/ai-usage/constants/ai-usage.constants.ts',
+  'database/seeds/plans.seeder.ts',
+  'modules/tarot/readings/dto/create-reading.dto.ts',
+].map((f) => path.join(SRC, f));
+
+function scanTs(file: string): string[] {
+  const lines = stripTsComments(
+    stripSwagger(fs.readFileSync(file, 'utf8')),
+  ).split('\n');
+  const hits: string[] = [];
+  lines.forEach((line, i) => {
+    if (IA_WORD.test(line) || IA_PHRASE.test(line)) {
+      hits.push(`${path.relative(SRC, file)}:${i + 1} → ${line.trim()}`);
+    }
+  });
+  return hits;
+}
+
+function scanHbs(file: string): string[] {
+  const lines = stripHbsComments(fs.readFileSync(file, 'utf8')).split('\n');
+  const hits: string[] = [];
+  lines.forEach((line, i) => {
+    if (IA_WORD.test(line) || IA_PHRASE.test(line)) {
+      hits.push(`${path.relative(SRC, file)}:${i + 1} → ${line.trim()}`);
+    }
+  });
+  return hits;
+}
+
+describe('Guardarraíl: sin "IA" en texto user-facing del backend (FBK-003)', () => {
+  const guardFiles = walk(
+    SRC,
+    (p) => p.endsWith('.guard.ts') && !p.endsWith('.spec.ts') && !isAdmin(p),
+  );
+  const hbsFiles = walk(SRC, (p) => p.endsWith('.hbs') && !isAdmin(p));
+
+  it('no menciona "IA" ni "inteligencia artificial" en guards, DTOs, emails, seed ni constantes', () => {
+    const violations = [
+      ...explicitFiles.flatMap(scanTs),
+      ...guardFiles.flatMap(scanTs),
+      ...hbsFiles.flatMap(scanHbs),
+    ];
+    expect(violations).toEqual([]);
+  });
+});

--- a/backend/tarot-app/src/no-ia-user-facing.spec.ts
+++ b/backend/tarot-app/src/no-ia-user-facing.spec.ts
@@ -6,24 +6,46 @@ import * as path from 'path';
  * mencionar "IA" / "inteligencia artificial". Debe usarse el glosario de marca
  * ("interpretaciones personalizadas", "análisis profundo", etc.).
  *
- * Este test escanea las superficies user-facing conocidas del backend (mensajes
- * de guards, validaciones de DTO, asuntos de email, plantillas .hbs, descripción
- * del plan en el seed y las constantes de mensajes) y falla si reaparece el token.
+ * Este test escanea las superficies user-facing del backend (mensajes de guards,
+ * services y controllers —excepciones/validaciones—, asuntos de email, plantillas
+ * .hbs, descripción del plan en el seed y las constantes de mensajes) y falla si
+ * reaparece el token.
  *
  * NO cuentan como violación (por decisión de producto — ver FBK-003):
- *  - Documentación Swagger (@ApiOperation/@ApiProperty/.addTag) y sus strings.
+ *  - Documentación Swagger (@ApiOperation/@ApiProperty/.addTag/.setDescription) y sus strings.
  *  - Comentarios y JSDoc.
+ *  - Logs (this.logger.*, console.*): no son texto de cara al usuario.
  *  - Nombres de variables/clases/archivos (AISynthesis, aiQuota, OPENAI_*, etc.).
  *  - Panel de admin (solo lo ven administradores).
- *  - El error interno de infraestructura "no hay proveedor de IA configurado"
- *    (ai-provider.service.ts) NO es copy de feature: no está en el set escaneado.
+ *  - Los strings de ALLOWLIST (error interno de infra + prompts al modelo).
  *
- * Si en el futuro se agrega una NUEVA superficie user-facing, añadirla al set.
+ * Si en el futuro se agrega una NUEVA superficie user-facing, quedará cubierta si
+ * es un guard/service/controller; para otros tipos, añadirla al set.
  */
 
 const SRC = __dirname;
 const IA_WORD = /\bIA\b/;
 const IA_PHRASE = /inteligencia artificial/i;
+
+/** Líneas de logging/consola: NO son texto de cara al usuario (FBK-003 excluye logs). */
+const LOG_LINE = /this\.logger\.|console\.|new Logger\(/;
+
+/**
+ * Strings que mencionan "IA" pero NO son copy de feature (excluidos por FBK-003).
+ * Se identifican por (archivo relativo, fragmento). Mantener la lista mínima y justificada.
+ */
+const ALLOWLIST: { file: string; snippet: string }[] = [
+  {
+    // Error interno de infraestructura (falta API key), no copy de feature — decisión de Ariel.
+    file: 'modules/ai/application/services/ai-provider.service.ts',
+    snippet: 'No hay ningún proveedor de IA configurado',
+  },
+  {
+    // Instrucción dentro de un prompt al modelo (no se muestra al usuario) — FBK-003 excluye prompts.
+    file: 'modules/birth-chart/application/services/chart-ai-synthesis.service.ts',
+    snippet: 'Menciones de que eres una IA',
+  },
+];
 
 /** Reemplaza un tramo por espacios preservando los saltos de línea (líneas exactas). */
 function blankKeepNewlines(match: string): string {
@@ -32,7 +54,7 @@ function blankKeepNewlines(match: string): string {
 
 /** Elimina spans balanceados de @Api...(...) y .addTag(...) (metadata Swagger), respetando strings. */
 function stripSwagger(src: string): string {
-  const triggers = [/@Api\w+\(/g, /\.addTag\(/g];
+  const triggers = [/@Api\w+\(/g, /\.addTag\(/g, /\.setDescription\(/g];
   for (const rx of triggers) {
     let m: RegExpExecArray | null;
     while ((m = rx.exec(src))) {
@@ -114,13 +136,17 @@ const explicitFiles = [
 ].map((f) => path.join(SRC, f));
 
 function scanTs(file: string): string[] {
+  const rel = path.relative(SRC, file);
+  const allowed = ALLOWLIST.filter((a) => a.file === rel);
   const lines = stripTsComments(
     stripSwagger(fs.readFileSync(file, 'utf8')),
   ).split('\n');
   const hits: string[] = [];
   lines.forEach((line, i) => {
+    if (LOG_LINE.test(line)) return;
+    if (allowed.some((a) => line.includes(a.snippet))) return;
     if (IA_WORD.test(line) || IA_PHRASE.test(line)) {
-      hits.push(`${path.relative(SRC, file)}:${i + 1} → ${line.trim()}`);
+      hits.push(`${rel}:${i + 1} → ${line.trim()}`);
     }
   });
   return hits;
@@ -138,16 +164,21 @@ function scanHbs(file: string): string[] {
 }
 
 describe('Guardarraíl: sin "IA" en texto user-facing del backend (FBK-003)', () => {
-  const guardFiles = walk(
+  const isScannableTs = (suffix: string) => (p: string) =>
+    p.endsWith(suffix) && !p.endsWith('.spec.ts') && !isAdmin(p);
+  const tsFiles = walk(
     SRC,
-    (p) => p.endsWith('.guard.ts') && !p.endsWith('.spec.ts') && !isAdmin(p),
+    (p) =>
+      isScannableTs('.guard.ts')(p) ||
+      isScannableTs('.service.ts')(p) ||
+      isScannableTs('.controller.ts')(p),
   );
   const hbsFiles = walk(SRC, (p) => p.endsWith('.hbs') && !isAdmin(p));
 
-  it('no menciona "IA" ni "inteligencia artificial" en guards, DTOs, emails, seed ni constantes', () => {
+  it('no menciona "IA" ni "inteligencia artificial" en guards, services, controllers, DTOs, emails, seed ni constantes', () => {
     const violations = [
       ...explicitFiles.flatMap(scanTs),
-      ...guardFiles.flatMap(scanTs),
+      ...tsFiles.flatMap(scanTs),
       ...hbsFiles.flatMap(scanHbs),
     ];
     expect(violations).toEqual([]);

--- a/backend/tarot-app/test/readings/create-reading.dto.spec.ts
+++ b/backend/tarot-app/test/readings/create-reading.dto.spec.ts
@@ -84,7 +84,7 @@ describe('CreateReadingDto', () => {
         Object.values(e.constraints || {}),
       );
       expect(errorMessages.flat()).toContain(
-        'Debes proporcionar una pregunta predefinida o una pregunta personalizada cuando se solicita interpretación con IA',
+        'Debes proporcionar una pregunta predefinida o una pregunta personalizada cuando se solicita una interpretación personalizada',
       );
     });
 

--- a/docs/BACKLOG_FEEDBACK_UX_2026_07.md
+++ b/docs/BACKLOG_FEEDBACK_UX_2026_07.md
@@ -324,7 +324,7 @@ El **recuadro de highlight que "ya existe"** es la clase condicional de borde: `
 | T-FBK-001 | Unificar la invitación a Premium del dashboard (Rituales → `PremiumUpsellCard`) | Frontend | 🟠 Alta | 1 pt |
 | T-FBK-002 | (Deuda) Unificar el sistema de upsell (tokens de marca + convergencia de banners) | Frontend | 🟢 Baja | 3 pts |
 | T-FBK-003 | Reubicar la ficha "¿Qué es…?" debajo de la actividad en las 9 páginas | Frontend | 🟡 Media | 1.5 pts |
-| T-FBK-004 | Erradicar "IA" del texto user-facing (front + back + emails + migración) | Full-stack | 🟠 Alta | 3 pts |
+| T-FBK-004 | Erradicar "IA" del texto user-facing (front + back + emails + migración) | Full-stack | 🟠 Alta | 3 pts | ✅ COMPLETADA |
 | T-FBK-005 | Alinear el copy/beneficios de Premium con la implementación real | Frontend | 🔴 Crítica | 2.5 pts | ✅ COMPLETADA |
 | T-FBK-006 | Resolver la incoherencia de la cuota de IA (fuente de verdad única) | Backend | 🔴 Crítica | 2 pts | ✅ COMPLETADA |
 | T-FBK-007 | Alinear los iconos del Horóscopo Chino al canon | Frontend | 🟡 Media | 2 pts |
@@ -415,21 +415,21 @@ El **recuadro de highlight que "ya existe"** es la clase condicional de borde: `
 **Estimación:** 3 puntos
 **Dependencias:** glosario de reemplazos aprobado por Ariel; coordinar con T-FBK-005
 **Cubre Hallazgo:** FBK-003
-**Estado:** 🔲 PENDIENTE
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] **Frontend:** reformular las 8 apariciones del inventario (PremiumPage, premium-benefits, AISynthesis, BirthChartPageContent, SubscriptionTab).
-- [ ] **Backend — mensajes:** reformular guards (`requires-premium-for-ai.guard.ts`, `requires-premium-for-numerology-ai.guard.ts`), DTO (`create-reading.dto.ts:53`) y asunto de email (`email.service.ts:173`).
-- [ ] **Backend — plan:** actualizar `plans.seeder.ts:67` **y** crear una **migración de datos** para reformular la descripción del plan en las filas existentes de la tabla `plans`.
-- [ ] **Backend — emails:** reformular las plantillas `.hbs` (welcome, quota-limit-reached, quota-warning-80, plan-change).
-- [ ] **Panel de admin: NO se toca** (decisión de Ariel — la regla no aplica al panel interno).
-- [ ] Añadir un **guardarraíl** (test/lint) que falle si reaparece "IA"/"inteligencia artificial" en texto user-facing (excluyendo `app/admin/**` y `components/features/admin/**`).
+- [x] **Frontend:** reformular las apariciones vigentes del inventario (AISynthesis, BirthChartPageContent, PremiumPage, SubscriptionTab, WelcomeModal). Nota: `PremiumPage:59/64` y `premium-benefits.ts:63` ya habían sido reformulados por T-FBK-005; se detectaron y corrigieron apariciones nuevas no listadas en el inventario original (`BirthChartPageContent`, `WelcomeModal`).
+- [x] **Backend — mensajes:** reformular guards (`requires-premium-for-ai.guard.ts`, `requires-premium-for-numerology-ai.guard.ts`, `ai-quota.guard.ts` — nuevo, de T-FBK-006), DTO (`create-reading.dto.ts`), asuntos de email (`email.service.ts:145` y `173`) y las constantes de mensaje `QUOTA_WARNING_MESSAGE`/`QUOTA_LIMIT_REACHED_MESSAGE`.
+- [x] **Backend — plan:** actualizar `plans.seeder.ts` **y** crear una **migración de datos** (`1776700000000-RemoveAiMentionFromPremiumPlanDescription.ts`) para reformular la descripción del plan en las filas existentes de la tabla `plans`.
+- [x] **Backend — emails:** reformular las plantillas `.hbs` (welcome, quota-limit-reached, quota-warning-80, plan-change).
+- [x] **Panel de admin: NO se tocó** (decisión de Ariel — la regla no aplica al panel interno).
+- [x] Añadir un **guardarraíl** (tests Jest + Vitest) que falla si reaparece "IA"/"inteligencia artificial" en texto user-facing (`no-ia-user-facing.spec.ts` / `no-ia-user-facing.test.ts`; excluyen admin, Swagger, comentarios y nombres). El error interno de infra "no hay proveedor de IA configurado" queda fuera de alcance (decisión de Ariel).
 
 #### 🎯 Criterios de Aceptación
 
-- Ningún texto de cara al usuario (UI, errores de API, emails, descripción del plan renderizada) menciona "IA".
-- Ciclos de calidad frontend y backend completos pasan.
+- [x] Ningún texto de cara al usuario (UI, errores de API, emails, descripción del plan renderizada) menciona "IA".
+- [x] Ciclos de calidad frontend y backend completos pasan (backend: 4450 tests, cobertura 84.6%; frontend: 5151 tests).
 
 #### 📁 Archivos involucrados
 

--- a/frontend/src/app/carta-astral/page.test.tsx
+++ b/frontend/src/app/carta-astral/page.test.tsx
@@ -283,7 +283,7 @@ describe('BirthChartPage', () => {
       expect(screen.getByText(/posiciones planetarias/i)).toBeInTheDocument();
       expect(screen.getByText(/big three/i)).toBeInTheDocument();
       expect(screen.queryByText(/interpretaciones completas/i)).not.toBeInTheDocument();
-      expect(screen.queryByText(/síntesis personalizada con ia/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/síntesis personalizada/i)).not.toBeInTheDocument();
     });
 
     it('should show additional features for authenticated free users', () => {
@@ -296,7 +296,7 @@ describe('BirthChartPage', () => {
 
       expect(screen.getByText(/interpretaciones completas/i)).toBeInTheDocument();
       expect(screen.getByText(/descarga en pdf/i)).toBeInTheDocument();
-      expect(screen.queryByText(/síntesis personalizada con ia/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/síntesis personalizada/i)).not.toBeInTheDocument();
     });
 
     it('should show all features for Premium users', () => {
@@ -309,7 +309,7 @@ describe('BirthChartPage', () => {
 
       expect(screen.getByText(/interpretaciones completas/i)).toBeInTheDocument();
       expect(screen.getByText(/descarga en pdf/i)).toBeInTheDocument();
-      expect(screen.getByText(/síntesis personalizada con ia/i)).toBeInTheDocument();
+      expect(screen.getByText(/síntesis personalizada/i)).toBeInTheDocument();
       expect(screen.getByText(/historial de cartas/i)).toBeInTheDocument();
     });
   });

--- a/frontend/src/components/features/birth-chart/AISynthesis/AISynthesis.test.tsx
+++ b/frontend/src/components/features/birth-chart/AISynthesis/AISynthesis.test.tsx
@@ -216,7 +216,7 @@ describe('AISynthesisPlaceholder', () => {
   it('debe mostrar texto descriptivo', () => {
     render(<AISynthesisPlaceholder />);
     expect(
-      screen.getByText(/Obtén un análisis único generado por inteligencia/i)
+      screen.getByText(/Obtén un análisis único, profundo y personalizado/i)
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/features/birth-chart/AISynthesis/AISynthesis.tsx
+++ b/frontend/src/components/features/birth-chart/AISynthesis/AISynthesis.tsx
@@ -103,7 +103,7 @@ export function AISynthesis({
                   Premium
                 </Badge>
               </CardTitle>
-              <CardDescription>Análisis único generado por inteligencia artificial</CardDescription>
+              <CardDescription>Análisis único, profundo y personalizado</CardDescription>
             </div>
           </div>
 
@@ -236,8 +236,8 @@ export function AISynthesisPlaceholder({ className }: { className?: string }) {
           </div>
           <h3 className="mb-2 text-lg font-semibold">Síntesis Personalizada</h3>
           <p className="text-muted-foreground mx-auto mb-6 max-w-md text-sm">
-            Obtén un análisis único generado por inteligencia artificial que conecta todos los
-            elementos de tu carta y revela patrones ocultos.
+            Obtén un análisis único, profundo y personalizado que conecta todos los elementos de tu
+            carta y revela patrones ocultos.
           </p>
           <Button
             type="button"

--- a/frontend/src/components/features/birth-chart/BirthChartPageContent/BirthChartPageContent.tsx
+++ b/frontend/src/components/features/birth-chart/BirthChartPageContent/BirthChartPageContent.tsx
@@ -233,8 +233,7 @@ export function BirthChartPageContent() {
               {isAuthenticated && user?.plan === 'free' && (
                 <div className="space-y-2">
                   <p className="text-sm">
-                    Actualiza a Premium para obtener cartas ilimitadas y síntesis personalizada con
-                    IA.
+                    Actualiza a Premium para obtener cartas ilimitadas y síntesis personalizada.
                   </p>
                   <Button asChild>
                     <Link href="/premium">Ver planes Premium</Link>
@@ -265,7 +264,7 @@ export function BirthChartPageContent() {
               )}
               {user?.plan === 'premium' && (
                 <>
-                  <li>✓ Síntesis personalizada con IA</li>
+                  <li>✓ Síntesis personalizada</li>
                   <li>✓ Historial de cartas</li>
                 </>
               )}

--- a/frontend/src/components/features/onboarding/WelcomeModal.test.tsx
+++ b/frontend/src/components/features/onboarding/WelcomeModal.test.tsx
@@ -33,8 +33,8 @@ describe('WelcomeModal', () => {
   it('should explain limitations and differences with PREMIUM', () => {
     render(<WelcomeModal isOpen={true} onClose={vi.fn()} />);
 
-    // Verificar que se menciona la limitación FREE (sin IA)
-    expect(screen.getByText(/sin interpretación de ia/i)).toBeInTheDocument();
+    // Verificar que se menciona la limitación FREE (sin interpretación premium)
+    expect(screen.getByText(/sin interpretación profunda/i)).toBeInTheDocument();
 
     // Verificar que se menciona la ventaja PREMIUM
     expect(screen.getByText(/premium/i)).toBeInTheDocument();

--- a/frontend/src/components/features/onboarding/WelcomeModal.tsx
+++ b/frontend/src/components/features/onboarding/WelcomeModal.tsx
@@ -60,7 +60,7 @@ export function WelcomeModal({ isOpen, onClose }: WelcomeModalProps) {
                 <div>
                   <p className="font-medium">1 Lectura por Día</p>
                   <p className="text-muted-foreground text-sm">
-                    Crea 1 lectura personalizada con múltiples cartas (sin interpretación de IA)
+                    Crea 1 lectura personalizada con múltiples cartas (sin interpretación profunda)
                   </p>
                 </div>
               </div>

--- a/frontend/src/components/features/premium/PremiumHero.tsx
+++ b/frontend/src/components/features/premium/PremiumHero.tsx
@@ -64,7 +64,7 @@ export interface PremiumHeroProps {
  * <PremiumHero
  *   badge="Plan Premium"
  *   title="Desbloquea todo el potencial del Tarot"
- *   subtitle={<>Interpretaciones con IA por <span className="text-secondary">$7.000/mes</span></>}
+ *   subtitle={<>Interpretaciones personalizadas por <span className="text-secondary">$7.000/mes</span></>}
  *   image={{ src: '/images/premium/premium-hero.webp', alt: '…' }}
  * >
  *   <PremiumCtaButton testId="cta-hero" />

--- a/frontend/src/components/features/premium/PremiumPage.tsx
+++ b/frontend/src/components/features/premium/PremiumPage.tsx
@@ -200,7 +200,7 @@ export function PremiumPage() {
 
   const heroSubtitle = (
     <>
-      Interpretaciones personalizadas con IA, tiradas avanzadas, historial completo y mucho más
+      Interpretaciones personalizadas, tiradas avanzadas, historial completo y mucho más
       {premiumPlan ? (
         <>
           {' '}

--- a/frontend/src/components/features/profile/SubscriptionTab.test.tsx
+++ b/frontend/src/components/features/profile/SubscriptionTab.test.tsx
@@ -265,7 +265,7 @@ describe('SubscriptionTab', () => {
       render(<SubscriptionTab profile={profile} />, { wrapper: createWrapper() });
 
       expect(screen.getByText(/3 tiradas de tarot por día/i)).toBeInTheDocument();
-      expect(screen.getByText(/interpretaciones personalizadas con ia/i)).toBeInTheDocument();
+      expect(screen.getByText(/interpretaciones personalizadas/i)).toBeInTheDocument();
       expect(screen.getByText(/acceso a todas las tiradas/i)).toBeInTheDocument();
       expect(screen.getByText(/preguntas personalizadas/i)).toBeInTheDocument();
     });

--- a/frontend/src/components/features/profile/SubscriptionTab.tsx
+++ b/frontend/src/components/features/profile/SubscriptionTab.tsx
@@ -266,7 +266,7 @@ export function SubscriptionTab({ profile }: SubscriptionTabProps) {
                 </li>
                 <li className="flex items-center gap-2">
                   <span className="text-green-600">✓</span>
-                  Interpretaciones personalizadas con IA
+                  Interpretaciones personalizadas
                 </li>
                 <li className="flex items-center gap-2">
                   <span className="text-green-600">✓</span>

--- a/frontend/src/no-ia-user-facing.test.ts
+++ b/frontend/src/no-ia-user-facing.test.ts
@@ -1,0 +1,72 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Guardarraíl T-FBK-004 (Hallazgo FBK-003): el texto de cara al usuario NO debe
+ * mencionar "IA" / "inteligencia artificial". Debe usarse el glosario de marca
+ * ("interpretaciones personalizadas", "análisis profundo", etc.).
+ *
+ * Escanea todo `src/` (excepto el panel de admin y los tests) y falla si aparece
+ * el token en código que llega al usuario.
+ *
+ * NO cuentan como violación (ver FBK-003):
+ *  - Comentarios y JSDoc.
+ *  - Nombres de variables/componentes/hooks en inglés (AISynthesis, useAdminAIUsage…),
+ *    que usan "AI" y no matchean el token español "IA".
+ *  - Panel de admin: `app/admin/**` y `components/features/admin/**`.
+ */
+
+const SRC = path.dirname(fileURLToPath(import.meta.url));
+const IA_WORD = /\bIA\b/;
+const IA_PHRASE = /inteligencia artificial/i;
+
+function blankKeepNewlines(match: string): string {
+  return match.replace(/[^\n]/g, ' ');
+}
+
+/** Elimina comentarios de bloque/JSDoc/JSX y de línea, preservando saltos de línea. */
+function stripComments(src: string): string {
+  let out = src.replace(/\/\*[\s\S]*?\*\//g, blankKeepNewlines);
+  out = out
+    .split('\n')
+    .map((l) => l.replace(/([^:"'`])\/\/.*$/, '$1').replace(/^\s*\/\/.*$/, ''))
+    .join('\n');
+  return out;
+}
+
+const ADMIN_DIR = /[/\\](app[/\\]admin|components[/\\]features[/\\]admin)[/\\]/;
+const isExcluded = (p: string): boolean =>
+  ADMIN_DIR.test(p) || /\.(test|spec)\.(ts|tsx)$/.test(p) || /\.d\.ts$/.test(p);
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (/[/\\]admin$/.test(p)) continue;
+      walk(p, acc);
+    } else if (/\.(ts|tsx)$/.test(p) && !isExcluded(p)) {
+      acc.push(p);
+    }
+  }
+  return acc;
+}
+
+function scan(file: string): string[] {
+  const lines = stripComments(fs.readFileSync(file, 'utf8')).split('\n');
+  const hits: string[] = [];
+  lines.forEach((line, i) => {
+    if (IA_WORD.test(line) || IA_PHRASE.test(line)) {
+      hits.push(`${path.relative(SRC, file)}:${i + 1} → ${line.trim()}`);
+    }
+  });
+  return hits;
+}
+
+describe('Guardarraíl: sin "IA" en texto user-facing del frontend (FBK-003)', () => {
+  it('no menciona "IA" ni "inteligencia artificial" en componentes/páginas user-facing', () => {
+    const violations = walk(SRC).flatMap(scan);
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 🎯 Objetivo

Erradicar toda mención a **"IA" / "inteligencia artificial"** del texto de cara al usuario, usando el **glosario de marca aprobado por Ariel** (`interpretaciones personalizadas`, `análisis profundo y personalizado`, etc.). Cubre el **Hallazgo FBK-003** (regla dura del proyecto). Task: **T-FBK-004**.

> ⚠️ Dependencia cumplida: el glosario de reemplazos fue aprobado por Ariel antes de aplicar cambios.

## 🔎 Contexto (el inventario original se corrió)

T-FBK-005 y T-FBK-006 ya se habían mergeado, así que el inventario de FBK-003 estaba desactualizado. Se **verificó el estado real** antes de tocar código:
- Ya resueltos por T-FBK-005 (no tocados): `PremiumPage:59/64`, `premium-benefits.ts:63`.
- **Apariciones nuevas** detectadas y corregidas, no listadas en el inventario: `BirthChartPageContent`, `WelcomeModal`, `ai-quota.guard.ts` (de T-FBK-006), `email.service.ts:145`, constantes `QUOTA_*`.

## 📦 Cambios

### Frontend
- `AISynthesis`, `BirthChartPageContent`, `PremiumPage`, `SubscriptionTab`, `WelcomeModal`.

### Backend
- **Guards:** `requires-premium-for-ai`, `requires-premium-for-numerology-ai`, `ai-quota`.
- **DTO:** `create-reading.dto.ts` (mensaje de validación 400).
- **Emails:** asuntos (80% y 100%) en `email.service.ts` + plantillas `.hbs` (welcome, quota-limit-reached, quota-warning-80, plan-change).
- **Constantes:** `QUOTA_WARNING_MESSAGE` / `QUOTA_LIMIT_REACHED_MESSAGE`.
- **Plan:** `plans.seeder.ts` **+ migración de datos** (`1776700000000-RemoveAiMentionFromPremiumPlanDescription.ts`) para reformular la descripción del plan en las filas ya persistidas de `plans` (se renderiza en `/premium`).

### Guardarraíl (nuevo)
- `no-ia-user-facing.spec.ts` (Jest) y `no-ia-user-facing.test.ts` (Vitest): fallan si reaparece "IA"/"inteligencia artificial" en texto user-facing. Excluyen admin, Swagger (`@Api…`/`.addTag`), comentarios y nombres de variables/componentes.

## 🚫 Fuera de alcance (decisión de Ariel)
- Panel de admin (`app/admin/**`, `components/features/admin/**`).
- Error interno de infraestructura `"no hay proveedor de IA configurado"` (`ai-provider.service.ts`) — no es copy de feature.

## ✅ Criterios de Aceptación
- [x] Ningún texto de cara al usuario (UI, errores de API, emails, descripción del plan renderizada) menciona "IA".
- [x] La descripción del plan proviene del backend (seed + migración de datos), no solo del frontend.
- [x] Guardarraíl que previene regresiones.

## 🧪 Validaciones
- **Backend:** `format` · `lint` · `test:cov` (308 suites, **4450 tests**, cobertura **84.6%**) · `build` · `validate-architecture` ✅
- **Frontend:** `format` · `lint:fix` (0 errores) · `type-check` · `test:run` (**5151 tests**, 7 skipped) · `build` · `validate-architecture` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)