### PR TITLE
feat(T-FBK-002): unificar el sistema de upsell en tokens de marca (dorado)

### DIFF
--- a/docs/BACKLOG_FEEDBACK_UX_2026_07.md
+++ b/docs/BACKLOG_FEEDBACK_UX_2026_07.md
@@ -322,7 +322,7 @@ El **recuadro de highlight que "ya existe"** es la clase condicional de borde: `
 | ID | Tarea | Tipo | Prioridad | Estimación |
 | ---------- | --------------------------------------------------------------------------- | ---------- | ---------- | ---------- |
 | T-FBK-001 | Unificar la invitación a Premium del dashboard (Rituales → `PremiumUpsellCard`) | Frontend | 🟠 Alta | 1 pt | ✅ COMPLETADA |
-| T-FBK-002 | (Deuda) Unificar el sistema de upsell (tokens de marca + convergencia de banners) | Frontend | 🟢 Baja | 3 pts |
+| T-FBK-002 | (Deuda) Unificar el sistema de upsell (tokens de marca + convergencia de banners) ✅ | Frontend | 🟢 Baja | 3 pts |
 | T-FBK-003 | Reubicar la ficha "¿Qué es…?" debajo de la actividad en las 9 páginas | Frontend | 🟡 Media | 1.5 pts | ✅ COMPLETADA |
 | T-FBK-004 | Erradicar "IA" del texto user-facing (front + back + emails + migración) | Full-stack | 🟠 Alta | 3 pts | ✅ COMPLETADA |
 | T-FBK-005 | Alinear el copy/beneficios de Premium con la implementación real | Frontend | 🔴 Crítica | 2.5 pts | ✅ COMPLETADA |
@@ -364,22 +364,49 @@ El **recuadro de highlight que "ya existe"** es la clase condicional de borde: `
 **Estimación:** 3 puntos
 **Dependencias:** T-FBK-001
 **Cubre Hallazgo:** FBK-001 (fragmentación general)
-**Estado:** 🔲 PENDIENTE
+**Estado:** ✅ COMPLETADA
 
 #### ✅ Tareas específicas
 
-- [ ] Migrar `PremiumUpsellCard` de `purple/pink` hardcodeado a **tokens de marca** (dorado/`secondary`), coherente con el rediseño del circuito premium (T-PREM-007).
-- [ ] Inventariar los ~10 componentes de upgrade/upsell dispersos y definir una base común (o cuáles convergen hacia `PremiumUpsellCard` vs. cuáles son banners específicos legítimos).
-- [ ] Documentar la guía de uso (cuándo usar tarjeta de upsell vs. banner vs. modal).
+- [x] Migrar `PremiumUpsellCard` de `purple/pink` hardcodeado a **tokens de marca** (dorado/`secondary`), coherente con el rediseño del circuito premium (T-PREM-007).
+- [x] Inventariar los ~10 componentes de upgrade/upsell dispersos y definir una base común (o cuáles convergen hacia `PremiumUpsellCard` vs. cuáles son banners específicos legítimos).
+- [x] Documentar la guía de uso (cuándo usar tarjeta de upsell vs. banner vs. modal).
 
 #### 🎯 Criterios de Aceptación
 
-- El upsell usa un lenguaje visual único de marca (sin `purple/pink` crudo) en todos los puntos de conversión.
-- Ciclo de calidad frontend completo pasa.
+- [x] El upsell usa un lenguaje visual único de marca (sin `purple/pink` crudo) en todos los puntos de conversión.
+- [x] Ciclo de calidad frontend completo pasa.
 
 #### 📁 Archivos involucrados
 
 - `ui/premium-upsell-card.tsx` + banners de `readings/` y `conversion/` (según inventario).
