### PR TITLE
feat(auth): página /restablecer-password para recuperar la cuenta (T-PROD-015 frontend)

### DIFF
--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -1065,11 +1065,23 @@ Es decir: hoy los únicos emails que la app manda de verdad son los de cuota, la
 - [x] **Marca:** las plantillas `welcome` y `password-reset` decían *"Tarot App"* → **Auguria**; el CTA del mail de bienvenida apuntaba a `href='#'` → ahora a `FRONTEND_URL`.
 - [x] Tests: reset envía el mail con el link correcto; el token **no** aparece en la respuesta ni en los logs; el registro sobrevive al fallo del email; la activación Premium notifica y sobrevive al fallo del email.
 
-#### ✅ Tareas específicas — Frontend
+#### ✅ Tareas específicas — Frontend (✅ COMPLETADO)
 
-- [ ] Página `/restablecer-password` que toma el `token` de la query, pide la nueva contraseña (con confirmación y las reglas de fortaleza del backend) y llama a `POST /auth/reset-password`.
-- [ ] Manejo de token inválido/expirado/ya usado (el backend responde 400) con opción de volver a pedir el mail.
-- [ ] Al éxito: redirigir a `/login` con feedback.
+- [x] Página `/restablecer-password` (client component con `useSearchParams` dentro de `Suspense`, siguiendo el patrón de `ritual/lectura`): toma el `token` de la query y se lo pasa a `ResetPasswordForm`.
+- [x] `ResetPasswordForm`: nueva contraseña + confirmación, con `resetPasswordSchema` que **replica las reglas del backend** (`IsStrongPassword`: mínimo 8 caracteres, una mayúscula y un número; máx. 128).
+- [x] Token inválido/expirado/ya usado (400 del backend) → mensaje claro + enlace a `/recuperar-password` para pedir uno nuevo. Enlace **sin** token (se cortó al copiarlo del mail) → tarjeta "Enlace inválido" con el mismo enlace de rescate.
+- [x] Al éxito: toast + redirección a `/login`.
+- [x] **Bonus (regla de endpoints centralizados):** `ForgotPasswordForm` tenía hardcodeado `'/auth/forgot-password'`. Se agregaron `AUTH.FORGOT_PASSWORD` y `AUTH.RESET_PASSWORD` a `API_ENDPOINTS` y ambos formularios los usan.
+
+##### 🔬 Verificación en navegador real (Chromium, 480 px)
+
+| Escenario | Resultado |
+|---|---|
+| `/restablecer-password?token=…` | ✅ renderiza el formulario |
+| Envío del formulario | ✅ sale `POST /auth/reset-password` con `{"token":"…","newPassword":"…"}` |
+| Respuesta 400 (token vencido/usado) | ✅ *"El enlace expiró o ya fue usado…"* + enlace para pedir uno nuevo |
+| `/restablecer-password` sin token | ✅ tarjeta "Enlace inválido" |
+| Contraseña débil / confirmación distinta | ✅ *"Mínimo 8 caracteres"* / *"Las contraseñas no coinciden"* (no llega al backend) |
 
 #### 🎯 Criterios de Aceptación
 

--- a/frontend/src/app/restablecer-password/layout.tsx
+++ b/frontend/src/app/restablecer-password/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Nueva Contraseña | Auguria',
+  description: 'Elegí una contraseña nueva para tu cuenta de Auguria',
+};
+
+export default function ResetPasswordLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/src/app/restablecer-password/page.test.tsx
+++ b/frontend/src/app/restablecer-password/page.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ResetPasswordPage from './page';
+
+const mockGet = vi.fn();
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: mockGet }),
+}));
+
+// Mock ResetPasswordForm component
+vi.mock('@/components/features/auth', () => ({
+  ResetPasswordForm: ({ token }: { token: string | null }) => (
+    <div data-testid="reset-password-form">token: {token ?? 'sin-token'}</div>
+  ),
+}));
+
+describe('ResetPasswordPage', () => {
+  it('should pass the token from the query string to the form', () => {
+    mockGet.mockReturnValue('token-del-email');
+
+    render(<ResetPasswordPage />);
+
+    expect(screen.getByTestId('reset-password-form')).toHaveTextContent('token: token-del-email');
+  });
+
+  it('should pass null to the form when the query string has no token', () => {
+    mockGet.mockReturnValue(null);
+
+    render(<ResetPasswordPage />);
+
+    expect(screen.getByTestId('reset-password-form')).toHaveTextContent('token: sin-token');
+  });
+
+  it('should have a centered full-height layout', () => {
+    mockGet.mockReturnValue('token-del-email');
+
+    const { container } = render(<ResetPasswordPage />);
+
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass('min-h-screen');
+    expect(wrapper).toHaveClass('bg-bg-main');
+    expect(wrapper).toHaveClass('flex');
+    expect(wrapper).toHaveClass('items-center');
+    expect(wrapper).toHaveClass('justify-center');
+  });
+});

