### PR TITLE
feat(T-FBK-007): alinear los iconos del Horóscopo Chino al canon (SVG monocromático)

### DIFF
--- a/docs/BACKLOG_FEEDBACK_UX_2026_07.md
+++ b/docs/BACKLOG_FEEDBACK_UX_2026_07.md
@@ -327,7 +327,7 @@ El **recuadro de highlight que "ya existe"** es la clase condicional de borde: `
 | T-FBK-004 | Erradicar "IA" del texto user-facing (front + back + emails + migración) | Full-stack | 🟠 Alta | 3 pts | ✅ COMPLETADA |
 | T-FBK-005 | Alinear el copy/beneficios de Premium con la implementación real | Frontend | 🔴 Crítica | 2.5 pts | ✅ COMPLETADA |
 | T-FBK-006 | Resolver la incoherencia de la cuota de IA (fuente de verdad única) | Backend | 🔴 Crítica | 2 pts | ✅ COMPLETADA |
-| T-FBK-007 | Alinear los iconos del Horóscopo Chino al canon | Frontend | 🟡 Media | 2 pts |
+| T-FBK-007 | Alinear los iconos del Horóscopo Chino al canon | Frontend | 🟡 Media | 2 pts | ✅ COMPLETADA |
 | T-FBK-008 | "Tu signo/animal" sin agrandar la tarjeta (solo borde + a11y) ✅ | Frontend | 🟡 Media | 1 pt |
 | T-FBK-009 | Carta astral ilimitada para Free + gestión de límite por admin (fuente única en DB) ✅ | Backend | 🟠 Alta | 3 pts |
 
@@ -522,25 +522,25 @@ El **recuadro de highlight que "ya existe"** es la clase condicional de borde: `
 **Estimación:** 2 puntos
 **Dependencias:** ninguna (dirección de diseño ya decidida — SVG monocromático `text-primary`)
 **Cubre Hallazgo:** FBK-005
-**Estado:** 🔲 PENDIENTE
+**Estado:** ✅ COMPLETADA
 
-> **Decisión de Ariel:** la opción consistente con el diseño de la página → **iconos SVG monocromáticos** coloreados con `text-primary` (mismo tratamiento que el Horóscopo Occidental).
+> **Decisión de Ariel:** la opción consistente con el diseño de la página → **iconos SVG monocromáticos** coloreados con `text-primary` (mismo tratamiento que el Horóscopo Occidental). Estilo elegido: **línea/contorno** (`stroke=currentColor`, `fill=none`), coherente con los glifos de trazo `♈`–`♓` del zodiaco occidental.
 
 #### ✅ Tareas específicas
 
-- [ ] Conseguir/crear el set de **12 SVG monocromáticos** de marca (Rata…Cerdo), aptos para colorear con `currentColor`/`text-primary`.
-- [ ] Crear un componente `ChineseAnimalSymbol` análogo a `ZodiacSymbol` (icono monocromático + `text-primary` + `role="img"`/`aria-label`).
-- [ ] Reemplazar el render en `ChineseAnimalCard.tsx:89` y propagar a los ~5 usos restantes (`AnimalCalculator`, `ChineseHoroscopeDetail`, `ChineseHoroscopeWidget`, `ChineseCompatibility`, `AnimalHoroscopePage`).
-- [ ] Tests del nuevo componente y de las tarjetas.
+- [x] Creado el set de **12 SVG monocromáticos** de marca (Rata…Cerdo) como arte de línea inline en `ChineseAnimalSymbol`, coloreable con `currentColor`/`text-primary`. Se descartó el truco Unicode U+FE0E de `ZodiacSymbol` porque los animales chinos no tienen glifo Unicode monocromático (solo emoji pictográficos), por eso se usa SVG propio.
+- [x] Creado el componente `ChineseAnimalSymbol` análogo a `ZodiacSymbol` (icono monocromático de trazo + `text-primary` + `role="img"`/`aria-label` obligatorio + `width/height="1em"` para escalar con `text-Nxl`).
+- [x] Reemplazado el render en `ChineseAnimalCard.tsx` y propagado a los consumidores restantes: `AnimalCalculator`, `ChineseHoroscopeDetail`, `ChineseHoroscopeWidget`, `ChineseCompatibility` y `ElementSelectorModal` (se le retiró la prop redundante `animalEmoji`, ya recibía `animal`; se actualizaron sus dos llamadores). `YearSelectorModal` quedó intacto por ser código muerto (no se renderiza en ninguna parte).
+- [x] Tests del nuevo componente (8) y migración de las aserciones de emoji de las tarjetas/consumidores al símbolo accesible (`getByRole('img', { name })`).
 
 #### 🎯 Criterios de Aceptación
 
-- Los animales del Horóscopo Chino se ven monocromáticos y coherentes con el Horóscopo Occidental (paleta de marca).
-- Ciclo de calidad frontend completo pasa.
+- Los animales del Horóscopo Chino se ven monocromáticos y coherentes con el Horóscopo Occidental (paleta de marca). ✅
+- Ciclo de calidad frontend completo pasa. ✅ (format, lint, type-check, 5172 tests, build, validate-architecture)
 
 #### 📁 Archivos involucrados
 
