### PR TITLE
feat(T-FBK-001): unificar la invitación a Premium del dashboard

### DIFF
--- a/docs/BACKLOG_FEEDBACK_UX_2026_07.md
+++ b/docs/BACKLOG_FEEDBACK_UX_2026_07.md
@@ -321,7 +321,7 @@ El **recuadro de highlight que "ya existe"** es la clase condicional de borde: `
 
 | ID | Tarea | Tipo | Prioridad | Estimación |
 | ---------- | --------------------------------------------------------------------------- | ---------- | ---------- | ---------- |
-| T-FBK-001 | Unificar la invitación a Premium del dashboard (Rituales → `PremiumUpsellCard`) | Frontend | 🟠 Alta | 1 pt |
+| T-FBK-001 | Unificar la invitación a Premium del dashboard (Rituales → `PremiumUpsellCard`) | Frontend | 🟠 Alta | 1 pt | ✅ COMPLETADA |
 | T-FBK-002 | (Deuda) Unificar el sistema de upsell (tokens de marca + convergencia de banners) | Frontend | 🟢 Baja | 3 pts |
 | T-FBK-003 | Reubicar la ficha "¿Qué es…?" debajo de la actividad en las 9 páginas | Frontend | 🟡 Media | 1.5 pts |
 | T-FBK-004 | Erradicar "IA" del texto user-facing (front + back + emails + migración) | Full-stack | 🟠 Alta | 3 pts | ✅ COMPLETADA |
@@ -339,13 +339,13 @@ El **recuadro de highlight que "ya existe"** es la clase condicional de borde: `
 **Estimación:** 1 punto
 **Dependencias:** ninguna
 **Cubre Hallazgo:** FBK-001
-**Estado:** 🔲 PENDIENTE
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] Reemplazar el markup inline de `PersonalizedRitualsWidget.tsx:64-81` por `<PremiumUpsellCard>` (mismo patrón que `SacredEventsWidget.tsx:206-216`), con `title`/`description` adecuados a rituales personalizados.
-- [ ] Migrar el CTA hardcodeado `"Desbloquear recomendaciones"` a una constante de `CTA_PREMIUM` (reutilizar `UPSELL_SOFT` o añadir una específica si Ariel prefiere ese texto).
-- [ ] Actualizar/añadir tests del widget para fijar el uso del componente compartido.
+- [x] Reemplazar el markup inline de `PersonalizedRitualsWidget.tsx:64-81` por `<PremiumUpsellCard>` (mismo patrón que `SacredEventsWidget.tsx:206-216`), con `title`/`description` adecuados a rituales personalizados.
+- [x] Migrar el CTA hardcodeado `"Desbloquear recomendaciones"` a una constante de `CTA_PREMIUM` (se reutiliza `UPSELL_SOFT` → "Upgrade a Premium", coherente con `SacredEventsWidget`).
+- [x] Actualizar/añadir tests del widget para fijar el uso del componente compartido.
 
 #### 🎯 Criterios de Aceptación
 

--- a/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.test.tsx
+++ b/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.test.tsx
@@ -7,6 +7,7 @@ import { useAuthStore } from '@/stores/authStore';
 import type { AuthUser, AuthStore } from '@/types';
 import type { UseQueryResult } from '@tanstack/react-query';
 import type { RitualRecommendationsResponse } from '@/types';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 
 // Mock dependencies
 vi.mock('@/hooks/api/useRitualRecommendations');
