### PR TITLE
fix(contacto): publicar la casilla real consultas@auguriatarot.com (T-PROD-013)

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,7 +783,7 @@ test(cache): agregar tests de invalidación
 
 ## 🔒 Seguridad
 
-Para reportar vulnerabilidades de seguridad, por favor **NO** crear un issue público. Enviar un email a: [seguridad@auguria.com] (o contactar directamente al mantenedor).
+Para reportar vulnerabilidades de seguridad, por favor **NO** crear un issue público. Enviar un email a: [consultas@auguriatarot.com](mailto:consultas@auguriatarot.com) (o contactar directamente al mantenedor).
 
 Ver [SECURITY.md](backend/tarot-app/docs/SECURITY.md) para más información sobre políticas de seguridad.
 
@@ -802,7 +802,7 @@ Este proyecto es privado y propietario. Todos los derechos reservados.
 Para preguntas o soporte:
 
 - **Issues**: [GitHub Issues](https://github.com/ArielDRighi/Auguria/issues)
-- **Email**: soporte@auguria.com
+- **Email**: consultas@auguriatarot.com
 - **Documentación**: Ver carpeta `docs/`
 
 ## 🗺️ Roadmap

--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -332,7 +332,7 @@ Además el frontend define tres tipos que el backend **nunca emite** (`reading_s
 | T-PROD-010 | ✅ Selector de horóscopo: carrusel móvil con nombres completos (occidental + chino) | Frontend | 🟠 Alta | 2 pts |
 | T-PROD-011 | ✅ Ocultar y bloquear notificaciones tras feature flag + sincronizar el enum | Frontend | 🟠 Alta | 1.5 pts |
 | T-PROD-012 | Fail-fast de SMTP en producción (hoy el fallback a jsonTransport es silencioso) + Reply-To | Backend | 🟠 Alta | 1 pt |
-| T-PROD-013 | Página de contacto: la dirección pública `contacto@auguria.com` no existe (dominio equivocado) | Frontend | 🔴 Crítica | 0.5 pt |
+| T-PROD-013 | ✅ Página de contacto: la dirección pública `contacto@auguria.com` no existe (dominio equivocado) | Frontend | 🔴 Crítica | 0.5 pt |
 | T-PROD-014 | Formulario de contacto: enviar de verdad (endpoint + EmailService); hoy los mensajes se pierden | Full-stack | 🟠 Alta | 3 pts |
 | T-PROD-015 | **Reset de contraseña no envía nada**: usuarios sin recuperación de cuenta + métodos huérfanos | Backend | 🔴 Crítica | 3 pts |
 | T-PROD-016 | **Alertas de costo al admin sin plantilla**: si el gasto de los proveedores se dispara, nadie se entera | Backend | 🟠 Alta | 1 pt |
@@ -939,8 +939,9 @@ Segundo problema, menor: el módulo no setea `replyTo`. Si un cliente le respond
 
 ---
 
-### T-PROD-013: La Dirección Pública de la Página de Contacto No Existe
+### T-PROD-013: La Dirección Pública de la Página de Contacto No Existe — ✅ COMPLETADA
 
+**Estado:** ✅ COMPLETADA (2026-07-12)
 **Prioridad:** 🔴 Crítica (dirección rota de cara al público; el fix es trivial)
 **Estimación:** 0.5 punto
 **Dependencias:** ninguna — **no** espera a T-PROD-004
@@ -955,15 +956,22 @@ Es un resto del rebrand: el mismo dominio equivocado aparece también en el `REA
 
 #### ✅ Tareas específicas
 
-- [ ] `contacto/page.tsx:55`: `contacto@auguria.com` → **`consultas@auguriatarot.com`** (la casilla real, creada en T-PROD-004).
-- [ ] Barrer el resto del repo por el dominio equivocado: `grep -rn "auguria\.com" --include="*.tsx" --include="*.ts" --include="*.md" .` y corregir (`README.md` incluido).
-- [ ] Considerar extraer la dirección a una constante única (`CONTACT_EMAIL`) para que no vuelva a divergir.
-- [ ] Test: la página de contacto renderiza la dirección correcta.
+- [x] [contacto/page.tsx](../frontend/src/app/contacto/page.tsx): `contacto@auguria.com` → **`consultas@auguriatarot.com`** (la casilla real, creada en T-PROD-004). Además ahora es un `mailto:` clickeable, no texto plano.
+- [x] Barrido del repo por el dominio equivocado. Corregido lo **publicado**: la página de contacto y el `README.md` (`soporte@` y `seguridad@` → `consultas@auguriatarot.com`; ninguno de esos dos alias existe en Porkbun, así que apuntar al buzón real).
+- [x] Dirección extraída a una constante única: `CONFIG.CONTACT_EMAIL` en [lib/constants/config.ts](../frontend/src/lib/constants/config.ts), para que no vuelva a divergir.
+- [x] Tests: la página de contacto renderiza la dirección correcta, la expone como `mailto:` y **no** contiene ninguna `@auguria.com`; [config.test.ts](../frontend/src/lib/constants/config.test.ts) fija el buzón y su dominio.
 
 #### 🎯 Criterios de Aceptación
 
-- [ ] Ninguna dirección de un dominio que no sea `auguriatarot.com` queda publicada en el frontend.
-- [ ] Ciclo de calidad frontend completo pasa.
+- [x] Ninguna dirección de un dominio que no sea `auguriatarot.com` queda publicada en el frontend. Verificado en el HTML prerenderizado de `/contacto` (0 ocurrencias de `auguria.com`); el único email en `src/` fuera de tests es la constante, el resto son placeholders `tu@email.com` de los formularios.
+- [x] Ciclo de calidad frontend completo pasa: format, lint (0 errores), type-check, 5291 tests, build y `validate-architecture.js`.
+
+#### 📌 Fuera de alcance (decisión del Delta — hallazgo abierto)
+
+El barrido encontró más `auguria.com` **no publicados** al usuario, que este PR **no** toca para mantenerlo Frontend puro:
+
+- 🟠 **Backend, funcional:** [geocode.service.ts](../backend/tarot-app/src/modules/birth-chart/application/services/geocode.service.ts) manda `User-Agent: Auguria/1.0 (contact@auguria.com)` a **Nominatim**, cuya política de uso exige un email de contacto **válido** para poder avisar antes de bloquear. Hoy es inexistente → merece su propia mini-tarea de backend (3 usos + 2 tests).
+- 🟡 **Placeholders y ejemplos** (sin impacto en runtime): `.env.example`, `system-config.entity.ts` (`example:` de Swagger), `docs/modules/birth-chart/*`, ADRs y `create-mp-preapproval-plan.ts`.
 
 ---
 

--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -957,7 +957,7 @@ Es un resto del rebrand: el mismo dominio equivocado aparece también en el `REA
 #### ✅ Tareas específicas
 
 - [x] [contacto/page.tsx](../frontend/src/app/contacto/page.tsx): `contacto@auguria.com` → **`consultas@auguriatarot.com`** (la casilla real, creada en T-PROD-004). Además ahora es un `mailto:` clickeable, no texto plano.
-- [x] Barrido del repo por el dominio equivocado. Corregido lo **publicado**: la página de contacto y el `README.md` (`soporte@` y `seguridad@` → `consultas@auguriatarot.com`; ninguno de esos dos alias existe en Porkbun, así que apuntar al buzón real).
+- [x] Barrido del repo por el dominio equivocado. Corregido lo **publicado**: la página de contacto y el `README.md` (`soporte@` y `seguridad@` → `consultas@auguriatarot.com`; ninguno de esos dos alias existe en Porkbun, así que apuntar al buzón real). Tras el review, también los 3 fixtures de test del frontend que mockeaban `test@auguria.com` (`AdSenseScript.test.tsx`, `AdSlot.test.tsx`, `useAdsEnabled.test.ts`) → `test@example.com` (dominio reservado por RFC 2606). El frontend queda con **cero** `auguria.com`.
 - [x] Dirección extraída a una constante única: `CONFIG.CONTACT_EMAIL` en [lib/constants/config.ts](../frontend/src/lib/constants/config.ts), para que no vuelva a divergir.
 - [x] Tests: la página de contacto renderiza la dirección correcta, la expone como `mailto:` y **no** contiene ninguna `@auguria.com`; [config.test.ts](../frontend/src/lib/constants/config.test.ts) fija el buzón y su dominio.
 

--- a/frontend/src/app/contacto/page.test.tsx
+++ b/frontend/src/app/contacto/page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { CONFIG } from '@/lib/constants';
 import ContactoPage from './page';
 
 describe('ContactoPage', () => {
@@ -34,10 +35,26 @@ describe('ContactoPage', () => {
   it('should display alternative contact information', () => {
     render(<ContactoPage />);
     expect(screen.getByText('Otras formas de contacto')).toBeInTheDocument();
-    expect(screen.getByText('contacto@auguria.com')).toBeInTheDocument();
+    expect(screen.getByText(CONFIG.CONTACT_EMAIL)).toBeInTheDocument();
     expect(
       screen.getByText('Respondemos todos los mensajes en un plazo de 24-48 horas.')
     ).toBeInTheDocument();
+  });
+
+  it('should publish the real contact mailbox of the auguriatarot.com domain', () => {
+    render(<ContactoPage />);
+    expect(screen.getByText('consultas@auguriatarot.com')).toBeInTheDocument();
+  });
+
+  it('should NOT publish any address of the wrong auguria.com domain', () => {
+    const { container } = render(<ContactoPage />);
+    expect(container.textContent).not.toMatch(/@auguria\.com/);
+  });
+
+  it('should expose the contact email as a mailto link', () => {
+    render(<ContactoPage />);
+    const link = screen.getByRole('link', { name: CONFIG.CONTACT_EMAIL });
+    expect(link).toHaveAttribute('href', `mailto:${CONFIG.CONTACT_EMAIL}`);
   });
 
   it('should display the disclaimer about form functionality', () => {

--- a/frontend/src/app/contacto/page.tsx
+++ b/frontend/src/app/contacto/page.tsx
@@ -3,6 +3,7 @@ import { Mail, Sparkles } from 'lucide-react';
 import { DisclaimerBanner } from '@/components/ui/disclaimer-banner';
 import { Reveal } from '@/components/common/Reveal';
 import { ContactForm } from '@/components/features/contact/ContactForm';
+import { CONFIG } from '@/lib/constants';
 
 /**
  * Página de Contacto
@@ -52,7 +53,14 @@ export default function ContactoPage() {
             </h2>
             <div className="text-foreground space-y-2 text-sm">
               <p>
-                <strong>Email:</strong> contacto@auguria.com
+                <strong>Email:</strong>{' '}
+                <a
+                  href={`mailto:${CONFIG.CONTACT_EMAIL}`}
+                  className="text-primary underline-offset-4 hover:underline"
+                  data-testid="contact-email-link"
+                >
+                  {CONFIG.CONTACT_EMAIL}
+                </a>
               </p>
               <p className="text-muted-foreground">
                 Respondemos todos los mensajes en un plazo de 24-48 horas.

--- a/frontend/src/components/features/ads/AdSenseScript.test.tsx
+++ b/frontend/src/components/features/ads/AdSenseScript.test.tsx
@@ -34,7 +34,7 @@ const ADSENSE_CLIENT = 'ca-pub-1234567890123456';
 function buildUser(plan: UserPlan): AuthUser {
   return {
     id: 1,
-    email: 'test@auguria.com',
+    email: 'test@example.com',
     name: 'Test User',
     roles: ['user'],
     plan,

--- a/frontend/src/components/features/ads/AdSlot.test.tsx
+++ b/frontend/src/components/features/ads/AdSlot.test.tsx
@@ -17,7 +17,7 @@ const AD_SLOT_ID = '9876543210';
 function buildUser(plan: UserPlan): AuthUser {
   return {
     id: 1,
-    email: 'test@auguria.com',
+    email: 'test@example.com',
     name: 'Test User',
     roles: ['user'],
     plan,

--- a/frontend/src/hooks/utils/useAdsEnabled.test.ts
+++ b/frontend/src/hooks/utils/useAdsEnabled.test.ts
@@ -15,7 +15,7 @@ const ADSENSE_CLIENT = 'ca-pub-1234567890123456';
 function buildUser(plan: UserPlan): AuthUser {
   return {
     id: 1,
-    email: 'test@auguria.com',
+    email: 'test@example.com',
     name: 'Test User',
     roles: ['user'],
     plan,

--- a/frontend/src/lib/constants/config.test.ts
+++ b/frontend/src/lib/constants/config.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { CONFIG } from './config';
+
+describe('CONFIG', () => {
+  describe('CONTACT_EMAIL', () => {
+    it('should be the real mailbox published to users', () => {
+      expect(CONFIG.CONTACT_EMAIL).toBe('consultas@auguriatarot.com');
+    });
+
+    it('should belong to the auguriatarot.com domain', () => {
+      expect(CONFIG.CONTACT_EMAIL.endsWith('@auguriatarot.com')).toBe(true);
+    });
+  });
+});

--- a/frontend/src/lib/constants/config.ts
+++ b/frontend/src/lib/constants/config.ts
@@ -9,6 +9,13 @@ export const CONFIG = {
   APP_NAME: 'Auguria',
   APP_DESCRIPTION: 'Marketplace de tarotistas profesionales',
 
+  // Contact
+  /**
+   * Única dirección de contacto pública. Es la casilla real del dominio del
+   * proyecto (`auguriatarot.com`); cualquier otro dominio rebota.
+   */
+  CONTACT_EMAIL: 'consultas@auguriatarot.com',
+
   // API
   API_TIMEOUT: 30000,
   STALE_TIME: 5 * 60 * 1000, // 5 minutes


### PR DESCRIPTION
## 🎯 T-PROD-013 — La dirección pública de la página de contacto no existe

La página de contacto publicaba **`contacto@auguria.com`**: un dominio que **no es el del proyecto** (el real es `auguriatarot.com`) y una casilla que **no existe**. Todo cliente que escribiera recibía un rebote — o peor, el mail le llegaba a quien tenga registrado `auguria.com`. Resto del rebrand.

## 📝 Cambios

- **`CONFIG.CONTACT_EMAIL`** (`lib/constants/config.ts`) como **fuente única** de la dirección pública → `consultas@auguriatarot.com`, la casilla real creada en T-PROD-004. Así no vuelve a divergir.
- **`app/contacto/page.tsx`** consume la constante y ahora expone la dirección como **`mailto:` clickeable** (antes era texto plano).
- **`README.md`**: `soporte@auguria.com` y `seguridad@auguria.com` → `consultas@auguriatarot.com`. Ninguno de esos dos alias existe en Porkbun, así que apuntan al buzón real.
- **Backlog** actualizado (T-PROD-013 ✅ + hallazgo fuera de alcance documentado).

## 🧪 Tests (TDD: 6 en rojo → verde)

- `contacto/page.test.tsx`: renderiza `consultas@auguriatarot.com`, lo expone como `mailto:`, y **no contiene ninguna `@auguria.com`** (guarda de regresión).
- `lib/constants/config.test.ts` (nuevo): fija el buzón y su dominio.

## 📌 Fuera de alcance (decisión del Delta)

El barrido del repo encontró más `auguria.com` **no publicados al usuario**; se dejan fuera para mantener el PR Frontend puro y quedan anotados en el backlog:

- 🟠 **Backend, funcional:** `geocode.service.ts` manda `User-Agent: Auguria/1.0 (contact@auguria.com)` a **Nominatim**, cuya política exige un email de contacto válido. Merece su propia mini-tarea de backend.
- 🟡 Placeholders sin impacto en runtime: `.env.example`, `example:` de Swagger, docs de infra, ADRs.

## ✅ Ciclo de calidad frontend

- [x] `npm run format`
- [x] `npm run lint:fix` — 0 errores
- [x] `npm run type-check`
- [x] `npm run test:run` — **5291 tests, 419 archivos, todos verdes**
- [x] `npm run build`
- [x] `node scripts/validate-architecture.js`
- [x] Verificado en el HTML prerenderizado de `/contacto`: **0 ocurrencias** de `auguria.com`, `mailto:` presente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)