+
+#### 🛠️ Notas de Implementación (6-jul-2026)
+
+**Base común vs. formas específicas.** El inventario confirmó que la unificación NO significa
+colapsar todo en un solo componente: `PremiumUpsellCard` es la **base común** (invitación inline
+discreta, ya consumida por `SacredEventsWidget` y `PersonalizedRitualsWidget` desde T-FBK-001), y
+el resto son **formas específicas legítimas** (modal, banner prominente, sección de límite, overlay
+de preview, badge) que responden a momentos de conversión distintos. Lo que se unificó fue el
+**lenguaje visual**: todos migraron al token dorado `secondary` (T-PREM-007), erradicando la clase
+cruda `purple/pink`.
+
+**Migración de tokens (raw `purple/pink` → `secondary`):**
+
+- `ui/premium-upsell-card.tsx`: fondo `from-purple-50 to-pink-50` → `border-secondary/40 bg-secondary/10`; icono `text-secondary`; CTA `<Button>` por defecto + `focus-visible:ring-secondary/50`; textos a `text-foreground`/`text-muted-foreground`.
+- `readings/PremiumBadge.tsx`: gradiente `from-purple-600 to-pink-600` → chip sólido `bg-secondary text-bg-hero` (coherente con el chip "PREMIUM" de `PremiumPage`).
+- `readings/FreeReadingUpgradeBanner.tsx`: `from-violet-600 to-purple-600` → `from-primary to-secondary` (unificado con `UpgradeBanner`); botón blanco `text-primary`.
+- `conversion/PremiumPreview.tsx`, `conversion/RegisterCTAModal.tsx`, `readings/UpgradeModal.tsx`, `readings/DailyLimitReachedModal.tsx`, `daily-reading/DailyCardLimitReached.tsx`, `readings/ReadingLimitReached.tsx`: círculos de icono → `bg-secondary/15`, iconos/acentos → `text-secondary`, cajas de beneficios → `border-secondary/40 bg-secondary/10`, CTAs → `<Button>` por defecto con foco dorado (se eliminaron los gradientes `from-purple-600 to-*`).
+
+**Ya en tokens (referencia, sin cambios):** `LimitReachedModal`, `PremiumUpgradePrompt`, `UpgradeBanner`, `AnonymousLimitReached`, `SubscriptionTab`, `PremiumBenefitsSection`.
+
+**Fuera de alcance (color de dominio, no upsell):** encyclopedia, numerología, birth-chart (aspectos/elementos), admin (badges de plan), notifications, holistic-services, pendulum. `UsageLimitBanner` usa ámbar/naranja (no `purple/pink`) — queda como deuda menor futura.
+
+**Guía de uso:** nueva en `frontend/docs/UPSELL_SYSTEM.md` (tabla de tokens + cuándo usar cada forma + árbol de decisión + checklist).
+
+**TDD:** se actualizaron los tests que fijaban las clases crudas (`premium-upsell-card`, `PremiumBadge`, `ReadingLimitReached`, `RegisterCTAModal`) para verificar los tokens de marca y la **ausencia** de `purple/pink`.
+
+**Ciclo de calidad frontend completo:** format ✅, lint (0 errores) ✅, type-check ✅, 5173 tests ✅, build ✅, validate-architecture ✅.
 
 ---
 

