### PR TITLE
feat(T-FBK-008): "Tu signo/animal" sin agrandar la tarjeta (solo borde + a11y)

### DIFF
--- a/docs/BACKLOG_FEEDBACK_UX_2026_07.md
+++ b/docs/BACKLOG_FEEDBACK_UX_2026_07.md
@@ -328,7 +328,7 @@ El **recuadro de highlight que "ya existe"** es la clase condicional de borde: `
 | T-FBK-005 | Alinear el copy/beneficios de Premium con la implementación real | Frontend | 🔴 Crítica | 2.5 pts | ✅ COMPLETADA |
 | T-FBK-006 | Resolver la incoherencia de la cuota de IA (fuente de verdad única) | Backend | 🔴 Crítica | 2 pts | ✅ COMPLETADA |
 | T-FBK-007 | Alinear los iconos del Horóscopo Chino al canon | Frontend | 🟡 Media | 2 pts |
-| T-FBK-008 | "Tu signo/animal" sin agrandar la tarjeta (solo borde + a11y) | Frontend | 🟡 Media | 1 pt |
+| T-FBK-008 | "Tu signo/animal" sin agrandar la tarjeta (solo borde + a11y) ✅ | Frontend | 🟡 Media | 1 pt |
 | T-FBK-009 | Carta astral ilimitada para Free + gestión de límite por admin (fuente única en DB) ✅ | Backend | 🟠 Alta | 3 pts |
 
 ---
@@ -550,14 +550,14 @@ El **recuadro de highlight que "ya existe"** es la clase condicional de borde: `
 **Estimación:** 1 punto
 **Dependencias:** ninguna
 **Cubre Hallazgo:** FBK-006
-**Estado:** 🔲 PENDIENTE
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] Quitar (o reposicionar como `absolute`/altura fija) el `<span>` "Tu signo" (`ZodiacSignCard.tsx:93`) y "Tu animal" (`ChineseAnimalCard.tsx:91`) para que no altere el alto de la card.
-- [ ] Apoyar el destacado solo en el borde existente; **unificar** el borde del chino de `border-red-500` a `border-accent`.
-- [ ] Añadir `aria-label` a la `Card` para conservar la accesibilidad del estado "tu signo/animal".
-- [ ] Migrar tests que dependan del texto visible al `aria-label`.
+- [x] Quitar el `<span>` "Tu signo" (`ZodiacSignCard.tsx`) y "Tu animal" (`ChineseAnimalCard.tsx`) para que no altere el alto de la card.
+- [x] Apoyar el destacado solo en el borde existente; **unificado** el borde del chino de `border-red-500` a `border-accent`.
+- [x] Añadido `aria-label` condicional a la `Card` (`"{nombre} (tu signo/animal)"` solo en la card del usuario) para conservar la accesibilidad del estado.
+- [x] Migrados los tests que dependían del texto visible al nombre accesible (`getByRole('button', { name: /tu signo|tu animal/i })`).
 
 #### 🎯 Criterios de Aceptación
 

--- a/frontend/src/components/features/chinese-horoscope/ChineseAnimalCard.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseAnimalCard.test.tsx
@@ -51,32 +51,43 @@ describe('ChineseAnimalCard', () => {
       expect(screen.getByTestId('chinese-animal-dragon')).toBeInTheDocument();
     });
 
-    it('should show "Tu animal" label when isUserAnimal is true', () => {
+    it('should not render a visible "Tu animal" label that alters card height', () => {
       const animalInfo = createTestAnimalInfo();
 
       render(
         <ChineseAnimalCard animalInfo={animalInfo} isUserAnimal={true} onClick={mockOnClick} />
       );
 
-      expect(screen.getByText('Tu animal')).toBeInTheDocument();
+      // El destacado se apoya solo en el borde: no debe agregarse texto visible.
+      expect(screen.queryByText('Tu animal')).not.toBeInTheDocument();
     });
 
-    it('should not show "Tu animal" label when isUserAnimal is false', () => {
+    it('should expose the "tu animal" state via aria-label when isUserAnimal is true', () => {
+      const animalInfo = createTestAnimalInfo();
+
+      render(
+        <ChineseAnimalCard animalInfo={animalInfo} isUserAnimal={true} onClick={mockOnClick} />
+      );
+
+      expect(screen.getByRole('button', { name: /tu animal/i })).toBeInTheDocument();
+    });
+
+    it('should not expose the "tu animal" state via aria-label when isUserAnimal is false', () => {
       const animalInfo = createTestAnimalInfo();
 
       render(
         <ChineseAnimalCard animalInfo={animalInfo} isUserAnimal={false} onClick={mockOnClick} />
       );
 
-      expect(screen.queryByText('Tu animal')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /tu animal/i })).not.toBeInTheDocument();
     });
 
-    it('should not show "Tu animal" label by default', () => {
+    it('should not expose the "tu animal" state via aria-label by default', () => {
       const animalInfo = createTestAnimalInfo();
 
       render(<ChineseAnimalCard animalInfo={animalInfo} onClick={mockOnClick} />);
 
-      expect(screen.queryByText('Tu animal')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /tu animal/i })).not.toBeInTheDocument();
     });
   });
 
@@ -103,7 +114,7 @@ describe('ChineseAnimalCard', () => {
       expect(card).not.toHaveClass('ring-primary');
     });
 