-- Nuevo `ChineseAnimalSymbol` (+ assets si SVG), `ChineseAnimalCard.tsx` y los ~5 consumidores del emoji (+ tests).
+- Nuevo `ChineseAnimalSymbol.tsx` (+ test), `ChineseAnimalCard.tsx`, `AnimalCalculator.tsx`, `ChineseHoroscopeDetail.tsx`, `ChineseHoroscopeWidget.tsx`, `ChineseCompatibility.tsx`, `ElementSelectorModal.tsx`, `AnimalHoroscopePage.tsx`, `app/horoscopo-chino/page.tsx` (+ tests migrados).
 
 ---
 

--- a/frontend/src/app/horoscopo-chino/page.tsx
+++ b/frontend/src/app/horoscopo-chino/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { Settings } from 'lucide-react';
 import {
   ChineseAnimalSelector,
+  ChineseAnimalSymbol,
   AnimalCalculator,
   ElementSelectorModal,
 } from '@/components/features/chinese-horoscope';
@@ -43,7 +44,11 @@ export default function HoroscopoChinoPage() {
           <Card className="border-primary/50 bg-primary/5 border-2">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                <span className="text-3xl">{CHINESE_ZODIAC_INFO[myHoroscope.animal].emoji}</span>
+                <ChineseAnimalSymbol
+                  animal={myHoroscope.animal}
+                  label={CHINESE_ZODIAC_INFO[myHoroscope.animal].nameEs}
+                  className="text-3xl"
+                />
                 <span className="text-xl">
                   Tu Horóscopo:{' '}
                   {myHoroscope.fullZodiacType || CHINESE_ZODIAC_INFO[myHoroscope.animal].nameEs}{' '}

--- a/frontend/src/app/horoscopo-chino/page.tsx
+++ b/frontend/src/app/horoscopo-chino/page.tsx
@@ -106,7 +106,6 @@ export default function HoroscopoChinoPage() {
           open={isModalOpen}
           animal={selectedAnimalForModal}
           animalNameEs={CHINESE_ZODIAC_INFO[selectedAnimalForModal].nameEs}
-          animalEmoji={CHINESE_ZODIAC_INFO[selectedAnimalForModal].emoji}
           onSelectElement={handleElementSelect}
           onOpenChange={handleModalOpenChange}
         />

--- a/frontend/src/components/features/chinese-horoscope/AnimalCalculator.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalCalculator.test.tsx
@@ -183,7 +183,7 @@ describe('AnimalCalculator', () => {
       expect(screen.getByTestId('animal-calculator-result')).toBeInTheDocument();
     });
 
-    it('should display animal emoji', () => {
+    it('should display the monochrome animal symbol', () => {
       mockUseCalculateAnimal.mockReturnValue({
         data: createMockCalculateResponse(),
         isLoading: false,
@@ -192,7 +192,9 @@ describe('AnimalCalculator', () => {
 
       render(<AnimalCalculator />);
 
-      expect(screen.getByText('🐉')).toBeInTheDocument();
+      const symbol = screen.getByRole('img', { name: 'Dragón' });
+      expect(symbol).toBeInTheDocument();
+      expect(symbol).toHaveClass('text-primary');
     });
 
     it('should display full zodiac type (animal + element)', () => {
@@ -359,7 +361,7 @@ describe('AnimalCalculator', () => {
 
       render(<AnimalCalculator />);
 
-      expect(screen.getByText('🐀')).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'Rata' })).toBeInTheDocument();
       expect(screen.getByTestId('full-zodiac-type')).toHaveTextContent('Eres Rata de Metal');
       expect(screen.getByText('Año chino: 2020')).toBeInTheDocument();
       expect(screen.getByTestId('birth-element')).toHaveTextContent('Elemento: ⚪ Metal');
@@ -389,7 +391,7 @@ describe('AnimalCalculator', () => {
 
       render(<AnimalCalculator />);
 
-      expect(screen.getByText('🐍')).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'Serpiente' })).toBeInTheDocument();
       expect(screen.getByTestId('full-zodiac-type')).toHaveTextContent('Eres Serpiente de Madera');
       expect(screen.getByText('Año chino: 2025')).toBeInTheDocument();
       expect(screen.getByTestId('birth-element')).toHaveTextContent('Elemento: 🟢 Madera');

--- a/frontend/src/components/features/chinese-horoscope/AnimalCalculator.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalCalculator.tsx
@@ -11,6 +11,8 @@ import { useCalculateAnimal } from '@/hooks/api/useChineseHoroscope';
 import { CHINESE_ZODIAC_INFO, getElementIcon } from '@/lib/utils/chinese-zodiac';
 import type { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
 
+import { ChineseAnimalSymbol } from './ChineseAnimalSymbol';
+
 /**
  * Props for AnimalCalculator component
  */
@@ -100,7 +102,11 @@ export function AnimalCalculator({ onAnimalFound, className }: AnimalCalculatorP
 
       {data && (
         <div className="bg-muted rounded-lg p-4 text-center" data-testid="animal-calculator-result">
-          <span className="text-5xl">{CHINESE_ZODIAC_INFO[data.animal].emoji}</span>
+          <ChineseAnimalSymbol
+            animal={data.animal}
+            label={CHINESE_ZODIAC_INFO[data.animal].nameEs}
+            className="text-5xl"
+          />
           <p className="mt-2 font-serif text-xl" data-testid="full-zodiac-type">
             Eres {data.fullZodiacType || data.animalInfo.nameEs}
           </p>

--- a/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePage.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePage.tsx
@@ -98,7 +98,6 @@ export function AnimalHoroscopePage() {
         open={shouldShowModal}
         animal={animal}
         animalNameEs={animalInfo.nameEs}
-        animalEmoji={animalInfo.emoji}
         onSelectElement={handleElementSelect}
         onOpenChange={handleModalClose}
       />

--- a/frontend/src/components/features/chinese-horoscope/ChineseAnimalCard.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseAnimalCard.test.tsx
@@ -27,12 +27,14 @@ describe('ChineseAnimalCard', () => {
   });
 
   describe('Rendering', () => {
-    it('should render animal emoji', () => {
+    it('should render the monochrome animal symbol (colorable with text-primary)', () => {
       const animalInfo = createTestAnimalInfo();
 
       render(<ChineseAnimalCard animalInfo={animalInfo} onClick={mockOnClick} />);
 
-      expect(screen.getByText('🐀')).toBeInTheDocument();
+      const symbol = screen.getByRole('img', { name: 'Rata' });
+      expect(symbol).toBeInTheDocument();
+      expect(symbol).toHaveClass('text-primary');
     });
 
     it('should render animal name in Spanish', () => {
@@ -269,7 +271,7 @@ describe('ChineseAnimalCard', () => {
           <ChineseAnimalCard animalInfo={animalInfo} onClick={mockOnClick} />
         );
 
-        expect(screen.getByText(emoji)).toBeInTheDocument();
+        expect(screen.getByRole('img', { name: nameEs })).toBeInTheDocument();
         expect(screen.getByText(nameEs)).toBeInTheDocument();
         expect(screen.getByTestId(`chinese-animal-${animal}`)).toBeInTheDocument();
 

--- a/frontend/src/components/features/chinese-horoscope/ChineseAnimalCard.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseAnimalCard.tsx
@@ -6,6 +6,8 @@ import { cn } from '@/lib/utils';
 import { Card } from '@/components/ui/card';
 import type { ChineseZodiacAnimal, ChineseZodiacInfo } from '@/types/chinese-horoscope.types';
 
+import { ChineseAnimalSymbol } from './ChineseAnimalSymbol';
+
 /**
  * ChineseAnimalCard Component Props
  */
@@ -87,7 +89,11 @@ export function ChineseAnimalCard({
       role="button"
       aria-label={isUserAnimal ? `${animalInfo.nameEs} (tu animal)` : undefined}
     >
-      <span className="text-4xl">{animalInfo.emoji}</span>
+      <ChineseAnimalSymbol
+        animal={animalInfo.animal}
+        label={animalInfo.nameEs}
+        className="text-4xl"
+      />
       <p className="mt-2 font-serif text-lg">{animalInfo.nameEs}</p>
     </Card>
   );

--- a/frontend/src/components/features/chinese-horoscope/ChineseAnimalSymbol.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseAnimalSymbol.test.tsx
@@ -73,14 +73,18 @@ describe('ChineseAnimalSymbol', () => {
     const animals = Object.values(ChineseZodiacAnimal);
     expect(animals).toHaveLength(12);
 
+    const markups = new Set<string>();
     for (const animal of animals) {
       const { unmount } = render(<ChineseAnimalSymbol animal={animal} label={animal} />);
       const el = screen.getByRole('img', { name: animal });
-      // Each animal must contribute at least one drawn shape.
+      // Each animal must contribute at least one drawn shape...
       expect(
         el.querySelectorAll('path, circle, ellipse, line, polyline, polygon').length
       ).toBeGreaterThan(0);
+      // ...and its glyph must differ from every other animal's.
+      markups.add(el.innerHTML);
       unmount();
     }
+    expect(markups.size).toBe(animals.length);
   });
 });

--- a/frontend/src/components/features/chinese-horoscope/ChineseAnimalSymbol.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseAnimalSymbol.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
+
+import { ChineseAnimalSymbol } from './ChineseAnimalSymbol';
+
+describe('ChineseAnimalSymbol', () => {
+  it('should render an accessible image with role="img" and the label', () => {
+    render(<ChineseAnimalSymbol animal={ChineseZodiacAnimal.RAT} label="Rata" />);
+
+    expect(screen.getByRole('img', { name: 'Rata' })).toBeInTheDocument();
+  });
+
+  it('should render an inline svg', () => {
+    render(<ChineseAnimalSymbol animal={ChineseZodiacAnimal.DRAGON} label="Dragón" />);
+
+    const el = screen.getByRole('img', { name: 'Dragón' });
+    expect(el.tagName.toLowerCase()).toBe('svg');
+  });
+
+  it('should inherit color via currentColor (monochrome, colorable with text-primary)', () => {
+    render(<ChineseAnimalSymbol animal={ChineseZodiacAnimal.TIGER} label="Tigre" />);
+
+    const el = screen.getByRole('img', { name: 'Tigre' });
+    expect(el.getAttribute('stroke')).toBe('currentColor');
+    expect(el.getAttribute('fill')).toBe('none');
+  });
+
+  it('should apply the lila/primary color class', () => {
+    render(<ChineseAnimalSymbol animal={ChineseZodiacAnimal.OX} label="Buey" />);
+
+    expect(screen.getByRole('img', { name: 'Buey' })).toHaveClass('text-primary');
+  });
+
+  it('should merge additional className', () => {
+    render(
+      <ChineseAnimalSymbol
+        animal={ChineseZodiacAnimal.HORSE}
+        label="Caballo"
+        className="text-6xl"
+      />
+    );
+
+    const el = screen.getByRole('img', { name: 'Caballo' });
+    expect(el).toHaveClass('text-6xl');
+    expect(el).toHaveClass('text-primary');
+  });
+
+  it('should keep text-primary even when className passes a conflicting text color', () => {
+    render(
+      <ChineseAnimalSymbol
+        animal={ChineseZodiacAnimal.PIG}
+        label="Cerdo"
+        className="text-red-500"
+      />
+    );
+
+    const el = screen.getByRole('img', { name: 'Cerdo' });
+    expect(el).toHaveClass('text-primary');
+    expect(el).not.toHaveClass('text-red-500');
+  });
+
+  it('should scale with the font-size (1em) so text-size utilities control its size', () => {
+    render(<ChineseAnimalSymbol animal={ChineseZodiacAnimal.MONKEY} label="Mono" />);
+
+    const el = screen.getByRole('img', { name: 'Mono' });
+    expect(el.getAttribute('width')).toBe('1em');
+    expect(el.getAttribute('height')).toBe('1em');
+  });
+
+  it('should render a distinct glyph for every one of the 12 animals', () => {
+    const animals = Object.values(ChineseZodiacAnimal);
+    expect(animals).toHaveLength(12);
+
+    for (const animal of animals) {
+      const { unmount } = render(<ChineseAnimalSymbol animal={animal} label={animal} />);
+      const el = screen.getByRole('img', { name: animal });
+      // Each animal must contribute at least one drawn shape.
+      expect(
+        el.querySelectorAll('path, circle, ellipse, line, polyline, polygon').length
+      ).toBeGreaterThan(0);
+      unmount();
+    }
+  });
+});

--- a/frontend/src/components/features/chinese-horoscope/ChineseAnimalSymbol.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseAnimalSymbol.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+import { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
+
+/**
+ * ChineseAnimalSymbol Component
+ *
+ * Renderiza el animal del Horóscopo Chino como un **icono de línea
+ * monocromático** que hereda el color del texto (`currentColor`), para tomar
+ * el lila/primary del sitio igual que `ZodiacSymbol` hace con los glifos
+ * zodiacales occidentales.
+ *
+ * A diferencia del zodiaco occidental (♈–♓, símbolos Unicode con variante de
+ * presentación de texto U+FE0E), los 12 animales chinos solo existen como
+ * emoji pictográficos multicolor sin variante monocromática. Por eso el canon
+ * decidido usa arte SVG de trazo propio en lugar del truco de U+FE0E.
+ *
+ * Técnica:
+ * - `stroke="currentColor"` + `fill="none"`: monocromático y coloreable.
+ * - `width/height="1em"`: escala con `font-size`, por lo que las utilidades
+ *   `text-4xl`, `text-6xl`, etc. controlan su tamaño (misma API que `ZodiacSymbol`).
+ * - `role="img"` + `aria-label`: nombre accesible obligatorio.
+ */
+
+/** Relleno sólido para detalles puntuales (ojos, hocico) manteniendo el trazo. */
+const SOLID = { fill: 'currentColor', stroke: 'none' } as const;
+
+/**
+ * Set de 12 iconos de línea de marca (Rata…Cerdo), en viewBox 24×24.
+ * Cada glifo prioriza el rasgo más reconocible del animal (orejas, cuernos,
+ * hocico, cresta…) para leerse incluso a tamaño pequeño (badges).
+ */
+const ANIMAL_GLYPHS: Record<ChineseZodiacAnimal, React.ReactNode> = {
+  [ChineseZodiacAnimal.RAT]: (
+    <>
+      <circle cx="7" cy="7.5" r="2.8" />
+      <circle cx="17" cy="7.5" r="2.8" />
+      <circle cx="12" cy="13" r="5.5" />
+      <circle cx="9.9" cy="12" r="0.7" {...SOLID} />
+      <circle cx="14.1" cy="12" r="0.7" {...SOLID} />
+      <circle cx="12" cy="14.3" r="0.9" {...SOLID} />
+      <path d="M9.5 14.5 L4.5 14 M9.5 15.2 L4.5 16 M14.5 14.5 L19.5 14 M14.5 15.2 L19.5 16" />
+    </>
+  ),
+  [ChineseZodiacAnimal.OX]: (
+    <>
+      <path d="M7 8 C3.5 6.5 3.5 3 5.5 3 M17 8 C20.5 6.5 20.5 3 18.5 3" />
+      <path d="M7 8 C8.5 6.3 15.5 6.3 17 8" />
+      <path d="M7 8 C6 15 9 19 12 19 C15 19 18 15 17 8" />
+      <ellipse cx="12" cy="15.5" rx="3.2" ry="2.2" />
+      <circle cx="9.5" cy="11" r="0.6" {...SOLID} />
+      <circle cx="14.5" cy="11" r="0.6" {...SOLID} />
+      <circle cx="10.7" cy="15.3" r="0.5" {...SOLID} />
+      <circle cx="13.3" cy="15.3" r="0.5" {...SOLID} />
+    </>
+  ),
+  [ChineseZodiacAnimal.TIGER]: (
+    <>
+      <path d="M6.5 8 C5.5 4 8 4 8.5 6.5 M17.5 8 C18.5 4 16 4 15.5 6.5" />
+      <path d="M6 9 C5.5 15 8.5 19 12 19 C15.5 19 18.5 15 18 9 C17.5 6 14.5 6 12 6 C9.5 6 6.5 6 6 9 Z" />
+      <path d="M12 6.5 L12 9 M9.5 8 L9 10 M14.5 8 L15 10" />
+      <circle cx="9.5" cy="12" r="0.7" {...SOLID} />
+      <circle cx="14.5" cy="12" r="0.7" {...SOLID} />
+      <path d="M12 13.5 L12 15 M12 15 L10 16 M12 15 L14 16" />
+    </>
+  ),
+  [ChineseZodiacAnimal.RABBIT]: (
+    <>
+      <path d="M9.5 11 C8 5 8 2.5 9.8 2.5 C11.4 2.5 10.8 7 11 11 M14.5 11 C16 5 16 2.5 14.2 2.5 C12.6 2.5 13.2 7 13 11" />
+      <circle cx="12" cy="15.5" r="4.4" />
+      <circle cx="12" cy="15.2" r="0.9" {...SOLID} />
+      <path d="M12 16 L8.5 17 M12 16 L15.5 17" />
+    </>
+  ),
+  [ChineseZodiacAnimal.DRAGON]: (
+    <>
+      <path d="M6 11 C6 7.5 9 6 12 6 C15 6 18 7.5 18 11 C18 14.5 15.5 16.5 12 16.5 C8.5 16.5 6 14.5 6 11 Z" />
+      <path d="M8 6.5 C6 3.5 4.5 3 4 4 C3.7 4.8 4.8 6 6.8 6.8 M16 6.5 C18 3.5 19.5 3 20 4 C20.3 4.8 19.2 6 17.2 6.8" />
+      <circle cx="9.5" cy="10.5" r="1.1" {...SOLID} />
+      <circle cx="14.5" cy="10.5" r="1.1" {...SOLID} />
+      <path d="M10.5 13.5 C11 14.5 13 14.5 13.5 13.5" />
+      <path d="M6 12 L3 12.3 M18 12 L21 12.3" />
+    </>
+  ),
+  [ChineseZodiacAnimal.SNAKE]: (
+    <>
+      <path d="M17.5 6.5 C13 5.5 11 9 13.5 11 C16 13 13 16.5 9 15.5 C5.5 14.6 5 18.5 8.5 19.5" />
+      <path d="M17.5 6.5 C19.5 6 20.5 4 19.5 3" />
+      <path d="M19.3 3.3 L21 2.4 M19.3 3.3 L21 4.2" />
+      <circle cx="17.8" cy="5.4" r="0.6" {...SOLID} />
+    </>
+  ),
+  [ChineseZodiacAnimal.HORSE]: (
+    <>
+      <path d="M8 20 C7.5 14 8 12 8 12 C6.2 12 5 10 6 8 C7 6 9 5 12 5 C15 5.2 17 6.5 18 9.5 C19 12.5 18.5 16.5 17 20" />
+      <path d="M14.5 5.2 L15.5 2 L17 5.5" />
+      <path d="M8 12 C7 10 8 7.5 10.5 6.5" />
+      <circle cx="14.5" cy="9.5" r="0.8" {...SOLID} />
+    </>
+  ),
+  [ChineseZodiacAnimal.GOAT]: (
+    <>
+      <path d="M9 7 C7 4 5.5 3 4.5 4.2 C4 5 4.8 6.5 6.5 7.5 M15 7 C17 4 18.5 3 19.5 4.2 C20 5 19.2 6.5 17.5 7.5" />
+      <path d="M8 7.5 C7 13 9 18 12 18 C15 18 17 13 16 7.5 C16 6.2 14 6 12 6 C10 6 8 6.2 8 7.5" />
+      <circle cx="10.3" cy="11" r="0.6" {...SOLID} />
+      <circle cx="13.7" cy="11" r="0.6" {...SOLID} />
+      <path d="M11 18 L11 21 M13 18 L13 21 M12 18 L12 21.5" />
+    </>
+  ),
+  [ChineseZodiacAnimal.MONKEY]: (
+    <>
+      <circle cx="4.8" cy="12" r="2.4" />
+      <circle cx="19.2" cy="12" r="2.4" />
+      <circle cx="12" cy="12" r="6.5" />
+      <path d="M8.5 11 C8.5 7.5 15.5 7.5 15.5 11 C15.5 16.5 8.5 16.5 8.5 11 Z" />
+      <circle cx="10.3" cy="11" r="0.7" {...SOLID} />
+      <circle cx="13.7" cy="11" r="0.7" {...SOLID} />
+    </>
+  ),
+  [ChineseZodiacAnimal.ROOSTER]: (
+    <>
+      <path d="M8 6 C8 4.3 9 4.3 9 6 C9 4.3 10 4.3 10 6 C10 4.3 11 4.3 11 6.3" />
+      <circle cx="10" cy="9" r="3" />
+      <path d="M12.8 8.3 L16 7.5 L12.8 10 Z" {...SOLID} />
+      <path d="M11 11.3 C11 12.8 10 13.3 9.3 12.6" />
+      <path d="M9 11.5 C6 12.5 5 16 7.5 18.5 C11 21 16 18.5 16.5 14 C13.5 15 11.2 14 10.7 11.2" />
+      <path d="M16.5 14 C19 12 20 8 18 6.5 C17.5 9 16.5 10.5 15 11.5" />
+      <circle cx="9.5" cy="8.7" r="0.7" {...SOLID} />
+    </>
+  ),
+  [ChineseZodiacAnimal.DOG]: (
+    <>
+      <path d="M7.5 7 C4.5 8 4.5 13 6.5 14.5 M16.5 7 C19.5 8 19.5 13 17.5 14.5" />
+      <path d="M7.5 7 C7.5 5 16.5 5 16.5 7 C17.5 10 16.5 13.5 13.5 15.5 L13.5 17 C13.5 18 10.5 18 10.5 17 L10.5 15.5 C7.5 13.5 6.5 10 7.5 7" />
+      <circle cx="12" cy="16" r="1" {...SOLID} />
+      <circle cx="10" cy="11" r="0.7" {...SOLID} />
+      <circle cx="14" cy="11" r="0.7" {...SOLID} />
+    </>
+  ),
+  [ChineseZodiacAnimal.PIG]: (
+    <>
+      <path d="M7.5 8 L6.5 4 L10.5 6.2 M16.5 8 L17.5 4 L13.5 6.2" />
+      <circle cx="12" cy="13" r="6" />
+      <ellipse cx="12" cy="14.5" rx="3.2" ry="2.3" />
+      <path d="M11 14.2 L11 15.4 M13 14.2 L13 15.4" />
+      <circle cx="9.3" cy="11" r="0.7" {...SOLID} />
+      <circle cx="14.7" cy="11" r="0.7" {...SOLID} />
+    </>
+  ),
+};
+
+/**
+ * ChineseAnimalSymbol Component Props
+ */
+export interface ChineseAnimalSymbolProps {
+  /** Animal del zodiaco chino a representar */
+  animal: ChineseZodiacAnimal;
+  /** Etiqueta accesible (nombre del animal en español). Obligatoria por a11y. */
+  label: string;
+  /** Clases CSS adicionales (ej. tamaño del texto `text-4xl`) */
+  className?: string;
+}
+
+/**
+ * ChineseAnimalSymbol Component
+ *
+ * @example
+ * ```tsx
+ * <ChineseAnimalSymbol animal={ChineseZodiacAnimal.DRAGON} label="Dragón" className="text-4xl" />
+ * ```
+ */
+export function ChineseAnimalSymbol({ animal, label, className }: ChineseAnimalSymbolProps) {
+  return (
+    <svg
+      className={cn('inline-block align-middle', className, 'text-primary')}
+      role="img"
+      aria-label={label}
+      viewBox="0 0 24 24"
+      width="1em"
+      height="1em"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {ANIMAL_GLYPHS[animal]}
+    </svg>
+  );
+}

--- a/frontend/src/components/features/chinese-horoscope/ChineseCompatibility.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseCompatibility.tsx
@@ -5,6 +5,8 @@ import { Badge } from '@/components/ui/badge';
 import { CHINESE_ZODIAC_INFO } from '@/lib/utils/chinese-zodiac';
 import type { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
 
+import { ChineseAnimalSymbol } from './ChineseAnimalSymbol';
+
 /**
  * ChineseCompatibility Component Props
  */
@@ -45,7 +47,12 @@ export function ChineseCompatibility({ compatibility }: ChineseCompatibilityProp
             className={variantClass}
             data-testid={`compatibility-badge-${animal}`}
           >
-            {info.emoji} {info.nameEs}
+            <ChineseAnimalSymbol
+              animal={info.animal}
+              label={info.nameEs}
+              className="mr-1 text-base"
+            />
+            {info.nameEs}
           </Badge>
         );
       })}

--- a/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeDetail.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeDetail.test.tsx
@@ -62,11 +62,13 @@ describe('ChineseHoroscopeDetail', () => {
       expect(container).toBeInTheDocument();
     });
 
-    it('should display animal emoji', () => {
+    it('should display the monochrome animal symbol', () => {
       const horoscope = createMockHoroscope();
       render(<ChineseHoroscopeDetail horoscope={horoscope} />);
 
-      expect(screen.getByText('🐉')).toBeInTheDocument();
+      const symbol = screen.getByRole('img', { name: 'Dragón' });
+      expect(symbol).toBeInTheDocument();
+      expect(symbol).toHaveClass('text-primary');
     });
 
     it('should display animal name in Spanish when no element provided', () => {
@@ -281,7 +283,7 @@ describe('ChineseHoroscopeDetail', () => {
       const horoscope = createMockHoroscope({ animal: ChineseZodiacAnimal.RAT });
       render(<ChineseHoroscopeDetail horoscope={horoscope} />);
 
-      expect(screen.getByText('🐀')).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'Rata' })).toBeInTheDocument();
       expect(screen.getByText('Rata')).toBeInTheDocument();
     });
 
@@ -289,7 +291,7 @@ describe('ChineseHoroscopeDetail', () => {
       const horoscope = createMockHoroscope({ animal: ChineseZodiacAnimal.TIGER });
       render(<ChineseHoroscopeDetail horoscope={horoscope} />);
 
-      expect(screen.getByText('🐅')).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'Tigre' })).toBeInTheDocument();
       expect(screen.getByText('Tigre')).toBeInTheDocument();
     });
 
@@ -297,7 +299,7 @@ describe('ChineseHoroscopeDetail', () => {
       const horoscope = createMockHoroscope({ animal: ChineseZodiacAnimal.SNAKE });
       render(<ChineseHoroscopeDetail horoscope={horoscope} />);
 
-      expect(screen.getByText('🐍')).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'Serpiente' })).toBeInTheDocument();
       expect(screen.getByText('Serpiente')).toBeInTheDocument();
     });
   });

--- a/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeDetail.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeDetail.tsx
@@ -2,6 +2,7 @@
 
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { ChineseAnimalSymbol } from './ChineseAnimalSymbol';
 import { ChineseCompatibility } from './ChineseCompatibility';
 import { CHINESE_ZODIAC_INFO, getElementNameEs } from '@/lib/utils/chinese-zodiac';
 import type { ChineseHoroscope, ChineseElementCode } from '@/types/chinese-horoscope.types';
@@ -46,7 +47,11 @@ export function ChineseHoroscopeDetail({ horoscope, element }: ChineseHoroscopeD
     <div className="space-y-6" data-testid="chinese-horoscope-detail">
       {/* Header */}
       <div className="text-center">
-        <span className="text-6xl">{animalInfo.emoji}</span>
+        <ChineseAnimalSymbol
+          animal={animalInfo.animal}
+          label={animalInfo.nameEs}
+          className="text-6xl"
+        />
         <h1 className="mt-2 font-serif text-3xl">{displayName}</h1>
         <Badge variant="secondary" className="mt-2">
           Horóscopo {horoscope.year}

--- a/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeWidget.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeWidget.test.tsx
@@ -177,7 +177,7 @@ describe('ChineseHoroscopeWidget', () => {
       expect(screen.getByTestId('chinese-horoscope-widget')).toBeInTheDocument();
     });
 
-    it('should display animal emoji', () => {
+    it('should display the monochrome animal symbol', () => {
       mockUseMyAnimalHoroscope.mockReturnValue({
         data: createMockHoroscope(),
         isLoading: false,
@@ -186,7 +186,9 @@ describe('ChineseHoroscopeWidget', () => {
 
       render(<ChineseHoroscopeWidget />);
 
-      expect(screen.getByText('🐉')).toBeInTheDocument();
+      const symbol = screen.getByRole('img', { name: 'Dragón' });
+      expect(symbol).toBeInTheDocument();
+      expect(symbol).toHaveClass('text-primary');
     });
 
     it('should display animal name in Spanish', () => {
@@ -369,7 +371,7 @@ describe('ChineseHoroscopeWidget', () => {
 
       render(<ChineseHoroscopeWidget />);
 
-      expect(screen.getByText('🐀')).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'Rata' })).toBeInTheDocument();
       expect(screen.getByText('Rata de Agua')).toBeInTheDocument();
     });
 
@@ -387,7 +389,7 @@ describe('ChineseHoroscopeWidget', () => {
 
       render(<ChineseHoroscopeWidget />);
 
-      expect(screen.getByText('🐍')).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'Serpiente' })).toBeInTheDocument();
       expect(screen.getByText('Serpiente de Fuego')).toBeInTheDocument();
     });
 

--- a/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeWidget.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeWidget.tsx
@@ -10,6 +10,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useMyAnimalHoroscope } from '@/hooks/api/useChineseHoroscope';
 import { CHINESE_ZODIAC_INFO, getCurrentYear, getElementIcon } from '@/lib/utils/chinese-zodiac';
 
+import { ChineseAnimalSymbol } from './ChineseAnimalSymbol';
+
 /**
  * ChineseHoroscopeWidget Component
  *
@@ -73,7 +75,11 @@ export function ChineseHoroscopeWidget() {
     <Card data-testid="chinese-horoscope-widget" className="p-6">
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="text-3xl">{animalInfo.emoji}</span>
+          <ChineseAnimalSymbol
+            animal={animalInfo.animal}
+            label={animalInfo.nameEs}
+            className="text-3xl"
+          />
           <div>
             <h2 className="font-serif text-xl">{displayName}</h2>
             <div className="flex items-center gap-2">

--- a/frontend/src/components/features/chinese-horoscope/ElementSelectorModal.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ElementSelectorModal.test.tsx
@@ -19,7 +19,6 @@ describe('ElementSelectorModal', () => {
     open: true,
     animal: ChineseZodiacAnimal.MONKEY,
     animalNameEs: 'Mono',
-    animalEmoji: '🐒',
     onSelectElement: mockOnSelectElement,
     onOpenChange: mockOnOpenChange,
   };
@@ -48,10 +47,12 @@ describe('ElementSelectorModal', () => {
       expect(screen.getByTestId('element-selector-modal')).toBeInTheDocument();
     });
 
-    it('should show animal emoji in title', () => {
+    it('should show the monochrome animal symbol in title', () => {
       render(<ElementSelectorModal {...defaultProps} />);
 
-      expect(screen.getByText('🐒')).toBeInTheDocument();
+      const symbol = screen.getByRole('img', { name: 'Mono' });
+      expect(symbol).toBeInTheDocument();
+      expect(symbol).toHaveClass('text-primary');
     });
 
     it('should show animal name in title', () => {
@@ -178,7 +179,6 @@ describe('ElementSelectorModal', () => {
           {...defaultProps}
           animal={ChineseZodiacAnimal.DRAGON}
           animalNameEs="Dragón"
-          animalEmoji="🐉"
         />
       );
 
@@ -193,7 +193,6 @@ describe('ElementSelectorModal', () => {
           {...defaultProps}
           animal={ChineseZodiacAnimal.RAT}
           animalNameEs="Rata"
-          animalEmoji="🐀"
         />
       );
 

--- a/frontend/src/components/features/chinese-horoscope/ElementSelectorModal.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ElementSelectorModal.tsx
@@ -29,6 +29,8 @@ import {
   getElementIcon,
 } from '@/lib/utils/chinese-zodiac';
 
+import { ChineseAnimalSymbol } from './ChineseAnimalSymbol';
+
 export interface ElementSelectorModalProps {
   /** Controls modal visibility */
   open: boolean;
@@ -36,8 +38,6 @@ export interface ElementSelectorModalProps {
   animal: ChineseZodiacAnimal;
   /** Animal name in Spanish */
   animalNameEs: string;
-  /** Animal emoji (optional) */
-  animalEmoji?: string;
   /** Callback when element is selected */
   onSelectElement: (element: ChineseElementCode) => void;
   /** Callback when modal open state changes */
@@ -69,7 +69,6 @@ const WU_XING_ELEMENTS: ChineseElementCode[] = ['metal', 'water', 'wood', 'fire'
  *   open={isOpen}
  *   animal={ChineseZodiacAnimal.MONKEY}
  *   animalNameEs="Mono"
- *   animalEmoji="🐒"
  *   onSelectElement={(element) => handleElementSelect(element)}
  *   onOpenChange={setIsOpen}
  * />
@@ -79,7 +78,6 @@ export function ElementSelectorModal({
   open,
   animal,
   animalNameEs,
-  animalEmoji,
   onSelectElement,
   onOpenChange,
 }: ElementSelectorModalProps) {
@@ -101,7 +99,7 @@ export function ElementSelectorModal({
       <DialogContent data-testid="element-selector-modal" className="max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            {animalEmoji && <span className="text-2xl">{animalEmoji}</span>}
+            <ChineseAnimalSymbol animal={animal} label={animalNameEs} className="text-2xl" />
             <span>{animalNameEs}</span>
           </DialogTitle>
           <DialogDescription>Selecciona tu elemento Wu Xing</DialogDescription>

--- a/frontend/src/components/features/chinese-horoscope/index.ts
+++ b/frontend/src/components/features/chinese-horoscope/index.ts
@@ -13,6 +13,9 @@ export type { ChineseAnimalCardProps } from './ChineseAnimalCard';
 export { ChineseAnimalSelector } from './ChineseAnimalSelector';
 export type { ChineseAnimalSelectorProps } from './ChineseAnimalSelector';
 
+export { ChineseAnimalSymbol } from './ChineseAnimalSymbol';
+export type { ChineseAnimalSymbolProps } from './ChineseAnimalSymbol';
+
 export { ChineseCompatibility } from './ChineseCompatibility';
 export type { ChineseCompatibilityProps } from './ChineseCompatibility';
 


### PR DESCRIPTION
## 🎯 Tarea

**T-FBK-007** — Alinear los iconos del Horóscopo Chino al canon (cubre hallazgo FBK-005).

Los 12 animales del Horóscopo Chino se mostraban como **emoji multicolor** del sistema, rompiendo la coherencia visual con el Horóscopo Occidental (que usa `ZodiacSymbol`: glifos `♈`–`♓` monocromáticos coloreados con `text-primary`).

## 🎨 Decisión de diseño

- **Iconos SVG monocromáticos** coloreados con `text-primary` (decisión de Ariel).
- Estilo **línea/contorno** (`stroke=currentColor`, `fill=none`), coherente con los glifos de trazo del zodiaco occidental.
- Se **descartó** el truco Unicode U+FE0E de `ZodiacSymbol`: los animales chinos (`🐀`…`🐖`) solo existen como emoji pictográficos sin variante monocromática, por eso se autor arte de línea SVG propio.

## 🛠️ Cambios

- **Nuevo `ChineseAnimalSymbol`** — 12 iconos de línea inline (Rata…Cerdo) en viewBox 24×24; `role="img"` + `aria-label` obligatorio; `width/height="1em"` para que las utilidades `text-Nxl` controlen su tamaño (misma API que `ZodiacSymbol`).
- **Consumidores migrados:** `ChineseAnimalCard`, `AnimalCalculator`, `ChineseHoroscopeDetail`, `ChineseHoroscopeWidget`, `ChineseCompatibility` y `ElementSelectorModal`.
  - A `ElementSelectorModal` se le **retiró la prop redundante `animalEmoji`** (ya recibía `animal`); se actualizaron sus dos llamadores (`AnimalHoroscopePage`, `app/horoscopo-chino/page.tsx`).
  - `YearSelectorModal` quedó **intacto** por ser código muerto (no se renderiza en ninguna parte).
- **Tests:** 8 tests nuevos del componente + migración de las aserciones de emoji de tarjetas/consumidores al símbolo accesible (`getByRole('img', { name })`).

## ✅ Ciclo de calidad

- [x] `npm run format`
- [x] `npm run lint:fix` (0 errores; solo warnings preexistentes ajenos a esta tarea)
- [x] `npm run type-check`
- [x] `npm run test:run` — **5172 tests OK**
- [x] `npm run build` — build de producción OK
- [x] `node scripts/validate-architecture.js` — OK

## 👀 Verificación visual

Los 12 iconos se rasterizaron y revisaron en aislamiento para confirmar que se leen como los animales correctos y forman un set monocromático coherente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)