--- a/frontend/docs/UPSELL_SYSTEM.md
+++ b/frontend/docs/UPSELL_SYSTEM.md
@@ -1,0 +1,125 @@
+# Sistema de Upsell — Guía de Uso
+
+> 🎯 **Propósito:** unificar el lenguaje visual de todos los puntos de conversión a
+> Premium bajo los **tokens de marca dorados** (`secondary`, `#d69e2e`), coherente con el
+> rediseño del circuito premium (T-PREM-007). Documento creado en **T-FBK-002**.
+> 📅 **Última actualización:** 6-jul-2026
+
+---
+
+## 🎨 Lenguaje visual único (tokens de marca)
+
+**Regla dura:** ningún punto de conversión usa clases crudas `purple/pink/violet/fuchsia`.
+El circuito premium quedó en **dorado (`secondary`)** tras T-PREM-007.
+
+| Elemento | Token / clase canónica |
+|----------|------------------------|
+| Icono de acento premium | `text-secondary` |
+| Círculo de icono (modales) | `bg-secondary/15` + icono `text-secondary` |
+| Caja de beneficios / contenedor | `border border-secondary/40 bg-secondary/10` |
+| CTA principal | `<Button>` por defecto (token `primary`) + `focus-visible:ring-secondary/50` |
+| Banner prominente (fondo de color) | `bg-gradient-to-r from-primary to-secondary` + botón blanco `text-primary` |
+| Badge "Premium" | `bg-secondary text-bg-hero` |
+
+> ⚠️ El texto lavanda de marca (`text-primary`, `#805ad5`) y el ámbar (`amber-*`) siguen
+> siendo válidos como acentos secundarios; lo prohibido es la clase **cruda** `purple/pink`.
+
+---
+
+## 🧩 Cuándo usar cada forma
+
+El sistema tiene **una base común** (`PremiumUpsellCard`) y un conjunto de **formas
+específicas legítimas** (modal, banner, sección, badge, overlay). No todo converge a la
+tarjeta: cada forma responde a un momento de conversión distinto.
+
+### 1. Tarjeta de upsell — `ui/premium-upsell-card.tsx` ⭐ base común
+
+Bloque **inline y discreto** (icono + título + descripción + CTA `Link`). Es la invitación
+"suave" que convive con otro contenido sin interrumpir.
+
+- **Úsala cuando:** quieras invitar a Premium **dentro de un widget o sección** ya poblada
+  (dashboard, listados) sin robar protagonismo.
+- **Consumidores actuales:** `SacredEventsWidget`, `PersonalizedRitualsWidget`.
+- **No la uses para:** bloqueos duros (límite alcanzado) ni CTAs de página completa.
+
+```tsx
+<PremiumUpsellCard
+  title="Rituales personalizados para tu momento"
+  description="Con Premium, analizamos tus lecturas para sugerirte rituales…"
+  href={ROUTES.PREMIUM}
+  ctaLabel={CTA_PREMIUM.UPSELL_SOFT}
+/>
+```
+
+### 2. Banner prominente — `readings/UpgradeBanner.tsx`, `readings/FreeReadingUpgradeBanner.tsx`
+
+Bloque **full-width con fondo de color** (`from-primary to-secondary`, texto blanco). Más
+peso visual que la tarjeta; cierra una experiencia invitando a subir de plan.
+
+- **Úsalo cuando:** el usuario **terminó** una acción (una lectura) y es buen momento para
+  una invitación destacada, pero **no bloqueante**.
+- `UpgradeBanner` dispara el flujo de pago (MercadoPago); `FreeReadingUpgradeBanner` navega a
+  `/premium`.
+
+### 3. Modal / diálogo — `conversion/LimitReachedModal.tsx`, `readings/UpgradeModal.tsx`, `readings/DailyLimitReachedModal.tsx`, `conversion/RegisterCTAModal.tsx`
+
+Overlay **interruptivo**. Detiene el flujo para comunicar algo puntual (límite alcanzado,
+detalle de beneficios + precio, invitación a registrarse).
+
+- **Úsalo cuando:** necesitás **cortar el flujo** ante un evento (se agotó el cupo, el usuario
+  intentó una acción premium). Requiere una decisión explícita (upgrade / cerrar).
+- `DailyLimitReachedModal` es informativo para usuarios **Premium** que llegaron a su tope del
+  día (no es upsell: comparte solo el lenguaje visual).
+
+### 4. Sección de límite alcanzado — `readings/ReadingLimitReached.tsx`, `daily-reading/DailyCardLimitReached.tsx`, `daily-reading/AnonymousLimitReached.tsx`
+
+`Card` **grande, in-place** que **reemplaza** el contenido cuando el usuario agotó su cupo
+gratuito. Lista beneficios + CTA de upgrade (y acciones secundarias).
+
+- **Úsala cuando:** el usuario Free/anónimo **no puede continuar** y hay que ocupar el espacio
+  del contenido bloqueado con la propuesta de valor.
+- Variante anónima → invita a **registrarse**; variante free → invita a **Premium**.
+
+### 5. Overlay de vista previa — `conversion/PremiumPreview.tsx`
+
+Envuelve contenido premium con **blur + overlay** y CTA de desbloqueo.
+
+- **Úsalo cuando:** quieras **mostrar que existe** contenido premium (teaser) sin revelarlo.
+
+### 6. Badge — `readings/PremiumBadge.tsx`
+
+Marcador **inline** (`bg-secondary text-bg-hero`) para señalar features gated. No es un CTA.
+
+- **Úsalo cuando:** necesites etiquetar un ítem/menú como "Premium".
+
+### 7. Prompt polimórfico — `conversion/PremiumUpgradePrompt.tsx`
+
+Componente con variantes `modal` / `inline` / `banner`; ya token-based. Útil cuando querés un
+único punto de entrada configurable.
+
+---
+
+## 🗺️ Árbol de decisión rápido
+
+```
+¿El usuario puede seguir usando la app ahora mismo?
+├── Sí, es una invitación no bloqueante
+│   ├── ¿Dentro de un widget/sección poblada?  → PremiumUpsellCard (base común)
+│   ├── ¿Al cerrar una experiencia (post-lectura)? → UpgradeBanner / FreeReadingUpgradeBanner
+│   └── ¿Solo marcar un feature como premium?   → PremiumBadge
+└── No, se topó con un límite o feature gated
+    ├── ¿Hay que cortar el flujo con una decisión? → Modal (LimitReached / Upgrade / RegisterCTA)
+    ├── ¿Hay que reemplazar el contenido bloqueado? → Sección LimitReached
+    └── ¿Mostrar un teaser difuminado?              → PremiumPreview
+```
+
+---
+
+## ✅ Checklist al agregar un punto de conversión
+
+- [ ] ¿Existe ya una forma que encaje? Reutilizá `PremiumUpsellCard` o el modal/banner existente.
+- [ ] Solo tokens de marca: **cero** `purple/pink/violet/fuchsia` crudo.
+- [ ] Copy del CTA desde `lib/constants/cta-copy.ts` (`CTA_PREMIUM.*`).
+- [ ] Beneficios desde la fuente única `lib/constants/premium-benefits.ts` (ver T-FBK-005).
+- [ ] Rutas desde `ROUTES` / endpoints centralizados.
+- [ ] Texto user-facing en español y sin mención a "IA" (T-FBK-004).