-    it('should have border-red-500 border-2 when isUserAnimal is true', () => {
+    it('should have border-accent border-2 when isUserAnimal is true', () => {
       const animalInfo = createTestAnimalInfo();
 
       render(
@@ -111,7 +122,7 @@ describe('ChineseAnimalCard', () => {
       );
 
       const card = screen.getByTestId(`chinese-animal-${animalInfo.animal}`);
-      expect(card).toHaveClass('border-red-500');
+      expect(card).toHaveClass('border-accent');
       expect(card).toHaveClass('border-2');
     });
 

--- a/frontend/src/components/features/chinese-horoscope/ChineseAnimalCard.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseAnimalCard.tsx
@@ -78,17 +78,17 @@ export function ChineseAnimalCard({
         'cursor-pointer p-4 text-center transition-all',
         'hover:scale-105 hover:shadow-md',
         isSelected && 'ring-primary ring-2',
-        isUserAnimal && 'border-2 border-red-500',
+        isUserAnimal && 'border-accent border-2',
         className
       )}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       tabIndex={0}
       role="button"
+      aria-label={isUserAnimal ? `${animalInfo.nameEs} (tu animal)` : undefined}
     >
       <span className="text-4xl">{animalInfo.emoji}</span>
       <p className="mt-2 font-serif text-lg">{animalInfo.nameEs}</p>
-      {isUserAnimal && <span className="text-xs font-medium text-red-500">Tu animal</span>}
     </Card>
   );
 }

--- a/frontend/src/components/features/horoscope/ZodiacSignCard.test.tsx
+++ b/frontend/src/components/features/horoscope/ZodiacSignCard.test.tsx
@@ -59,28 +59,37 @@ describe('ZodiacSignCard', () => {
       expect(screen.getByTestId('zodiac-card-leo')).toBeInTheDocument();
     });
 
-    it('should show "Tu signo" label when isUserSign is true', () => {
+    it('should not render a visible "Tu signo" label that alters card height', () => {
       const signInfo = createTestSignInfo();
 
       render(<ZodiacSignCard signInfo={signInfo} isUserSign={true} onClick={mockOnClick} />);
 
-      expect(screen.getByText('Tu signo')).toBeInTheDocument();
+      // El destacado se apoya solo en el borde: no debe agregarse texto visible.
+      expect(screen.queryByText('Tu signo')).not.toBeInTheDocument();
     });
 
-    it('should not show "Tu signo" label when isUserSign is false', () => {
+    it('should expose the "tu signo" state via aria-label when isUserSign is true', () => {
+      const signInfo = createTestSignInfo();
+
+      render(<ZodiacSignCard signInfo={signInfo} isUserSign={true} onClick={mockOnClick} />);
+
+      expect(screen.getByRole('button', { name: /tu signo/i })).toBeInTheDocument();
+    });
+
+    it('should not expose the "tu signo" state via aria-label when isUserSign is false', () => {
       const signInfo = createTestSignInfo();
 
       render(<ZodiacSignCard signInfo={signInfo} isUserSign={false} onClick={mockOnClick} />);
 
-      expect(screen.queryByText('Tu signo')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /tu signo/i })).not.toBeInTheDocument();
     });
 
-    it('should not show "Tu signo" label by default', () => {
+    it('should not expose the "tu signo" state via aria-label by default', () => {
       const signInfo = createTestSignInfo();
 
       render(<ZodiacSignCard signInfo={signInfo} onClick={mockOnClick} />);
 
-      expect(screen.queryByText('Tu signo')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /tu signo/i })).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/features/horoscope/ZodiacSignCard.tsx
+++ b/frontend/src/components/features/horoscope/ZodiacSignCard.tsx
@@ -87,10 +87,10 @@ export function ZodiacSignCard({
       onKeyDown={handleKeyDown}
       tabIndex={0}
       role="button"
+      aria-label={isUserSign ? `${signInfo.nameEs} (tu signo)` : undefined}
     >
       <ZodiacSymbol symbol={signInfo.symbol} label={signInfo.nameEs} className="text-4xl" />
       <p className="mt-2 font-serif text-lg">{signInfo.nameEs}</p>
-      {isUserSign && <span className="text-muted-foreground text-xs">Tu signo</span>}
     </Card>
   );
 }


### PR DESCRIPTION
## Resumen

Cierra el hallazgo **FBK-006**: el destacado "Tu signo"/"Tu animal" agregaba un `<span>` de texto extra dentro de la card, ocupando una línea adicional que agrandaba esa tarjeta y **rompía la alineación de la fila** de la grilla.

## Cambios

- 🗑️ **Quitado el `<span>` de texto** "Tu signo" (`ZodiacSignCard.tsx`) y "Tu animal" (`ChineseAnimalCard.tsx`): la card del usuario ya no crece de alto → todas las tarjetas de la fila mantienen el mismo tamaño.
- 🎨 **Borde unificado**: el destacado del horóscopo chino pasa de `border-red-500` a `border-accent`, mismo token que el occidental (deja de desentonar con el lila).
- ♿ **Accesibilidad conservada**: se añade `aria-label` condicional en la `Card` (`"{nombre} (tu signo/animal)"`, solo en la card del usuario) para que un lector de pantalla siga percibiendo el estado sin texto visible.
- 🧪 **Tests migrados**: las aserciones que dependían del texto visible ahora verifican el **nombre accesible** del botón (`getByRole('button', { name: /tu signo|tu animal/i })`); el test de estilo del chino ahora espera `border-accent`.

## Criterios de aceptación

- ✅ La card del usuario se destaca **solo con el borde** (token `accent`), sin agregar altura → fila alineada.
- ✅ El destacado del chino usa el **mismo token** que el occidental.
- ✅ La accesibilidad del estado "tu signo/animal" se conserva vía `aria-label`.

## Validaciones (ciclo de calidad frontend)

- ✅ `format` · `lint:fix` (0 errores) · `type-check`
- ✅ `test:run` → **412 archivos / 5164 tests OK**
- ✅ `build` producción
- ✅ `validate-architecture.js`

Ref: **T-FBK-008** — `docs/BACKLOG_FEEDBACK_UX_2026_07.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)