### PR TITLE
feat(T-FBK-003): reubicar la ficha "¿Qué es…?" debajo de la actividad

### DIFF
--- a/docs/BACKLOG_FEEDBACK_UX_2026_07.md
+++ b/docs/BACKLOG_FEEDBACK_UX_2026_07.md
@@ -323,7 +323,7 @@ El **recuadro de highlight que "ya existe"** es la clase condicional de borde: `
 | ---------- | --------------------------------------------------------------------------- | ---------- | ---------- | ---------- |
 | T-FBK-001 | Unificar la invitación a Premium del dashboard (Rituales → `PremiumUpsellCard`) | Frontend | 🟠 Alta | 1 pt | ✅ COMPLETADA |
 | T-FBK-002 | (Deuda) Unificar el sistema de upsell (tokens de marca + convergencia de banners) | Frontend | 🟢 Baja | 3 pts |
-| T-FBK-003 | Reubicar la ficha "¿Qué es…?" debajo de la actividad en las 9 páginas | Frontend | 🟡 Media | 1.5 pts |
+| T-FBK-003 | Reubicar la ficha "¿Qué es…?" debajo de la actividad en las 9 páginas | Frontend | 🟡 Media | 1.5 pts | ✅ COMPLETADA |
 | T-FBK-004 | Erradicar "IA" del texto user-facing (front + back + emails + migración) | Full-stack | 🟠 Alta | 3 pts | ✅ COMPLETADA |
 | T-FBK-005 | Alinear el copy/beneficios de Premium con la implementación real | Frontend | 🔴 Crítica | 2.5 pts | ✅ COMPLETADA |
 | T-FBK-006 | Resolver la incoherencia de la cuota de IA (fuente de verdad única) | Backend | 🔴 Crítica | 2 pts | ✅ COMPLETADA |
@@ -389,23 +389,30 @@ El **recuadro de highlight que "ya existe"** es la clase condicional de borde: `
 **Estimación:** 1.5 puntos
 **Dependencias:** ninguna
 **Cubre Hallazgo:** FBK-002
-**Estado:** 🔲 PENDIENTE
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] Mover el `<ServiceIntro>` (o `<NumerologyIntro>`) debajo de la actividad en las 9 páginas del alcance.
-- [ ] Cambiar el margen de separación de `mb-*` a `mt-*` en las 9 llamadas.
-- [ ] En páginas con varios bloques de actividad, ubicar el intro al final de todos ellos.
-- [ ] Actualizar tests que asuman el orden previo.
+- [x] Mover el `<ServiceIntro>` (o `<NumerologyIntro>`) debajo de la actividad en las 9 páginas del alcance.
+- [x] Cambiar el margen de separación de `mb-*` a `mt-*` en las 9 llamadas.
+- [x] En páginas con varios bloques de actividad, ubicar el intro al final de todos ellos.
+- [x] Actualizar tests que asuman el orden previo.
 
 #### 🎯 Criterios de Aceptación
 
-- Las 9 páginas muestran la ficha informativa debajo de la actividad, con separación consistente.
-- Ciclo de calidad frontend completo pasa.
+- [x] Las 9 páginas muestran la ficha informativa debajo de la actividad, con separación consistente.
+- [x] Ciclo de calidad frontend completo pasa.
 
 #### 📁 Archivos involucrados
 
 - Los 9 del alcance (ver tabla de FBK-002) + sus tests.
+
+#### 🛠️ Notas de Implementación (6-jul-2026)
+
+- Reubicación puramente de orden de JSX: el intro compartido (`ServiceIntro`/`NumerologyIntro`) se movió del tope al final del bloque de actividad en las 9 páginas, con `mb-*` → `mt-*`.
+- En páginas con múltiples bloques de actividad el intro va al final de todos ellos: **Numerología** (tras perfil + calculadora + resultado), **Carta Astral** (tras el form + info "¿Qué incluye?"/"Importante"), **Horóscopo Chino** (tras el selector de animales, antes del modal overlay), **Péndulo** (tras el área del péndulo + controles), **Rituales** (tras la lista completa), **Horóscopo** (tras el selector de signos).
+- **TDD:** se añadió un test de orden por página que verifica con `compareDocumentPosition` que el intro queda **después** de un ancla de actividad (`calculate-button`, `unrevealed-state`, `birth-data-form`, `zodiac-selector`, `chinese-animal-selector`, `pendulum-animation`, `ritual-grid`, `category-selector`). Los tests de presencia previos se mantienen.
+- Ciclo de calidad frontend completo: format ✅, lint (0 errores) ✅, type-check ✅, 5162 tests ✅, build ✅, validate-architecture ✅.
 
 ---
 