--- a/frontend/src/app/horoscopo/[sign]/page.tsx
+++ b/frontend/src/app/horoscopo/[sign]/page.tsx
@@ -45,7 +45,7 @@ export default function HoroscopeSignPage() {
         Todos los signos
       </Button>
 
-      <div className="mb-8 overflow-x-auto pb-2">
+      <div className="mb-8 overflow-x-auto px-1 py-2">
         <ZodiacSignSelector
           selectedSign={sign}
           userSign={userSign}

--- a/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePage.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePage.tsx
@@ -82,7 +82,7 @@ export function AnimalHoroscopePage() {
         Todos los animales
       </Button>
 
-      <div className="mb-8 overflow-x-auto pb-2">
+      <div className="mb-8 overflow-x-auto px-1 py-2">
         <ChineseAnimalSelector
           selectedAnimal={animal}
           userAnimal={userAnimal}

--- a/frontend/src/components/features/chinese-horoscope/ChineseAnimalCard.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseAnimalCard.test.tsx
@@ -37,6 +37,18 @@ describe('ChineseAnimalCard', () => {
       expect(symbol).toHaveClass('text-primary');
     });
 
+    it('should center the animal symbol like the western zodiac card', () => {
+      const animalInfo = createTestAnimalInfo();
+
+      render(<ChineseAnimalCard animalInfo={animalInfo} onClick={mockOnClick} />);
+
+      // El <svg> es display:block por el preflight de Tailwind, así que `text-center`
+      // no lo centra: se fuerza `block mx-auto` para alinearlo igual que el occidental.
+      const symbol = screen.getByRole('img', { name: 'Rata' });
+      expect(symbol).toHaveClass('block');
+      expect(symbol).toHaveClass('mx-auto');
+    });
+
     it('should render animal name in Spanish', () => {
       const animalInfo = createTestAnimalInfo({ nameEs: 'Dragón' });
 

--- a/frontend/src/components/features/chinese-horoscope/ChineseAnimalCard.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseAnimalCard.tsx
@@ -92,7 +92,7 @@ export function ChineseAnimalCard({
       <ChineseAnimalSymbol
         animal={animalInfo.animal}
         label={animalInfo.nameEs}
-        className="text-4xl"
+        className="mx-auto block text-4xl"
       />
       <p className="mt-2 font-serif text-lg">{animalInfo.nameEs}</p>
     </Card>

--- a/frontend/src/components/features/conversion/PremiumPreview.tsx
+++ b/frontend/src/components/features/conversion/PremiumPreview.tsx
@@ -63,8 +63,8 @@ export default function PremiumPreview({
       {/* Overlay with CTA */}
       <div className="from-background/95 via-background/80 to-background/60 absolute inset-0 flex items-center justify-center bg-gradient-to-t backdrop-blur-sm">
         <div className="flex max-w-sm flex-col items-center gap-4 p-6 text-center">
-          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-purple-500/20 to-pink-500/20">
-            <Lock className="text-accent h-8 w-8" />
+          <div className="bg-secondary/15 flex h-16 w-16 items-center justify-center rounded-full">
+            <Lock className="text-secondary h-8 w-8" />
           </div>
           <div className="space-y-2">
             <h3 className="text-foreground font-serif text-lg font-semibold">{message}</h3>
@@ -75,7 +75,7 @@ export default function PremiumPreview({
           <Button
             onClick={handleUpgrade}
             disabled={isPending}
-            className="bg-gradient-to-r from-purple-600 to-pink-600 text-white hover:from-purple-700 hover:to-pink-700"
+            className="focus-visible:ring-secondary/50"
             size="lg"
           >
             {isPending ? 'Cargando...' : CTA_PREMIUM.PURCHASE}

--- a/frontend/src/components/features/conversion/RegisterCTAModal.test.tsx
+++ b/frontend/src/components/features/conversion/RegisterCTAModal.test.tsx
@@ -54,8 +54,9 @@ describe('RegisterCTAModal', () => {
     const registerButton = screen.getByRole('button', { name: /registrarme gratis/i });
     const closeButton = screen.getByRole('button', { name: /no, gracias/i });
 
-    // Primary button should have gradient classes
-    expect(registerButton).toHaveClass('bg-gradient-to-r');
+    // Primary button uses the default brand token variant (no raw purple/pink) — T-FBK-002.
+    expect(registerButton).toHaveClass('bg-primary');
+    expect(registerButton.className).not.toMatch(/purple|pink/);
     // Secondary button should have outline variant (has border class)
     expect(closeButton.className).toContain('border');
   });

--- a/frontend/src/components/features/conversion/RegisterCTAModal.tsx
+++ b/frontend/src/components/features/conversion/RegisterCTAModal.tsx
@@ -98,11 +98,7 @@ export default function RegisterCTAModal({ open, onClose, onRegister }: Register
 
         {/* CTA Buttons */}
         <DialogFooter className="flex-col gap-3 sm:flex-col">
-          <Button
-            onClick={onRegister}
-            className="w-full bg-gradient-to-r from-purple-600 to-pink-600 text-white hover:from-purple-700 hover:to-pink-700"
-            size="lg"
-          >
+          <Button onClick={onRegister} className="focus-visible:ring-secondary/50 w-full" size="lg">
             Registrarme Gratis
           </Button>
           <Button variant="outline" onClick={onClose} className="w-full" size="lg">

--- a/frontend/src/components/features/daily-reading/DailyCardLimitReached.tsx
+++ b/frontend/src/components/features/daily-reading/DailyCardLimitReached.tsx
@@ -107,9 +107,9 @@ export function DailyCardLimitReached() {
         ) : (
           <>
             {/* FREE: Premium Benefits CTA */}
-            <div className="via-primary/10 border-primary/30 rounded-lg border bg-gradient-to-br from-purple-500/10 to-amber-500/10 p-4">
+            <div className="border-secondary/40 bg-secondary/10 rounded-lg border p-4">
               <div className="mb-3 flex items-center gap-2">
-                <Crown className="h-5 w-5 text-amber-500" />
+                <Crown className="text-secondary h-5 w-5" />
                 <p className="text-lg font-semibold">Actualiza a Premium</p>
               </div>
               <ul className="space-y-2 text-sm">
@@ -153,11 +153,9 @@ export function DailyCardLimitReached() {
                   } as const;
                   const IconComponent = iconMap[benefit.icon as keyof typeof iconMap];
                   const colorClass =
-                    benefit.icon === 'CalendarHeart'
-                      ? 'text-purple-500'
-                      : benefit.icon === 'Wand2'
-                        ? 'text-amber-500'
-                        : 'text-primary';
+                    benefit.icon === 'CalendarHeart' || benefit.icon === 'Wand2'
+                      ? 'text-secondary'
+                      : 'text-primary';
                   return (
                     <li key={index} className="flex items-start gap-2">
                       <IconComponent className={`mt-0.5 h-4 w-4 shrink-0 ${colorClass}`} />
@@ -168,7 +166,7 @@ export function DailyCardLimitReached() {
                   );
                 })}
                 <li className="flex items-start gap-2">
-                  <CalendarHeart className="mt-0.5 h-4 w-4 shrink-0 text-purple-500" />
+                  <CalendarHeart className="text-secondary mt-0.5 h-4 w-4 shrink-0" />
                   <span>
                     <strong>Calendario sagrado completo</strong> con notificaciones
                   </span>
@@ -230,7 +228,7 @@ export function DailyCardLimitReached() {
             {/* FREE: Upgrade CTA + secondary actions */}
             <Button
               onClick={handleUpgradePremium}
-              className="w-full bg-gradient-to-r from-purple-600 to-amber-600 hover:from-purple-700 hover:to-amber-700"
+              className="focus-visible:ring-secondary/50 w-full"
               size="lg"
             >
               <Crown className="h-4 w-4" />

--- a/frontend/src/components/features/readings/DailyLimitReachedModal.tsx
+++ b/frontend/src/components/features/readings/DailyLimitReachedModal.tsx
@@ -94,8 +94,8 @@ export default function DailyLimitReachedModal({
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-purple-100">
-            <Icon className="h-8 w-8 text-purple-600" aria-hidden="true" />
+          <div className="bg-secondary/15 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+            <Icon className="text-secondary h-8 w-8" aria-hidden="true" />
           </div>
           <DialogTitle className="text-center font-serif text-2xl">{content.title}</DialogTitle>
           <DialogDescription className="text-center text-base">
@@ -104,9 +104,9 @@ export default function DailyLimitReachedModal({
         </DialogHeader>
 
         {/* Stats Display */}
-        <div className="my-6 rounded-lg border border-purple-200 bg-gradient-to-br from-purple-50 to-pink-50 p-6 text-center">
+        <div className="border-secondary/40 bg-secondary/10 my-6 rounded-lg border p-6 text-center">
           <div className="flex items-baseline justify-center gap-2">
-            <span className="text-4xl font-bold text-purple-900">{usedReadings}</span>
+            <span className="text-secondary text-4xl font-bold">{usedReadings}</span>
             <span className="text-muted-foreground">/ {totalReadings}</span>
           </div>
           <p className="text-muted-foreground mt-2 text-sm">

--- a/frontend/src/components/features/readings/DailyLimitReachedModal.tsx
+++ b/frontend/src/components/features/readings/DailyLimitReachedModal.tsx
@@ -106,7 +106,7 @@ export default function DailyLimitReachedModal({
         {/* Stats Display */}
         <div className="border-secondary/40 bg-secondary/10 my-6 rounded-lg border p-6 text-center">
           <div className="flex items-baseline justify-center gap-2">
-            <span className="text-secondary text-4xl font-bold">{usedReadings}</span>
+            <span className="text-foreground text-4xl font-bold">{usedReadings}</span>
             <span className="text-muted-foreground">/ {totalReadings}</span>
           </div>
           <p className="text-muted-foreground mt-2 text-sm">

--- a/frontend/src/components/features/readings/FreeReadingUpgradeBanner.tsx
+++ b/frontend/src/components/features/readings/FreeReadingUpgradeBanner.tsx
@@ -27,7 +27,7 @@ export default function FreeReadingUpgradeBanner() {
   return (
     <div
       data-testid="free-reading-upgrade-banner"
-      className="mt-6 rounded-lg bg-gradient-to-r from-violet-600 to-purple-600 p-6 text-white shadow-lg"
+      className="from-primary to-secondary mt-6 rounded-lg bg-gradient-to-r p-6 text-white shadow-lg"
     >
       <div className="flex flex-col items-center gap-4 text-center sm:flex-row sm:items-start sm:text-left">
         <div className="flex-shrink-0">
@@ -45,7 +45,7 @@ export default function FreeReadingUpgradeBanner() {
         <Button
           onClick={handleUpgradeClick}
           variant="secondary"
-          className="flex-shrink-0 bg-white text-purple-700 hover:bg-white/90"
+          className="text-primary flex-shrink-0 bg-white hover:bg-white/90"
         >
           Conocer Premium
         </Button>

--- a/frontend/src/components/features/readings/PremiumBadge.test.tsx
+++ b/frontend/src/components/features/readings/PremiumBadge.test.tsx
@@ -87,9 +87,9 @@ describe('PremiumBadge', () => {
       const { container } = render(<PremiumBadge />);
 
       const badge = container.querySelector('[data-slot="badge"]');
-      expect(badge).toHaveClass('bg-gradient-to-r');
-      expect(badge).toHaveClass('from-purple-600');
-      expect(badge).toHaveClass('to-pink-600');
+      // Circuito premium en dorado (secondary) tras T-PREM-007/T-FBK-002.
+      expect(badge).toHaveClass('bg-secondary');
+      expect(badge?.className).not.toMatch(/purple|pink/);
     });
 
     it('should apply custom className', () => {

--- a/frontend/src/components/features/readings/PremiumBadge.tsx
+++ b/frontend/src/components/features/readings/PremiumBadge.tsx
@@ -78,9 +78,9 @@ export function PremiumBadge({
       title={tooltip}
       className={cn(
         'inline-flex items-center gap-1.5',
-        'bg-gradient-to-r from-purple-600 to-pink-600',
-        'border-none text-white',
-        'hover:from-purple-700 hover:to-pink-700',
+        'bg-secondary text-bg-hero',
+        'border-none',
+        'hover:bg-secondary/90',
         'transition-all duration-200',
         'font-semibold',
         SIZE_CLASSES[size],

--- a/frontend/src/components/features/readings/ReadingLimitReached.test.tsx
+++ b/frontend/src/components/features/readings/ReadingLimitReached.test.tsx
@@ -123,11 +123,13 @@ describe('ReadingLimitReached', () => {
     expect(alert).toBeInTheDocument();
   });
 
-  it('should have primary button styling on upgrade button', () => {
+  it('should have brand-token button styling on upgrade button (no raw purple/pink)', () => {
     render(<ReadingLimitReached />);
 
     const upgradeButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
-    expect(upgradeButton).toHaveClass('bg-gradient-to-r', 'from-purple-600', 'to-amber-600');
+    // Tras T-FBK-002 el CTA usa el Button por defecto (token) con foco dorado.
+    expect(upgradeButton).toHaveClass('focus-visible:ring-secondary/50');
+    expect(upgradeButton.className).not.toMatch(/purple|pink/);
   });
 
   it('should have outline styling on history and daily card buttons', () => {

--- a/frontend/src/components/features/readings/ReadingLimitReached.test.tsx
+++ b/frontend/src/components/features/readings/ReadingLimitReached.test.tsx
@@ -127,7 +127,8 @@ describe('ReadingLimitReached', () => {
     render(<ReadingLimitReached />);
 
     const upgradeButton = screen.getByRole('button', { name: /Mejorar a Premium/i });
-    // Tras T-FBK-002 el CTA usa el Button por defecto (token) con foco dorado.
+    // Tras T-FBK-002 el CTA usa el Button por defecto (token `primary`) con foco dorado.
+    expect(upgradeButton).toHaveClass('bg-primary');
     expect(upgradeButton).toHaveClass('focus-visible:ring-secondary/50');
     expect(upgradeButton.className).not.toMatch(/purple|pink/);
   });

--- a/frontend/src/components/features/readings/ReadingLimitReached.tsx
+++ b/frontend/src/components/features/readings/ReadingLimitReached.tsx
@@ -70,9 +70,9 @@ export function ReadingLimitReached() {
 
       <CardContent className="space-y-4">
         {/* Premium Benefits CTA */}
-        <div className="via-primary/10 border-primary/30 rounded-lg border bg-gradient-to-br from-purple-500/10 to-amber-500/10 p-4">
+        <div className="border-secondary/40 bg-secondary/10 rounded-lg border p-4">
           <div className="mb-3 flex items-center gap-2">
-            <Crown className="h-5 w-5 text-amber-500" />
+            <Crown className="text-secondary h-5 w-5" />
             <p className="text-lg font-semibold">Actualiza a Premium</p>
           </div>
           <ul className="space-y-2 text-sm">
@@ -130,7 +130,7 @@ export function ReadingLimitReached() {
       <CardFooter className="flex flex-col gap-3">
         <Button
           onClick={handleUpgradePremium}
-          className="w-full bg-gradient-to-r from-purple-600 to-amber-600 hover:from-purple-700 hover:to-amber-700"
+          className="focus-visible:ring-secondary/50 w-full"
           size="lg"
         >
           <Crown className="h-4 w-4" />

--- a/frontend/src/components/features/readings/UpgradeModal.tsx
+++ b/frontend/src/components/features/readings/UpgradeModal.tsx
@@ -128,7 +128,7 @@ export default function UpgradeModal({ open, onClose, reason }: UpgradeModalProp
                   </div>
                   <div className="flex-1">
                     <div className="flex items-center gap-2">
-                      <Icon className="h-4 w-4 text-purple-600" aria-hidden="true" />
+                      <Icon className="text-secondary h-4 w-4" aria-hidden="true" />
                       <p className="text-text-primary font-semibold">{benefit.text}</p>
                     </div>
                     <p className="text-muted-foreground mt-1 text-sm">{benefit.description}</p>
@@ -140,9 +140,9 @@ export default function UpgradeModal({ open, onClose, reason }: UpgradeModalProp
         </div>
 
         {/* Pricing */}
-        <div className="rounded-lg border border-purple-200 bg-gradient-to-br from-purple-50 to-pink-50 p-6 text-center">
+        <div className="border-secondary/40 bg-secondary/10 rounded-lg border p-6 text-center">
           <div className="flex items-baseline justify-center gap-1">
-            <span className="text-4xl font-bold text-purple-900">
+            <span className="text-secondary text-4xl font-bold">
               {premiumPrice != null ? formatPriceArs(premiumPrice) : '---'}
             </span>
             <span className="text-muted-foreground">/ mes</span>
@@ -158,7 +158,7 @@ export default function UpgradeModal({ open, onClose, reason }: UpgradeModalProp
             onClick={handleUpgradeClick}
             disabled={isPending}
             size="lg"
-            className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
+            className="focus-visible:ring-secondary/50 w-full"
           >
             <Sparkles className="mr-2 h-5 w-5" aria-hidden="true" />
             {isPending

--- a/frontend/src/components/features/readings/UpgradeModal.tsx
+++ b/frontend/src/components/features/readings/UpgradeModal.tsx
@@ -142,7 +142,7 @@ export default function UpgradeModal({ open, onClose, reason }: UpgradeModalProp
         {/* Pricing */}
         <div className="border-secondary/40 bg-secondary/10 rounded-lg border p-6 text-center">
           <div className="flex items-baseline justify-center gap-1">
-            <span className="text-secondary text-4xl font-bold">
+            <span className="text-foreground text-4xl font-bold">
               {premiumPrice != null ? formatPriceArs(premiumPrice) : '---'}
             </span>
             <span className="text-muted-foreground">/ mes</span>

--- a/frontend/src/components/ui/premium-upsell-card.test.tsx
+++ b/frontend/src/components/ui/premium-upsell-card.test.tsx
@@ -66,4 +66,21 @@ describe('PremiumUpsellCard', () => {
     );
     expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
   });
+
+  it('should use brand tokens (gold/secondary) and no raw purple/pink colors', () => {
+    const { container } = render(
+      <PremiumUpsellCard
+        title="Título"
+        description="Descripción"
+        href="/premium"
+        ctaLabel="CTA"
+        data-testid="premium-upsell"
+      />
+    );
+    // El circuito premium quedó en dorado (secondary) tras T-PREM-007:
+    // el upsell no debe usar clases crudas purple/pink en ningún elemento.
+    expect(container.innerHTML).not.toMatch(/purple|pink|fuchsia|violet/);
+    // El contenedor usa el token de marca dorado.
+    expect(screen.getByTestId('premium-upsell').className).toMatch(/secondary/);
+  });
 });

--- a/frontend/src/components/ui/premium-upsell-card.tsx
+++ b/frontend/src/components/ui/premium-upsell-card.tsx
@@ -18,7 +18,9 @@ interface PremiumUpsellCardProps {
 /**
  * PremiumUpsellCard — CTA de conversión a plan Premium.
  *
- * Componente dedicado para banners de upsell con gradiente intencional.
+ * Base común del sistema de upsell. Usa los tokens de marca dorados
+ * (`secondary`) alineados con el rediseño del circuito premium (T-PREM-007):
+ * borde y fondo `secondary`, icono `text-secondary` y CTA con foco dorado.
  * NO usar <Alert> aquí ya que es una CTA de conversión, no una notificación.
  */
 export function PremiumUpsellCard({
@@ -34,19 +36,15 @@ export function PremiumUpsellCard({
     <div
       data-testid={testId}
       className={cn(
-        'flex items-start gap-3 rounded-lg bg-gradient-to-r from-purple-50 to-pink-50 p-3',
+        'border-secondary/40 bg-secondary/10 flex items-start gap-3 rounded-lg border p-3',
         className
       )}
     >
-      {icon ?? <Zap className="mt-0.5 h-5 w-5 flex-shrink-0 text-purple-600" aria-hidden="true" />}
+      {icon ?? <Zap className="text-secondary mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />}
       <div className="min-w-0 flex-1">
-        <p className="mb-1 text-sm font-medium text-gray-900">{title}</p>
-        <p className="mb-2 text-xs text-gray-600">{description}</p>
-        <Button
-          asChild
-          size="sm"
-          className="bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
-        >
+        <p className="text-foreground mb-1 text-sm font-medium">{title}</p>
+        <p className="text-muted-foreground mb-2 text-xs">{description}</p>
+        <Button asChild size="sm" className="focus-visible:ring-secondary/50">
           <Link href={href}>{ctaLabel}</Link>
         </Button>
       </div>


### PR DESCRIPTION
## 🎯 T-FBK-002 — Unificar el Sistema de Upsell (Deuda de Diseño)

Unifica el **lenguaje visual** de todos los puntos de conversión a Premium bajo el token de marca **dorado** (`secondary`, `#d69e2e`), coherente con el rediseño del circuito premium (T-PREM-007). Erradica las clases crudas `purple/pink` de la superficie de upsell.

### 🧩 Base común vs. formas específicas

El inventario (~17 componentes) confirmó que unificar **no** significa colapsar todo en un componente:

- **Base común:** `PremiumUpsellCard` — invitación inline discreta (ya consumida por los widgets del dashboard desde T-FBK-001).
- **Formas específicas legítimas** (se conservan, pero adoptan el lenguaje dorado): modal, banner prominente, sección de límite, overlay de preview, badge.

### 🎨 Cambios (raw `purple/pink` → `secondary`)

- `ui/premium-upsell-card.tsx`: fondo/borde/icono/CTA a tokens dorados + textos a `text-foreground`/`text-muted-foreground`.
- `readings/PremiumBadge.tsx`: chip sólido `bg-secondary text-bg-hero`.
- `readings/FreeReadingUpgradeBanner.tsx`: `from-primary to-secondary` (unificado con `UpgradeBanner`).
- `conversion/PremiumPreview.tsx`, `conversion/RegisterCTAModal.tsx`, `readings/UpgradeModal.tsx`, `readings/DailyLimitReachedModal.tsx`, `daily-reading/DailyCardLimitReached.tsx`, `readings/ReadingLimitReached.tsx`: círculos de icono `bg-secondary/15`, acentos `text-secondary`, cajas `border-secondary/40 bg-secondary/10`, CTAs `<Button>` por defecto con foco dorado.

### 📄 Documentación

Nueva guía **`frontend/docs/UPSELL_SYSTEM.md`**: tabla de tokens, cuándo usar cada forma (tarjeta / banner / modal / sección / overlay / badge), árbol de decisión y checklist.

### ✅ Criterios de aceptación

- [x] Lenguaje visual único de marca (sin `purple/pink` crudo) en todos los puntos de conversión.
- [x] Ciclo de calidad frontend completo pasa.

### 🧪 Calidad

`format` ✅ · `lint` (0 errores) ✅ · `type-check` ✅ · **5173 tests** ✅ · `build` ✅ · `validate-architecture` ✅

Tests actualizados (TDD) para verificar tokens de marca y **ausencia** de `purple/pink`.

### 📌 Fuera de alcance

Color de dominio no-upsell (encyclopedia, numerología, birth-chart, admin, etc.). `UsageLimitBanner` usa ámbar/naranja (no `purple/pink`) → deuda menor futura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)