@@ -71,10 +72,27 @@ describe('PersonalizedRitualsWidget', () => {
       expect(
         screen.getByText(/analizamos tus lecturas para sugerirte rituales personalizados/i)
       ).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: /desbloquear recomendaciones/i })).toHaveAttribute(
-        'href',
-        '/premium'
-      );
+    });
+
+    it('should render the shared PremiumUpsellCard component', () => {
+      mockAuthStore('free');
+      mockRecommendationsHook(undefined);
+
+      render(<PersonalizedRitualsWidget />, { wrapper });
+
+      expect(screen.getByTestId('rituals-premium-upsell')).toBeInTheDocument();
+    });
+
+    it('should use the canonical CTA_PREMIUM copy pointing to /premium', () => {
+      mockAuthStore('free');
+      mockRecommendationsHook(undefined);
+
+      render(<PersonalizedRitualsWidget />, { wrapper });
+
+      const cta = screen.getByRole('link', {
+        name: new RegExp(CTA_PREMIUM.UPSELL_SOFT, 'i'),
+      });
+      expect(cta).toHaveAttribute('href', '/premium');
     });
 
     it('should not call useRitualRecommendations for free users', () => {

--- a/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.test.tsx
+++ b/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.test.tsx
@@ -8,6 +8,7 @@ import type { AuthUser, AuthStore } from '@/types';
 import type { UseQueryResult } from '@tanstack/react-query';
 import type { RitualRecommendationsResponse } from '@/types';
 import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
+import { ROUTES } from '@/lib/constants/routes';
 
 // Mock dependencies
 vi.mock('@/hooks/api/useRitualRecommendations');
@@ -89,10 +90,8 @@ describe('PersonalizedRitualsWidget', () => {
 
       render(<PersonalizedRitualsWidget />, { wrapper });
 
-      const cta = screen.getByRole('link', {
-        name: new RegExp(CTA_PREMIUM.UPSELL_SOFT, 'i'),
-      });
-      expect(cta).toHaveAttribute('href', '/premium');
+      const cta = screen.getByRole('link', { name: CTA_PREMIUM.UPSELL_SOFT });
+      expect(cta).toHaveAttribute('href', ROUTES.PREMIUM);
     });
 
     it('should not call useRitualRecommendations for free users', () => {

--- a/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.tsx
+++ b/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.tsx
@@ -5,11 +5,13 @@ import { Card } from '@/components/ui/card';
 import { WidgetCard } from './WidgetCard';
 import { WidgetEmptyState } from './WidgetEmptyState';
 import { Button } from '@/components/ui/button';
+import { PremiumUpsellCard } from '@/components/ui/premium-upsell-card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useRitualRecommendations } from '@/hooks/api/useRitualRecommendations';
 import { useAuthStore } from '@/stores/authStore';
 import Link from 'next/link';
 import { ROUTES } from '@/lib/constants/routes';
+import { CTA_PREMIUM } from '@/lib/constants/cta-copy';
 import type { RecommendationPattern } from '@/types';
 
 const PATTERN_ICONS: Record<RecommendationPattern, React.ComponentType<{ className?: string }>> = {
@@ -69,13 +71,13 @@ export function PersonalizedRitualsWidget() {
         className="bg-secondary/5"
         data-testid="personalized-rituals-widget"
       >
-        <p className="text-muted-foreground mb-4 text-sm">
-          Con Premium, analizamos tus lecturas para sugerirte rituales personalizados según tu
-          momento energético actual.
-        </p>
-        <Button asChild>
-          <Link href="/premium">Desbloquear recomendaciones</Link>
-        </Button>
+        <PremiumUpsellCard
+          title="Rituales personalizados para tu momento"
+          description="Con Premium, analizamos tus lecturas para sugerirte rituales personalizados según tu momento energético actual."
+          href="/premium"
+          ctaLabel={CTA_PREMIUM.UPSELL_SOFT}
+          data-testid="rituals-premium-upsell"
+        />
       </WidgetCard>
     );
   }

--- a/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.tsx
+++ b/frontend/src/components/features/dashboard/PersonalizedRitualsWidget.tsx
@@ -74,7 +74,7 @@ export function PersonalizedRitualsWidget() {
         <PremiumUpsellCard
           title="Rituales personalizados para tu momento"
           description="Con Premium, analizamos tus lecturas para sugerirte rituales personalizados según tu momento energético actual."
-          href="/premium"
+          href={ROUTES.PREMIUM}
           ctaLabel={CTA_PREMIUM.UPSELL_SOFT}
           data-testid="rituals-premium-upsell"
         />


### PR DESCRIPTION
## 📋 Tarea

**T-FBK-001:** Unificar la Invitación a Premium del Dashboard (Rituales → `PremiumUpsellCard`)
Cubre el hallazgo **FBK-001** (fragmentación del upsell en el dashboard).

## 🎯 Cambios

- `PersonalizedRitualsWidget` deja de renderizar markup inline propio para el estado Free y consume el componente compartido **`<PremiumUpsellCard>`**, el mismo patrón que ya usa `SacredEventsWidget`. Ahora ambos widgets del dashboard muestran la misma invitación visual.
- El CTA hardcodeado `"Desbloquear recomendaciones"` se migra a la constante canónica **`CTA_PREMIUM.UPSELL_SOFT`** (`"Upgrade a Premium"`), coherente con el resto del dashboard. (Decisión de Ariel: reutilizar la constante existente en lugar de crear una nueva.)
- `title`/`description` adaptados a rituales personalizados.
- Tests del widget actualizados para fijar el uso del componente compartido (`data-testid="rituals-premium-upsell"`) y el CTA proveniente de `CTA_PREMIUM`.

## ✅ Criterios de Aceptación

- [x] Ambos widgets del dashboard muestran la misma invitación visual; el CTA proviene de `CTA_PREMIUM`.
- [x] Ciclo de calidad frontend completo pasa.

## 🧪 Validaciones

- [x] `npm run format`
- [x] `npm run lint:fix` (0 errores)
- [x] `npm run type-check`
- [x] `npm run test:run` (412 archivos / 5153 tests ✓)
- [x] `npm run build`
- [x] `node scripts/validate-architecture.js` ✓

## 📁 Archivos

- `frontend/src/components/features/dashboard/PersonalizedRitualsWidget.tsx` (+ test)
- `docs/BACKLOG_FEEDBACK_UX_2026_07.md` (backlog actualizado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)