--- a/frontend/src/app/carta-del-dia/page.test.tsx
+++ b/frontend/src/app/carta-del-dia/page.test.tsx
@@ -180,6 +180,23 @@ describe('CartaDelDiaPage', () => {
       expect(screen.getByTestId('unrevealed-state')).toBeInTheDocument();
     });
 
+    it('should render ServiceIntro below the activity', () => {
+      mockUseDailyReadingToday.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: null,
+      });
+
+      renderWithProviders(<CartaDelDiaPage />);
+
+      const activity = screen.getByTestId('unrevealed-state');
+      const intro = screen.getByTestId('service-intro');
+
+      expect(
+        activity.compareDocumentPosition(intro) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+
     it('should display mystical prompt text', () => {
       mockUseDailyReadingToday.mockReturnValue({
         data: null,

--- a/frontend/src/app/carta-del-dia/page.tsx
+++ b/frontend/src/app/carta-del-dia/page.tsx
@@ -17,11 +17,11 @@ export default function CartaDelDiaPage() {
           Tarot del Día
         </h1>
 
-        {/* Encyclopedia Widget */}
-        <ServiceIntro data={SERVICE_INTROS['daily-card']} className="mb-8 w-full" />
-
         {/* Main Content - All logic delegated to feature component */}
         <DailyCardExperience />
+
+        {/* Encyclopedia Widget */}
+        <ServiceIntro data={SERVICE_INTROS['daily-card']} className="mt-8 w-full" />
       </div>
     </div>
   );

--- a/frontend/src/app/horoscopo-chino/page.test.tsx
+++ b/frontend/src/app/horoscopo-chino/page.test.tsx
@@ -201,6 +201,20 @@ describe('HoroscopoChinoPage', () => {
     expect(widget).toHaveAttribute('data-key', 'chinese-horoscope-intro');
   });
 
+  it('debe ubicar ServiceIntro debajo de la actividad (selector de animales)', () => {
+    mockUseChineseHoroscopesByYear.mockReturnValue({
+      isLoading: false,
+      data: [],
+    });
+
+    renderWithProviders(<HoroscopoChinoPage />);
+
+    const activity = screen.getByTestId('chinese-animal-selector');
+    const intro = screen.getByTestId('service-intro');
+
+    expect(activity.compareDocumentPosition(intro) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('debe renderizar correctamente la página con la tarjeta informativa', () => {
     mockUseChineseHoroscopesByYear.mockReturnValue({
       isLoading: false,

--- a/frontend/src/app/horoscopo-chino/page.tsx
+++ b/frontend/src/app/horoscopo-chino/page.tsx
@@ -37,8 +37,6 @@ export default function HoroscopoChinoPage() {
         <p className="text-muted-foreground">Descubre las predicciones anuales según tu animal</p>
       </div>
 
-      <ServiceIntro data={SERVICE_INTROS['chinese-horoscope']} className="mb-6" />
-
       {/* User's horoscope card (if authenticated and has birthDate) */}
       {isAuthenticated && userBirthDate && myHoroscope && (
         <div className="mx-auto mb-8 max-w-2xl">
@@ -99,6 +97,8 @@ export default function HoroscopoChinoPage() {
 
       {/* Selector de animales */}
       <ChineseAnimalSelector userAnimal={userAnimal} onSelect={handleAnimalSelect} />
+
+      <ServiceIntro data={SERVICE_INTROS['chinese-horoscope']} className="mt-6" />
 
       {/* Element Selector Modal */}
       {selectedAnimalForModal && (

--- a/frontend/src/app/horoscopo/page.test.tsx
+++ b/frontend/src/app/horoscopo/page.test.tsx
@@ -187,6 +187,24 @@ describe('HoroscopoPage', () => {
     expect(widget).toHaveAttribute('data-key', 'western-horoscope-intro');
   });
 
+  it('debe ubicar ServiceIntro debajo de la actividad (selector de signos)', () => {
+    mockUseAuthStore.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+    });
+    mockUseTodayAllHoroscopes.mockReturnValue({
+      isLoading: false,
+      data: [],
+    });
+
+    renderWithProviders(<HoroscopoPage />);
+
+    const activity = screen.getByTestId('zodiac-selector');
+    const intro = screen.getByTestId('service-intro');
+
+    expect(activity.compareDocumentPosition(intro) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('debe renderizar correctamente la página con la tarjeta informativa', () => {
     mockUseAuthStore.mockReturnValue({
       user: null,

--- a/frontend/src/app/horoscopo/page.tsx
+++ b/frontend/src/app/horoscopo/page.tsx
@@ -29,8 +29,6 @@ export default function HoroscopoPage() {
         <p className="text-muted-foreground">Selecciona tu signo para ver las predicciones</p>
       </div>
 
-      <ServiceIntro data={SERVICE_INTROS['western-horoscope']} className="mb-6" />
-
       {!isAuthenticated && (
         <div className="bg-muted/50 mb-8 rounded-lg p-4 text-center">
           <p className="text-muted-foreground text-sm">
@@ -57,6 +55,8 @@ export default function HoroscopoPage() {
       ) : (
         <ZodiacSignSelector userSign={userSign} onSelect={handleSignSelect} />
       )}
+
+      <ServiceIntro data={SERVICE_INTROS['western-horoscope']} className="mt-6" />
     </div>
   );
 }

--- a/frontend/src/app/ritual/page.test.tsx
+++ b/frontend/src/app/ritual/page.test.tsx
@@ -225,6 +225,31 @@ describe('RitualPage', () => {
       expect(screen.getByTestId('category-selector')).toBeInTheDocument();
     });
 
+    it('should render ServiceIntro below the activity (category selector)', () => {
+      (useAuth as Mock).mockReturnValue({
+        user: { id: 1, plan: 'premium' },
+        isAuthenticated: true,
+        isLoading: false,
+      });
+
+      (useUserCapabilities as Mock).mockReturnValue({
+        data: {
+          canCreateTarotReading: true,
+          canUseCustomQuestions: true,
+        },
+        isLoading: false,
+      });
+
+      render(<RitualPage />);
+
+      const activity = screen.getByTestId('category-selector');
+      const intro = screen.getByTestId('service-intro');
+
+      expect(
+        activity.compareDocumentPosition(intro) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+
     it('should NOT redirect PREMIUM users with custom questions capability', () => {
       (useAuth as Mock).mockReturnValue({
         user: { id: 1, plan: 'premium' },

--- a/frontend/src/app/ritual/page.tsx
+++ b/frontend/src/app/ritual/page.tsx
@@ -23,10 +23,10 @@ export default function RitualPage() {
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <div className="mx-auto mb-8 max-w-2xl">
+      <RitualPageContent />
+      <div className="mx-auto mt-8 max-w-2xl">
         <ServiceIntro data={SERVICE_INTROS.tarot} />
       </div>
-      <RitualPageContent />
     </div>
   );
 }

--- a/frontend/src/app/tarot/page.test.tsx
+++ b/frontend/src/app/tarot/page.test.tsx
@@ -225,6 +225,31 @@ describe('TarotPage', () => {
       expect(screen.getByTestId('category-selector')).toBeInTheDocument();
     });
 
+    it('should render ServiceIntro below the activity (category selector)', () => {
+      (useAuth as Mock).mockReturnValue({
+        user: { id: 1, plan: 'premium' },
+        isAuthenticated: true,
+        isLoading: false,
+      });
+
+      (useUserCapabilities as Mock).mockReturnValue({
+        data: {
+          canCreateTarotReading: true,
+          canUseCustomQuestions: true,
+        },
+        isLoading: false,
+      });
+
+      render(<TarotPage />);
+
+      const activity = screen.getByTestId('category-selector');
+      const intro = screen.getByTestId('service-intro');
+
+      expect(
+        activity.compareDocumentPosition(intro) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+
     it('should NOT redirect PREMIUM users with custom questions capability', () => {
       (useAuth as Mock).mockReturnValue({
         user: { id: 1, plan: 'premium' },

--- a/frontend/src/app/tarot/page.tsx
+++ b/frontend/src/app/tarot/page.tsx
@@ -23,10 +23,10 @@ export default function TarotPage() {
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <div className="mx-auto mb-8 max-w-2xl">
+      <TarotPageContent />
+      <div className="mx-auto mt-8 max-w-2xl">
         <ServiceIntro data={SERVICE_INTROS.tarot} />
       </div>
-      <TarotPageContent />
     </div>
   );
 }

--- a/frontend/src/components/features/birth-chart/BirthChartPageContent/BirthChartPageContent.test.tsx
+++ b/frontend/src/components/features/birth-chart/BirthChartPageContent/BirthChartPageContent.test.tsx
@@ -109,6 +109,15 @@ describe('BirthChartPageContent', () => {
     expect(widget).toBeInTheDocument();
   });
 
+  it('debe ubicar ServiceIntro debajo de la actividad (formulario)', () => {
+    renderWithProviders(<BirthChartPageContent />);
+
+    const activity = screen.getByTestId('birth-data-form');
+    const intro = screen.getByTestId('birth-chart-intro');
+
+    expect(activity.compareDocumentPosition(intro) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('debe renderizar correctamente la página con la tarjeta informativa', () => {
     renderWithProviders(<BirthChartPageContent />);
 

--- a/frontend/src/components/features/birth-chart/BirthChartPageContent/BirthChartPageContent.tsx
+++ b/frontend/src/components/features/birth-chart/BirthChartPageContent/BirthChartPageContent.tsx
@@ -184,8 +184,6 @@ export function BirthChartPageContent() {
         )}
       </div>
 
-      <ServiceIntro data={SERVICE_INTROS['birth-chart']} className="mb-6" />
-
       {/* Error global */}
       {error && (
         <Alert variant="destructive" className="mb-6">
@@ -284,6 +282,8 @@ export function BirthChartPageContent() {
           </CardContent>
         </Card>
       </div>
+
+      <ServiceIntro data={SERVICE_INTROS['birth-chart']} className="mt-6" />
     </div>
   );
 }

--- a/frontend/src/components/features/numerology/NumerologyPage.test.tsx
+++ b/frontend/src/components/features/numerology/NumerologyPage.test.tsx
@@ -64,6 +64,15 @@ describe('NumerologyPage', () => {
     expect(screen.getByTestId('numerology-intro')).toBeInTheDocument();
   });
 
+  it('debe ubicar NumerologyIntro debajo de la actividad (calculadora)', () => {
+    renderWithProviders(<NumerologyPage />);
+
+    const activity = screen.getByTestId('calculate-button');
+    const intro = screen.getByTestId('numerology-intro');
+
+    expect(activity.compareDocumentPosition(intro) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('debe renderizar correctamente la página sin errores', () => {
     renderWithProviders(<NumerologyPage />);
 

--- a/frontend/src/components/features/numerology/NumerologyPage.tsx
+++ b/frontend/src/components/features/numerology/NumerologyPage.tsx
@@ -76,8 +76,6 @@ export function NumerologyPage() {
           <p className="text-muted-foreground">Descubre los números que rigen tu vida</p>
         </div>
 
-        <NumerologyIntro className="mb-8" />
-
         {/* Alert for incomplete profile */}
         {hasIncompleteProfile && (
           <Alert className="mb-8 border-amber-200 bg-amber-50">
@@ -212,6 +210,8 @@ export function NumerologyPage() {
             <NumerologyProfile profile={calculatedResult} />
           </div>
         )}
+
+        <NumerologyIntro className="mt-8" />
       </div>
     </div>
   );

--- a/frontend/src/components/features/pendulum/PendulumConsultation.test.tsx
+++ b/frontend/src/components/features/pendulum/PendulumConsultation.test.tsx
@@ -93,6 +93,15 @@ describe('PendulumConsultation', () => {
     expect(widget).toBeInTheDocument();
   });
 
+  it('debe ubicar ServiceIntro debajo de la actividad (péndulo)', () => {
+    renderWithProviders(<PendulumConsultation />);
+
+    const activity = screen.getByTestId('pendulum-animation');
+    const intro = screen.getByTestId('pendulum-intro');
+
+    expect(activity.compareDocumentPosition(intro) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('debe renderizar correctamente la página con la tarjeta informativa', () => {
     renderWithProviders(<PendulumConsultation />);
 

--- a/frontend/src/components/features/pendulum/PendulumConsultation.tsx
+++ b/frontend/src/components/features/pendulum/PendulumConsultation.tsx
@@ -124,8 +124,6 @@ export function PendulumConsultation() {
           <p className="text-muted-foreground">Formula tu pregunta y deja que el péndulo te guíe</p>
         </div>
 
-        <ServiceIntro data={SERVICE_INTROS.pendulum} className="mb-6" />
-
         {/* Límites */}
         <PendulumLimitBanner />
 
@@ -217,6 +215,8 @@ export function PendulumConsultation() {
             Nueva consulta
           </Button>
         )}
+
+        <ServiceIntro data={SERVICE_INTROS.pendulum} className="mt-6" />
       </div>
 
       {/* Modal de contenido bloqueado */}

--- a/frontend/src/components/features/rituals/RitualsPage.test.tsx
+++ b/frontend/src/components/features/rituals/RitualsPage.test.tsx
@@ -91,6 +91,15 @@ describe('RitualsPage', () => {
     expect(widget).toBeInTheDocument();
   });
 
+  it('debe ubicar ServiceIntro debajo de la actividad (lista de rituales)', () => {
+    renderWithProviders(<RitualsPage />);
+
+    const activity = screen.getByTestId('ritual-grid');
+    const intro = screen.getByTestId('rituals-intro');
+
+    expect(activity.compareDocumentPosition(intro) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('debe renderizar correctamente la página con la tarjeta informativa', () => {
     renderWithProviders(<RitualsPage />);
 

--- a/frontend/src/components/features/rituals/RitualsPage.test.tsx
+++ b/frontend/src/components/features/rituals/RitualsPage.test.tsx
@@ -94,7 +94,10 @@ describe('RitualsPage', () => {
   it('debe ubicar ServiceIntro debajo de la actividad (lista de rituales)', () => {
     renderWithProviders(<RitualsPage />);
 
-    const activity = screen.getByTestId('ritual-grid');
+    // Anclamos en la última grilla (la de "Todos los Rituales"); si un test
+    // futuro renderiza destacados habría más de un 'ritual-grid'.
+    const grids = screen.getAllByTestId('ritual-grid');
+    const activity = grids[grids.length - 1];
     const intro = screen.getByTestId('rituals-intro');
 
     expect(activity.compareDocumentPosition(intro) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();

--- a/frontend/src/components/features/rituals/RitualsPage.tsx
+++ b/frontend/src/components/features/rituals/RitualsPage.tsx
@@ -64,8 +64,6 @@ export function RitualsPage() {
         )}
       </div>
 
-      <ServiceIntro data={SERVICE_INTROS.rituals} className="mb-6" />
-
       {/* Rituales destacados */}
       {!hasFilters && (
         <section className="mb-12">
@@ -110,6 +108,8 @@ export function RitualsPage() {
           />
         )}
       </section>
+
+      <ServiceIntro data={SERVICE_INTROS.rituals} className="mt-6" />
     </div>
   );
 }


### PR DESCRIPTION
## Resumen

Reubica la ficha informativa "¿Qué es…?" (`ServiceIntro` / `NumerologyIntro`) para que aparezca **debajo** de la actividad en las **9 páginas** del alcance, en vez de arriba. Cubre el hallazgo **FBK-002** (Ariel: "la información de las actividades está arriba de la propia actividad; debería estar abajo en todas las páginas").

Es un cambio de orden de JSX sobre un componente compartido: en cada página el intro se movió al final del bloque de actividad y el margen de separación pasó de `mb-*` a `mt-*`.

## Páginas modificadas (9)

| # | Actividad | Archivo | Ubicación del intro ahora |
|---|-----------|---------|---------------------------|
| 1 | Numerología | `numerology/NumerologyPage.tsx` | tras perfil + calculadora + resultado |
| 2 | Tarot del Día | `app/carta-del-dia/page.tsx` | tras `DailyCardExperience` |
| 3 | Carta Astral | `birth-chart/BirthChartPageContent.tsx` | tras el form + "¿Qué incluye?"/"Importante" |
| 4 | Horóscopo | `app/horoscopo/page.tsx` | tras el selector de signos |
| 5 | Horóscopo Chino | `app/horoscopo-chino/page.tsx` | tras el selector de animales (antes del modal overlay) |
| 6 | Péndulo | `pendulum/PendulumConsultation.tsx` | tras el área del péndulo + controles |
| 7 | Rituales | `rituals/RitualsPage.tsx` | tras la lista completa de rituales |
| 8 | Tirada de Tarot | `app/tarot/page.tsx` | tras `TarotPageContent` |
| 9 | Ritual | `app/ritual/page.tsx` | tras `RitualPageContent` |

En las páginas con varios bloques de actividad, el intro queda al final de **todos** ellos (criterio de FBK-002).

## TDD

Se añadió un test de orden por página que verifica con `compareDocumentPosition` que el intro queda **después** de un ancla de actividad (`calculate-button`, `unrevealed-state`, `birth-data-form`, `zodiac-selector`, `chinese-animal-selector`, `pendulum-animation`, `ritual-grid`, `category-selector`). Los tests de presencia previos se mantienen.

## Ciclo de calidad

- ✅ `format`
- ✅ `lint` (0 errores)
- ✅ `type-check`
- ✅ `test:run` — 5162 tests
- ✅ `build`
- ✅ `validate-architecture`

## Referencia

- Tarea: **T-FBK-003** · Hallazgo: **FBK-002** · `docs/BACKLOG_FEEDBACK_UX_2026_07.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)