--- a/frontend/src/app/restablecer-password/page.tsx
+++ b/frontend/src/app/restablecer-password/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+import { ResetPasswordForm } from '@/components/features/auth';
+
+/**
+ * Lee el token del enlace que llegó por email y se lo pasa al formulario.
+ */
+function ResetPasswordPageContent() {
+  const searchParams = useSearchParams();
+
+  return <ResetPasswordForm token={searchParams.get('token')} />;
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="bg-bg-main flex min-h-screen items-center justify-center p-4">
+      <Suspense fallback={null}>
+        <ResetPasswordPageContent />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/src/components/features/auth/ForgotPasswordForm.tsx
+++ b/frontend/src/components/features/auth/ForgotPasswordForm.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
 import { apiClient } from '@/lib/api/axios-config';
+import { API_ENDPOINTS } from '@/lib/api/endpoints';
 import { toast } from '@/hooks/utils/useToast';
 import { forgotPasswordSchema, type ForgotPasswordFormData } from '@/lib/validations/auth.schemas';
 
@@ -50,7 +51,7 @@ export function ForgotPasswordForm() {
   const onSubmit = async (data: ForgotPasswordFormData) => {
     setIsSubmitting(true);
     try {
-      await apiClient.post('/auth/forgot-password', { email: data.email });
+      await apiClient.post(API_ENDPOINTS.AUTH.FORGOT_PASSWORD, { email: data.email });
     } catch {
       // Silently ignore errors for security - don't reveal if email exists
     } finally {

--- a/frontend/src/components/features/auth/ResetPasswordForm.test.tsx
+++ b/frontend/src/components/features/auth/ResetPasswordForm.test.tsx
@@ -58,6 +58,9 @@ describe('ResetPasswordForm', () => {
     it('should not render the form when there is no token', () => {
       render(<ResetPasswordForm token={null} />);
 
+      // El testid del formulario no debe existir en el estado de enlace inválido:
+      // si no, un test que afirme "el form se renderiza" pasaría también acá
+      expect(screen.queryByTestId('reset-password-form')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('Nueva contraseña')).not.toBeInTheDocument();
     });
 

--- a/frontend/src/components/features/auth/ResetPasswordForm.test.tsx
+++ b/frontend/src/components/features/auth/ResetPasswordForm.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ResetPasswordForm } from './ResetPasswordForm';
+
+// Mock apiClient
+const mockPost = vi.fn();
+vi.mock('@/lib/api/axios-config', () => ({
+  apiClient: {
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+// Mock toast
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock('@/hooks/utils/useToast', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+// Mock router
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const VALID_TOKEN = 'a1b2c3d4e5f6';
+const VALID_PASSWORD = 'NuevaPass123';
+
+/** Rellena el formulario y lo envía */
+async function fillAndSubmit(
+  user: ReturnType<typeof userEvent.setup>,
+  password: string = VALID_PASSWORD,
+  confirmation: string = password
+) {
+  await user.type(screen.getByLabelText('Nueva contraseña'), password);
+  await user.type(screen.getByLabelText('Repetir contraseña'), confirmation);
+  await user.click(screen.getByRole('button', { name: /restablecer contraseña/i }));
+}
+
+describe('ResetPasswordForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue({ data: { message: 'Password reset successful' } });
+  });
+
+  describe('Enlace sin token', () => {
+    it('should show an invalid link message when there is no token', () => {
+      render(<ResetPasswordForm token={null} />);
+
+      expect(screen.getByTestId('reset-password-invalid-link')).toBeInTheDocument();
+      expect(screen.getByText(/enlace no es válido/i)).toBeInTheDocument();
+    });
+
+    it('should not render the form when there is no token', () => {
+      render(<ResetPasswordForm token={null} />);
+
+      expect(screen.queryByLabelText('Nueva contraseña')).not.toBeInTheDocument();
+    });
+
+    it('should offer a link to request a new email when there is no token', () => {
+      render(<ResetPasswordForm token={null} />);
+
+      expect(screen.getByRole('link', { name: /solicitar un enlace nuevo/i })).toHaveAttribute(
+        'href',
+        '/recuperar-password'
+      );
+    });
+  });
+
+  describe('Rendering', () => {
+    it('should render the form with both password fields', () => {
+      render(<ResetPasswordForm token={VALID_TOKEN} />);
+
+      expect(screen.getByTestId('reset-password-form')).toBeInTheDocument();
+      expect(screen.getByLabelText('Nueva contraseña')).toBeInTheDocument();
+      expect(screen.getByLabelText('Repetir contraseña')).toBeInTheDocument();
+    });
+  });
+
+  describe('Validación', () => {
+    it('should reject a password shorter than 8 characters', async () => {
+      const user = userEvent.setup();
+      render(<ResetPasswordForm token={VALID_TOKEN} />);
+
+      await fillAndSubmit(user, 'Corta1');
+
+      // Texto exacto: el copy de ayuda del formulario también menciona los 8 caracteres
+      expect(await screen.findByText('Mínimo 8 caracteres')).toBeInTheDocument();
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('should reject a password without an uppercase letter or a number', async () => {
+      const user = userEvent.setup();
+      render(<ResetPasswordForm token={VALID_TOKEN} />);
+
+      await fillAndSubmit(user, 'sinmayusculas');
+
+      expect(
+        await screen.findByText(/debe incluir al menos una mayúscula y un número/i)
+      ).toBeInTheDocument();
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('should reject when the confirmation does not match', async () => {
+      const user = userEvent.setup();
+      render(<ResetPasswordForm token={VALID_TOKEN} />);
+
+      await fillAndSubmit(user, VALID_PASSWORD, 'OtraPass123');
+
+      expect(await screen.findByText(/las contraseñas no coinciden/i)).toBeInTheDocument();
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Envío', () => {
+    it('should send the token and the new password to the API', async () => {
+      const user = userEvent.setup();
+      render(<ResetPasswordForm token={VALID_TOKEN} />);
+
+      await fillAndSubmit(user);
+
+      await waitFor(() => {
+        expect(mockPost).toHaveBeenCalledWith('/auth/reset-password', {
+          token: VALID_TOKEN,
+          newPassword: VALID_PASSWORD,
+        });
+      });
+    });
+
+    it('should redirect to login with a success toast', async () => {
+      const user = userEvent.setup();
+      render(<ResetPasswordForm token={VALID_TOKEN} />);
+
+      await fillAndSubmit(user);
+
+      await waitFor(() => {
+        expect(mockToastSuccess).toHaveBeenCalled();
+        expect(mockPush).toHaveBeenCalledWith('/login');
+      });
+    });
+
+    it('should show an expired-link error when the API answers 400', async () => {
+      const user = userEvent.setup();
+      mockPost.mockRejectedValue({ response: { status: 400 } });
+      render(<ResetPasswordForm token={VALID_TOKEN} />);
+
+      await fillAndSubmit(user);
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(/expiró|ya fue usado/i);
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it('should offer a link to request a new email when the token is rejected', async () => {
+      const user = userEvent.setup();
+      mockPost.mockRejectedValue({ response: { status: 400 } });
+      render(<ResetPasswordForm token={VALID_TOKEN} />);
+
+      await fillAndSubmit(user);
+
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: /solicitar un enlace nuevo/i })).toHaveAttribute(
+          'href',
+          '/recuperar-password'
+        );
+      });
+    });
+
+    it('should show a generic error on server failure', async () => {
+      const user = userEvent.setup();
+      mockPost.mockRejectedValue({ response: { status: 500 } });
+      render(<ResetPasswordForm token={VALID_TOKEN} />);
+
+      await fillAndSubmit(user);
+
+      expect(await screen.findByRole('alert')).toHaveTextContent(/intentá de nuevo más tarde/i);
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it('should disable the submit button while submitting', async () => {
+      const user = userEvent.setup();
+      let resolvePost: (value: unknown) => void = () => {};
+      mockPost.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolvePost = resolve;
+          })
+      );
+      render(<ResetPasswordForm token={VALID_TOKEN} />);
+
+      await fillAndSubmit(user);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /restableciendo/i })).toBeDisabled();
+      });
+
+      resolvePost({ data: {} });
+    });
+  });
+});

--- a/frontend/src/components/features/auth/ResetPasswordForm.tsx
+++ b/frontend/src/components/features/auth/ResetPasswordForm.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Loader2, KeyRound } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { apiClient } from '@/lib/api/axios-config';
+import { API_ENDPOINTS } from '@/lib/api/endpoints';
+import { toast } from '@/hooks/utils/useToast';
+import { resetPasswordSchema, type ResetPasswordFormData } from '@/lib/validations/auth.schemas';
+
+const EXPIRED_TOKEN_MESSAGE =
+  'El enlace expiró o ya fue usado. Los enlaces valen una hora y una sola vez.';
+const GENERIC_ERROR_MESSAGE = 'No pudimos restablecer tu contraseña. Intentá de nuevo más tarde.';
+
+interface ResetPasswordFormProps {
+  /** Token recibido por email (query param `token`). `null` si el enlace vino sin él. */
+  token: string | null;
+}
+
+/** Enlace para volver a pedir el mail de recuperación */
+function RequestNewLink() {
+  return (
+    <Link href="/recuperar-password" className="text-primary text-sm hover:underline">
+      Solicitar un enlace nuevo
+    </Link>
+  );
+}
+
+/**
+ * ResetPasswordForm component
+ *
+ * Pantalla final de la recuperación de cuenta: toma el token que llegó por email
+ * y permite fijar una contraseña nueva.
+ */
+export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ResetPasswordFormData>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: {
+      newPassword: '',
+      confirmPassword: '',
+    },
+  });
+
+  const onSubmit = async (data: ResetPasswordFormData) => {
+    if (!token) return;
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      await apiClient.post(API_ENDPOINTS.AUTH.RESET_PASSWORD, {
+        token,
+        newPassword: data.newPassword,
+      });
+
+      toast.success('Contraseña actualizada. Ya podés iniciar sesión.');
+      router.push('/login');
+    } catch (error) {
+      // El backend responde 400 si el token es inválido, expiró o ya se usó
+      const axiosError = error as { response?: { status?: number } };
+      const isRejectedToken = axiosError.response?.status === 400;
+
+      setSubmitError(isRejectedToken ? EXPIRED_TOKEN_MESSAGE : GENERIC_ERROR_MESSAGE);
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!token) {
+    return (
+      <Card className="shadow-soft w-full max-w-md rounded-2xl" data-testid="reset-password-form">
+        <CardHeader className="text-center">
+          <h1 className="text-primary font-serif text-3xl">Enlace inválido</h1>
+        </CardHeader>
+
+        <CardContent
+          className="text-muted-foreground text-center text-sm"
+          data-testid="reset-password-invalid-link"
+        >
+          <p>
+            El enlace no es válido: le falta el código de recuperación. Puede que se haya cortado al
+            copiarlo del email.
+          </p>
+        </CardContent>
+
+        <CardFooter className="justify-center">
+          <RequestNewLink />
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="shadow-soft w-full max-w-md rounded-2xl" data-testid="reset-password-form">
+      <CardHeader className="space-y-2 text-center">
+        <KeyRound className="text-secondary mx-auto h-8 w-8" aria-hidden="true" />
+        <h1 className="text-primary font-serif text-3xl">Nueva Contraseña</h1>
+        <p className="text-muted-foreground text-sm">
+          Elegí una contraseña nueva para tu cuenta. Mínimo 8 caracteres, con una mayúscula y un
+          número.
+        </p>
+      </CardHeader>
+
+      <CardContent>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {submitError && (
+            <div
+              className="bg-destructive/10 border-destructive/30 text-destructive space-y-2 rounded-lg border p-4 text-sm"
+              role="alert"
+              aria-live="polite"
+            >
+              <p className="font-medium">{submitError}</p>
+              {submitError === EXPIRED_TOKEN_MESSAGE && <RequestNewLink />}
+            </div>
+          )}
+
+          {/* New Password Field */}
+          <div className="space-y-2">
+            <label htmlFor="newPassword" className="text-sm font-medium">
+              Nueva contraseña
+            </label>
+            <Input
+              id="newPassword"
+              type="password"
+              autoComplete="new-password"
+              disabled={isSubmitting}
+              className="focus:border-primary bg-gray-50"
+              {...register('newPassword')}
+              aria-invalid={errors.newPassword ? 'true' : 'false'}
+            />
+            {errors.newPassword && (
+              <p className="text-destructive text-sm">{errors.newPassword.message}</p>
+            )}
+          </div>
+
+          {/* Confirm Password Field */}
+          <div className="space-y-2">
+            <label htmlFor="confirmPassword" className="text-sm font-medium">
+              Repetir contraseña
+            </label>
+            <Input
+              id="confirmPassword"
+              type="password"
+              autoComplete="new-password"
+              disabled={isSubmitting}
+              className="focus:border-primary bg-gray-50"
+              {...register('confirmPassword')}
+              aria-invalid={errors.confirmPassword ? 'true' : 'false'}
+            />
+            {errors.confirmPassword && (
+              <p className="text-destructive text-sm">{errors.confirmPassword.message}</p>
+            )}
+          </div>
+
+          <Button
+            type="submit"
+            className="focus-visible:ring-secondary/50 w-full"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Restableciendo...
+              </>
+            ) : (
+              'Restablecer contraseña'
+            )}
+          </Button>
+        </form>
+      </CardContent>
+
+      <CardFooter className="justify-center">
+        <Link href="/login" className="text-muted-foreground hover:text-primary text-sm">
+          Volver a iniciar sesión
+        </Link>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/frontend/src/components/features/auth/ResetPasswordForm.tsx
+++ b/frontend/src/components/features/auth/ResetPasswordForm.tsx
@@ -82,15 +82,15 @@ export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
 
   if (!token) {
     return (
-      <Card className="shadow-soft w-full max-w-md rounded-2xl" data-testid="reset-password-form">
+      <Card
+        className="shadow-soft w-full max-w-md rounded-2xl"
+        data-testid="reset-password-invalid-link"
+      >
         <CardHeader className="text-center">
           <h1 className="text-primary font-serif text-3xl">Enlace inválido</h1>
         </CardHeader>
 
-        <CardContent
-          className="text-muted-foreground text-center text-sm"
-          data-testid="reset-password-invalid-link"
-        >
+        <CardContent className="text-muted-foreground text-center text-sm">
           <p>
             El enlace no es válido: le falta el código de recuperación. Puede que se haya cortado al
             copiarlo del email.

--- a/frontend/src/components/features/auth/index.ts
+++ b/frontend/src/components/features/auth/index.ts
@@ -2,3 +2,4 @@ export { LoginForm } from './LoginForm';
 export { RegisterForm } from './RegisterForm';
 export { RegisterPage } from './RegisterPage';
 export { ForgotPasswordForm } from './ForgotPasswordForm';
+export { ResetPasswordForm } from './ResetPasswordForm';

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -12,6 +12,8 @@ export const API_ENDPOINTS = {
     LOGOUT: '/auth/logout',
     REFRESH: '/auth/refresh',
     PROFILE: '/auth/profile',
+    FORGOT_PASSWORD: '/auth/forgot-password',
+    RESET_PASSWORD: '/auth/reset-password',
   },
 
   // Categories

--- a/frontend/src/lib/validations/auth.schemas.ts
+++ b/frontend/src/lib/validations/auth.schemas.ts
@@ -71,3 +71,27 @@ export const forgotPasswordSchema = z.object({
 });
 
 export type ForgotPasswordFormData = z.infer<typeof forgotPasswordSchema>;
+
+/**
+ * Reset password form schema
+ *
+ * Las reglas replican las del backend (`IsStrongPassword` + `MaxLength(128)`):
+ * mínimo 8 caracteres, al menos una mayúscula y al menos un número.
+ */
+export const resetPasswordSchema = z
+  .object({
+    newPassword: z
+      .string()
+      .min(8, 'Mínimo 8 caracteres')
+      .max(128, 'Máximo 128 caracteres')
+      .refine((val) => /[A-Z]/.test(val) && /[0-9]/.test(val), {
+        message: 'Debe incluir al menos una mayúscula y un número',
+      }),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: 'Las contraseñas no coinciden',
+    path: ['confirmPassword'],
+  });
+
+export type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>;


### PR DESCRIPTION
## Contexto — T-PROD-015 🔴 (la mitad que cierra el flujo)

El PR #591 hace que el backend **mande** el mail de recuperación. Pero el link de ese mail apuntaba a una página **que no existe**: el frontend solo tenía `/recuperar-password` (el formulario que *pide* el mail), y ninguna pantalla que tomara el token y llamara a `POST /auth/reset-password` (endpoint que existe y funciona hace tiempo en el backend).

Sin este PR, el usuario recibe el mail, hace clic y **cae en un 404**. Con los dos, recupera su cuenta de punta a punta.

> ⚠️ **Depende de #591** (backend). Esta rama está apoyada sobre esa: **mergear #591 primero** y este PR queda solo con los cambios de frontend.

## Cambios

- **Nueva ruta `/restablecer-password`**: client component que lee el `token` de la query con `useSearchParams` dentro de `Suspense` (mismo patrón que `ritual/lectura`), y se lo pasa al formulario. Sin lógica en `app/`.
- **`ResetPasswordForm`**: nueva contraseña + confirmación. `resetPasswordSchema` **replica las reglas del backend** (`IsStrongPassword`: mínimo 8 caracteres, al menos una mayúscula y un número; máx. 128), así el usuario no descubre las reglas por un 400.
- **Errores con salida**: si el backend rechaza el token (400 — inválido, expirado o ya usado), se muestra *"El enlace expiró o ya fue usado…"* **con un enlace para pedir uno nuevo**. Si el link llegó **sin** token (se cortó al copiarlo del mail), tarjeta "Enlace inválido" con el mismo rescate.
- **Éxito**: toast + redirección a `/login`.
- **Endpoints centralizados** (regla del proyecto): `ForgotPasswordForm` tenía `'/auth/forgot-password'` **hardcodeado**. Se agregaron `AUTH.FORGOT_PASSWORD` y `AUTH.RESET_PASSWORD` a `API_ENDPOINTS` y ambos formularios los usan.

## Verificación en navegador real (Chromium, 480 px)

No solo jsdom — se manejó la página real con Playwright:

| Escenario | Resultado |
|---|---|
| `/restablecer-password?token=…` | ✅ renderiza el formulario |
| Envío del formulario | ✅ sale `POST /auth/reset-password` con `{"token":"…","newPassword":"…"}` |
| Respuesta 400 (token vencido/usado) | ✅ mensaje de enlace expirado + enlace para pedir uno nuevo |
| `/restablecer-password` sin token | ✅ tarjeta "Enlace inválido" |
| Contraseña débil / confirmación distinta | ✅ *"Mínimo 8 caracteres"* / *"Las contraseñas no coinciden"*, sin llegar al backend |

## Validaciones

- [x] `npm run format`
- [x] `npm run lint:fix` — 0 errores
- [x] `npm run type-check`
- [x] `npm run test:run` — **5286 tests pasan** (12 nuevos: formulario + página)
- [x] `npm run build` — la ruta `/restablecer-password` compila
- [x] `node scripts/validate-architecture.js`
- [x] Sin `any`, sin `eslint-disable`; `'use client'`, `data-testid` y textos en español

🤖 Generated with [Claude Code](https://claude.com/claude-code)