### PR TITLE
feat(email): fail-fast de SMTP en producción + Reply-To (T-PROD-012)

### DIFF
--- a/backend/tarot-app/.env.example
+++ b/backend/tarot-app/.env.example
@@ -198,30 +198,43 @@ RATE_LIMIT_TTL=60
 RATE_LIMIT_MAX=100
 
 # -----------------------------------------------------------------------------
-# Email Configuration (OPTIONAL)
+# Email Configuration
 # -----------------------------------------------------------------------------
-# SMTP settings for sending emails (shared readings, welcome, password reset, etc.)
-# If not configured, email functionality will be disabled (app will still work)
-# For development/testing, use Mailtrap.io (free service)
+# SMTP settings for sending emails (password reset, welcome, quota + cost alerts).
+#
+# OPTIONAL in development/test: if the 5 variables below are not complete, the app
+# falls back to jsonTransport (emails are logged to the console, not sent).
+#
+# MANDATORY in production: an incomplete SMTP setup FAILS THE BOOT (T-PROD-012).
+# Before, it fell back to jsonTransport silently: the app looked healthy while every
+# email was dropped — including password resets, which lock users out of their account.
 
-# SMTP server hostname (e.g., smtp.gmail.com, smtp.mailtrap.io, smtp-mail.outlook.com)
-# SMTP_HOST=smtp.mailtrap.io
+# SMTP server hostname (production: Resend)
+# SMTP_HOST=smtp.resend.com
 
-# SMTP server port (587 for TLS, 465 for SSL, 25 for unencrypted)
+# SMTP server port (587 for STARTTLS, 465 for implicit TLS)
 # SMTP_PORT=587
 
-# SMTP authentication username
-# SMTP_USER=your_smtp_username
+# SMTP authentication username (Resend uses the literal "resend")
+# SMTP_USER=resend
 
-# SMTP authentication password
-# SMTP_PASS=your_smtp_password
+# SMTP authentication password (Resend API key)
+# SMTP_PASS=re_your_api_key
 
 # Email address used as sender (From: field)
-# EMAIL_FROM=noreply@auguria.com
+# EMAIL_FROM=noreply@auguriatarot.com
+
+# Mailbox that receives the users' replies to noreply@ (Reply-To: field).
+# Optional: if unset, replies go back to EMAIL_FROM, where nobody reads them.
+# EMAIL_REPLY_TO=consultas@auguriatarot.com
+
+# Recipient of the AI provider cost alerts (80% and 100% of the monthly limit).
+# If unset, the alerts are skipped with a warning: if the spend spikes, nobody finds out.
+# ADMIN_EMAIL_COST_ALERTS=consultas@auguriatarot.com
 
 # Frontend URL for password reset links and back_url de MercadoPago.
-# OBLIGATORIA en producción: si falta, los links de los emails salen apuntando a
-# localhost y no se registra ningún error (cae al default de env.validation.ts).
+# OBLIGATORIA en producción, y no puede apuntar a localhost: el boot falla si no lo está.
+# Antes caía al default en silencio y los links de todos los emails salían a localhost.
 FRONTEND_URL=http://localhost:3001
 
 # -----------------------------------------------------------------------------

--- a/backend/tarot-app/docs/EMAIL_SETUP.md
+++ b/backend/tarot-app/docs/EMAIL_SETUP.md
@@ -1,51 +1,86 @@
-# TASK-016: Email Service - Configuración de Email
+# Configuración de Email
 
-## Variables nuevas agregadas a .env.example
+> Envío transaccional: reset de contraseña, avisos de cuota, confirmación de compra y
+> alertas de costo al admin.
+> **Producción:** Resend (SMTP) sobre el dominio `auguriatarot.com`.
 
-Las siguientes variables de entorno son **OPCIONALES** pero recomendadas para habilitar el envío de emails reales:
+---
 
-```bash
-# -----------------------------------------------------------------------------
-# Email Configuration (OPTIONAL - recommended for production)
-# -----------------------------------------------------------------------------
-SMTP_HOST=smtp.mailtrap.io
-SMTP_PORT=587
-SMTP_USER=your_smtp_username
-SMTP_PASS=your_smtp_password
-EMAIL_FROM=noreply@tarotflavia.com
-FRONTEND_URL=http://localhost:3000
-```
+## Variables
 
-## Comportamiento sin configuración
+| Variable | ¿Obligatoria? | Para qué |
+| --- | --- | --- |
+| `SMTP_HOST` | 🔴 sí en producción | Servidor SMTP (`smtp.resend.com`) |
+| `SMTP_PORT` | 🔴 sí en producción | `587` (STARTTLS) o `465` (TLS implícito) |
+| `SMTP_USER` | 🔴 sí en producción | Usuario SMTP (en Resend, el literal `resend`) |
+| `SMTP_PASS` | 🔴 sí en producción | Password SMTP (en Resend, la API key `re_…`) |
+| `EMAIL_FROM` | 🔴 sí en producción | Remitente (`noreply@auguriatarot.com`) |
+| `FRONTEND_URL` | 🔴 sí en producción | Base de los links de los emails. **No puede ser localhost** |
+| `EMAIL_REPLY_TO` | 🟡 opcional | Buzón que recibe las respuestas a `noreply@`. Sin ella, caen en `EMAIL_FROM`, donde nadie las lee |
+| `ADMIN_EMAIL_COST_ALERTS` | 🟡 opcional | Destinatario de las alertas de costo de IA. Sin ella, las alertas se saltean con un warning |
 
-Si las variables de email **NO están configuradas**, el módulo funcionará en **modo de prueba (jsonTransport)**:
+---
 
-- ✅ La aplicación iniciará sin problemas
-- ✅ Los tests pasarán correctamente
-- ⚠️ Los emails se loguearán en consola pero NO se enviarán realmente
-- ℹ️ Se mostrará un warning al iniciar indicando que está en modo de prueba
+## Comportamiento según el entorno
 
-## Para desarrollo/testing local
+### 🔴 Producción — fail-fast (T-PROD-012)
 
-Puedes usar [Mailtrap.io](https://mailtrap.io) (servicio gratuito de testing de emails):
+Si **falta cualquiera** de las 5 variables SMTP, **la app no arranca**: el boot falla con un
+error que nombra las variables faltantes.
 
-1. Crea una cuenta en Mailtrap.io
-2. Crea un nuevo inbox
-3. Copia las credenciales SMTP
-4. Agrégalas a tu archivo `.env`:
+Es deliberado. Antes, una configuración incompleta caía en silencio a `jsonTransport`: la app
+levantaba **perfecta**, escribía un `logger.warn` que nadie lee, y **ningún email salía** — reset
+de contraseña incluido, que es lo que deja a un usuario encerrado afuera de su cuenta. Un typo en
+una variable de Railway era un incidente invisible hasta que un cliente reclamaba. Ahora falla
+fuerte y temprano.
 
-```bash
-SMTP_HOST=sandbox.smtp.mailtrap.io
-SMTP_PORT=2525
-SMTP_USER=tu_username_de_mailtrap
-SMTP_PASS=tu_password_de_mailtrap
-EMAIL_FROM=noreply@tarotflavia.com
-FRONTEND_URL=http://localhost:3000
-```
+Lo mismo vale para `FRONTEND_URL`: en producción **debe** estar seteada y **no** puede apuntar a
+localhost. Tiene default (`http://localhost:3001`), así que sin esta validación los links de todos
+los emails salían apuntando a localhost sin un solo error en los logs.
 
-## Notas importantes
+### 🟢 Desarrollo y test — jsonTransport
 
-- ✅ Las variables de email son **opcionales** - no bloquean la aplicación ni los tests
-- ⚠️ En producción, se recomienda configurar un servicio real de email (SendGrid, AWS SES, etc.)
-- 📧 Para testing, Mailtrap.io es ideal ya que captura todos los emails sin enviarlos realmente
-- 🔍 El módulo emitirá un warning si detecta configuración incompleta
+Sin configuración SMTP completa, el módulo cae a **modo de prueba**:
+
+- La app arranca normalmente y los tests pasan.
+- Los emails se loguean en la consola, **no se envían**.
+- Se emite un warning al arranque nombrando las variables que faltan.
+- El `HandlebarsAdapter` **también** se configura en este modo, así una plantilla `.hbs` rota se
+  detecta corriendo los tests y no en producción.
+
+---
+
+## Reply-To
+
+El remitente es `noreply@`, pero mucha gente **responde igual**. Por eso el módulo setea
+`replyTo` en los `defaults` del mailer: si `EMAIL_REPLY_TO` está seteada, la respuesta del cliente
+aterriza en el buzón humano (`consultas@auguriatarot.com`); si no, cae a `EMAIL_FROM`.
+
+---
+
+## Setup local
+
+Basta con **no** setear las variables SMTP: los emails se imprimen en la consola. Es lo que usan
+los tests.
+
+Si querés ver los emails renderizados de verdad, podés apuntar el SMTP a cualquier servicio de
+captura (Mailtrap, MailHog) o a tu propia API key de Resend. En ese caso **deshabilitá las
+credenciales cuando termines**: los tests de integración con SMTP real mandan mails a direcciones
+inexistentes y acumulan hard bounces.
+
+---
+
+## ⚠️ El ciclo de calidad no prueba el envío real
+
+Los tests unitarios corren desde `src/` (ts-jest), donde los `.hbs` **siempre** existen. Por eso
+pasaban con un `dist/` sin una sola plantilla. **Cualquier cambio que toque emails debe probarse
+contra el build** (`npm run build && node dist/src/main`) o directamente en el entorno desplegado.
+
+---
+
+## Referencias
+
+- `src/modules/email/mailer.config.ts` — construcción de la config del mailer (fail-fast, replyTo)
+- `src/modules/email/email.service.ts` — métodos de envío
+- `src/modules/email/templates/` — plantillas Handlebars
+- `src/config/env.validation.ts` — declaración y validación de las variables

--- a/backend/tarot-app/docs/EMAIL_SETUP.md
+++ b/backend/tarot-app/docs/EMAIL_SETUP.md
@@ -19,6 +19,9 @@
 | `EMAIL_REPLY_TO` | 🟡 opcional | Buzón que recibe las respuestas a `noreply@`. Sin ella, caen en `EMAIL_FROM`, donde nadie las lee |
 | `ADMIN_EMAIL_COST_ALERTS` | 🟡 opcional | Destinatario de las alertas de costo de IA. Sin ella, las alertas se saltean con un warning |
 
+Las dos opcionales se pueden **dejar vacías** (`EMAIL_REPLY_TO=`) para desactivarlas: el string
+vacío se trata como "sin valor", no como config inválida, y no rompe el arranque.
+
 ---
 
 ## Comportamiento según el entorno
@@ -26,7 +29,7 @@
 ### 🔴 Producción — fail-fast (T-PROD-012)
 
 Si **falta cualquiera** de las 5 variables SMTP, **la app no arranca**: el boot falla con un
-error que nombra las variables faltantes.
+error que nombra **todas** las variables faltantes de una vez.
 
 Es deliberado. Antes, una configuración incompleta caía en silencio a `jsonTransport`: la app
 levantaba **perfecta**, escribía un `logger.warn` que nadie lee, y **ningún email salía** — reset
@@ -34,9 +37,14 @@ de contraseña incluido, que es lo que deja a un usuario encerrado afuera de su 
 una variable de Railway era un incidente invisible hasta que un cliente reclamaba. Ahora falla
 fuerte y temprano.
 
-Lo mismo vale para `FRONTEND_URL`: en producción **debe** estar seteada y **no** puede apuntar a
-localhost. Tiene default (`http://localhost:3001`), así que sin esta validación los links de todos
-los emails salían apuntando a localhost sin un solo error en los logs.
+Lo mismo vale para `FRONTEND_URL`: en producción **debe** ser una URL absoluta (con esquema) y
+**no** puede apuntar a un host local. Tiene default (`http://localhost:3001`), así que sin esta
+validación los links de todos los emails salían apuntando a localhost sin un solo error en los
+logs; y una URL sin esquema (`www.auguriatarot.com`) los dejaría rotos igual de silenciosamente.
+
+La validación vive en `validate()` (`src/config/env-validator.ts`), que corre en
+`ConfigModule.forRoot` — es decir, **antes** de que TypeORM conecte y aplique las migraciones. Un
+deploy con el email mal configurado muere **sin haber tocado la base**.
 
 ### 🟢 Desarrollo y test — jsonTransport
 
@@ -45,8 +53,21 @@ Sin configuración SMTP completa, el módulo cae a **modo de prueba**:
 - La app arranca normalmente y los tests pasan.
 - Los emails se loguean en la consola, **no se envían**.
 - Se emite un warning al arranque nombrando las variables que faltan.
-- El `HandlebarsAdapter` **también** se configura en este modo, así una plantilla `.hbs` rota se
-  detecta corriendo los tests y no en producción.
+- El `HandlebarsAdapter` **también** se configura en este modo, así el dev local renderiza los
+  `.hbs` de verdad en vez de solo serializarlos.
+
+---
+
+## 🧯 El guard de render (`email-templates.spec.ts`)
+
+Los tests de `EmailService` mockean `MailerService`, así que **nadie compilaba un `.hbs`**: un
+template roto, o un `{{placeholder}}` que el servicio dejó de pasar en el contexto, atravesaba todo
+el ciclo de calidad y explotaba recién en producción.
+
+`email-templates.spec.ts` monta el `MailerModule` **real** con `jsonTransport` y **renderiza los 8
+templates** con el mismo contexto que les pasa `EmailService`. Handlebars corre con `strict: true`,
+así que una variable faltante **rompe el test**. Si agregás un template o cambiás el contexto de uno
+existente, sumalo ahí.
 
 ---
 

--- a/backend/tarot-app/src/config/env-validator.spec.ts
+++ b/backend/tarot-app/src/config/env-validator.spec.ts
@@ -127,4 +127,100 @@ describe('env-validator', () => {
       expect(message).toContain('.env.example');
     }
   });
+
+  // ===========================================================================
+  // T-PROD-012: variables de email que fallaban en silencio
+  // ===========================================================================
+
+  describe('email configuration (T-PROD-012)', () => {
+    const baseConfig = (): Record<string, string> => ({
+      POSTGRES_HOST: 'localhost',
+      POSTGRES_PORT: '5432',
+      POSTGRES_USER: 'user',
+      POSTGRES_PASSWORD: 'password',
+      POSTGRES_DB: 'database',
+      JWT_SECRET: 'a'.repeat(32),
+      JWT_EXPIRES_IN: '1h',
+      GROQ_API_KEY: 'gsk_test',
+    });
+
+    describe('EMAIL_REPLY_TO', () => {
+      it('acepta una dirección válida', () => {
+        const config = {
+          ...baseConfig(),
+          EMAIL_REPLY_TO: 'consultas@auguriatarot.com',
+        };
+
+        expect(validate(config).EMAIL_REPLY_TO).toBe(
+          'consultas@auguriatarot.com',
+        );
+      });
+
+      it('rechaza una dirección inválida', () => {
+        const config = { ...baseConfig(), EMAIL_REPLY_TO: 'no-es-un-email' };
+
+        expect(() => validate(config)).toThrow('EMAIL_REPLY_TO');
+      });
+
+      it('es opcional (sin ella, el replyTo cae a EMAIL_FROM)', () => {
+        expect(() => validate(baseConfig())).not.toThrow();
+      });
+    });
+
+    describe('ADMIN_EMAIL_COST_ALERTS', () => {
+      it('acepta una dirección válida', () => {
+        const config = {
+          ...baseConfig(),
+          ADMIN_EMAIL_COST_ALERTS: 'consultas@auguriatarot.com',
+        };
+
+        expect(validate(config).ADMIN_EMAIL_COST_ALERTS).toBe(
+          'consultas@auguriatarot.com',
+        );
+      });
+
+      it('rechaza una dirección inválida: un typo dejaba las alertas de costo mudas', () => {
+        const config = {
+          ...baseConfig(),
+          ADMIN_EMAIL_COST_ALERTS: 'admin@',
+        };
+
+        expect(() => validate(config)).toThrow('ADMIN_EMAIL_COST_ALERTS');
+      });
+    });
+
+    describe('FRONTEND_URL en producción', () => {
+      it('falla el boot si no está seteada: los links de los emails saldrían a localhost sin un solo error', () => {
+        const config = { ...baseConfig(), NODE_ENV: 'production' };
+
+        expect(() => validate(config)).toThrow(/FRONTEND_URL/);
+      });
+
+      it('falla el boot si apunta a localhost', () => {
+        const config = {
+          ...baseConfig(),
+          NODE_ENV: 'production',
+          FRONTEND_URL: 'http://localhost:3001',
+        };
+
+        expect(() => validate(config)).toThrow(/FRONTEND_URL/);
+      });
+
+      it('acepta una URL productiva real', () => {
+        const config = {
+          ...baseConfig(),
+          NODE_ENV: 'production',
+          FRONTEND_URL: 'https://auguriatarot.com',
+        };
+
+        expect(() => validate(config)).not.toThrow();
+      });
+
+      it('fuera de producción sigue cayendo al default de localhost sin quejarse', () => {
+        const config = { ...baseConfig(), NODE_ENV: 'development' };
+
+        expect(validate(config).FRONTEND_URL).toBe('http://localhost:3001');
+      });
+    });
+  });
 });

--- a/backend/tarot-app/src/config/env-validator.spec.ts
+++ b/backend/tarot-app/src/config/env-validator.spec.ts
@@ -98,6 +98,12 @@ describe('env-validator', () => {
       RATE_LIMIT_MAX: '200',
       GROQ_MODEL: 'llama-3.2-90b-text-preview',
       FRONTEND_URL: 'https://app.example.com',
+      // Obligatorias en producción desde T-PROD-012: sin ellas el boot falla.
+      SMTP_HOST: 'smtp.resend.com',
+      SMTP_PORT: '587',
+      SMTP_USER: 'resend',
+      SMTP_PASS: 're_test_key',
+      EMAIL_FROM: 'noreply@auguriatarot.com',
     };
 
     const result = validate(config);
@@ -144,6 +150,22 @@ describe('env-validator', () => {
       GROQ_API_KEY: 'gsk_test',
     });
 
+    /** Config productiva completa: lo que Railway tiene cargado y hace arrancar la app. */
+    const productionConfig = (): Record<string, string> => ({
+      ...baseConfig(),
+      NODE_ENV: 'production',
+      SMTP_HOST: 'smtp.resend.com',
+      SMTP_PORT: '587',
+      SMTP_USER: 'resend',
+      SMTP_PASS: 're_test_key',
+      EMAIL_FROM: 'noreply@auguriatarot.com',
+      FRONTEND_URL: 'https://auguriatarot.com',
+    });
+
+    it('una config productiva completa arranca sin quejas', () => {
+      expect(() => validate(productionConfig())).not.toThrow();
+    });
+
     describe('EMAIL_REPLY_TO', () => {
       it('acepta una dirección válida', () => {
         const config = {
@@ -164,6 +186,13 @@ describe('env-validator', () => {
 
       it('es opcional (sin ella, el replyTo cae a EMAIL_FROM)', () => {
         expect(() => validate(baseConfig())).not.toThrow();
+      });
+
+      it('tolera el string vacío: dejar la variable vacía es la forma habitual de desactivarla, no debe tumbar el boot', () => {
+        const config = { ...baseConfig(), EMAIL_REPLY_TO: '' };
+
+        expect(() => validate(config)).not.toThrow();
+        expect(validate(config).EMAIL_REPLY_TO).toBeUndefined();
       });
     });
 
@@ -187,33 +216,106 @@ describe('env-validator', () => {
 
         expect(() => validate(config)).toThrow('ADMIN_EMAIL_COST_ALERTS');
       });
+
+      it('tolera el string vacío: sin destinatario, el servicio ya saltea la alerta con un warning', () => {
+        const config = { ...baseConfig(), ADMIN_EMAIL_COST_ALERTS: '' };
+
+        expect(() => validate(config)).not.toThrow();
+        expect(validate(config).ADMIN_EMAIL_COST_ALERTS).toBeUndefined();
+      });
+    });
+
+    describe('SMTP en producción', () => {
+      it.each([
+        'SMTP_HOST',
+        'SMTP_PORT',
+        'SMTP_USER',
+        'SMTP_PASS',
+        'EMAIL_FROM',
+      ])('falla el boot si falta %s', (missingKey) => {
+        const config = productionConfig();
+        delete config[missingKey];
+
+        expect(() => validate(config)).toThrow(missingKey);
+      });
+
+      it('falla ANTES de conectar la base: la validación de entorno corre en ConfigModule, no en el factory del mailer (así un deploy incompleto no corre las migraciones y muere después)', () => {
+        const config = productionConfig();
+        delete config.SMTP_PASS;
+
+        expect(() => validate(config)).toThrow(
+          /SMTP configuration is incomplete/i,
+        );
+      });
+
+      it('reporta TODAS las variables faltantes de una vez, no de a una por deploy', () => {
+        const config = productionConfig();
+        delete config.SMTP_PASS;
+        delete config.EMAIL_FROM;
+        delete config.FRONTEND_URL;
+
+        try {
+          validate(config);
+          fail('debería haber lanzado');
+        } catch (error) {
+          const message = (error as Error).message;
+          expect(message).toContain('SMTP_PASS');
+          expect(message).toContain('EMAIL_FROM');
+          expect(message).toContain('FRONTEND_URL');
+        }
+      });
+
+      it('fuera de producción, un SMTP incompleto no molesta (el mailer cae a jsonTransport)', () => {
+        expect(() => validate(baseConfig())).not.toThrow();
+      });
     });
 
     describe('FRONTEND_URL en producción', () => {
       it('falla el boot si no está seteada: los links de los emails saldrían a localhost sin un solo error', () => {
-        const config = { ...baseConfig(), NODE_ENV: 'production' };
+        const config = productionConfig();
+        delete config.FRONTEND_URL;
 
         expect(() => validate(config)).toThrow(/FRONTEND_URL/);
       });
 
-      it('falla el boot si apunta a localhost', () => {
-        const config = {
-          ...baseConfig(),
-          NODE_ENV: 'production',
-          FRONTEND_URL: 'http://localhost:3001',
-        };
+      it.each(['http://localhost:3001', 'http://127.0.0.1:3001'])(
+        'falla el boot si apunta a %s',
+        (frontendUrl) => {
+          const config = { ...productionConfig(), FRONTEND_URL: frontendUrl };
 
-        expect(() => validate(config)).toThrow(/FRONTEND_URL/);
-      });
+          expect(() => validate(config)).toThrow(/FRONTEND_URL/);
+        },
+      );
+
+      it.each(['www.auguriatarot.com', 'auguriatarot.com'])(
+        'falla el boot si le falta el esquema (%s): los links saldrían rotos, otra vez en silencio',
+        (frontendUrl) => {
+          const config = { ...productionConfig(), FRONTEND_URL: frontendUrl };
+
+          expect(() => validate(config)).toThrow(/FRONTEND_URL/);
+        },
+      );
 
       it('acepta una URL productiva real', () => {
+        expect(() => validate(productionConfig())).not.toThrow();
+      });
+
+      it('no confunde un host legítimo que contenga "localhost" con el localhost real', () => {
         const config = {
-          ...baseConfig(),
-          NODE_ENV: 'production',
-          FRONTEND_URL: 'https://auguriatarot.com',
+          ...productionConfig(),
+          FRONTEND_URL: 'https://localhost.auguriatarot.com',
         };
 
         expect(() => validate(config)).not.toThrow();
+      });
+
+      it('recorta los espacios: la app consume el valor validado, así que no puede quedar con un espacio adelante', () => {
+        const config = {
+          ...productionConfig(),
+          FRONTEND_URL: '  https://auguriatarot.com  ',
+        };
+
+        expect(validate(config).FRONTEND_URL).toBe('https://auguriatarot.com');
       });
 
       it('fuera de producción sigue cayendo al default de localhost sin quejarse', () => {

--- a/backend/tarot-app/src/config/env-validator.ts
+++ b/backend/tarot-app/src/config/env-validator.ts
@@ -3,10 +3,65 @@ import { plainToInstance } from 'class-transformer';
 import { Environment, EnvironmentVariables } from './env.validation';
 
 /**
- * `FRONTEND_URL` tiene default, así que class-validator nunca la marca como faltante.
- * En producción eso era una falla silenciosa: sin la variable, los links de todos los
- * emails (reset de contraseña incluido) salían apuntando a localhost y no se registraba
- * ningún error. En producción exigimos una URL real (T-PROD-012).
+ * Sin estas 5, no se puede enviar un solo email.
+ */
+const REQUIRED_SMTP_KEYS = [
+  'SMTP_HOST',
+  'SMTP_PORT',
+  'SMTP_USER',
+  'SMTP_PASS',
+  'EMAIL_FROM',
+] as const;
+
+/**
+ * Hostnames que delatan una URL de desarrollo colada en producción.
+ */
+const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0'];
+
+/**
+ * `FRONTEND_URL` tiene default, así que class-validator nunca la marca como faltante, y
+ * la app la consume tal cual para armar los links de todos los emails. Se valida
+ * **parseándola**: una URL sin esquema (`www.auguriatarot.com`) produciría links rotos,
+ * y sería la misma falla silenciosa un escalón más abajo (T-PROD-012).
+ *
+ * @returns el mensaje de error, o `null` si la URL sirve.
+ */
+function checkFrontendUrl(rawValue: unknown): string | null {
+  const value = typeof rawValue === 'string' ? rawValue.trim() : '';
+
+  if (!value) {
+    return (
+      `FRONTEND_URL: must be set to the real frontend URL in production (not set).\n` +
+      `  It builds the links of every email (password reset included): left unset it falls back ` +
+      `to localhost, and the links point nowhere without a single error in the logs.`
+    );
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return (
+      `FRONTEND_URL: must be an absolute URL including the scheme (got: ${value}).\n` +
+      `  Without it, every email link comes out broken. Example: https://auguriatarot.com`
+    );
+  }
+
+  if (LOCAL_HOSTNAMES.includes(url.hostname)) {
+    return `FRONTEND_URL: must not point to a local host in production (got: ${value}).`;
+  }
+
+  return null;
+}
+
+/**
+ * Validaciones que solo aplican en producción, y que class-validator no puede expresar
+ * (variables con default, o exigidas únicamente cuando `NODE_ENV=production`).
+ *
+ * Corre dentro de `ConfigModule.forRoot`, es decir **antes** de que TypeORM conecte y
+ * aplique las migraciones: un deploy con el email mal configurado muere sin haber tocado
+ * la base. Y acumula **todos** los errores en un solo mensaje, para que Ops no tenga que
+ * descubrir las variables faltantes de a una por deploy (T-PROD-012).
  */
 function validateProductionOnlyVariables(
   config: Record<string, unknown>,
@@ -16,19 +71,27 @@ function validateProductionOnlyVariables(
     return;
   }
 
-  const frontendUrl =
-    typeof config.FRONTEND_URL === 'string' ? config.FRONTEND_URL.trim() : '';
-  const isLocal =
-    frontendUrl.includes('localhost') || frontendUrl.includes('127.0.0.1');
+  const errors: string[] = [];
 
-  if (!frontendUrl || isLocal) {
+  const missingSmtpKeys = REQUIRED_SMTP_KEYS.filter((key) => !config[key]);
+  if (missingSmtpKeys.length > 0) {
+    errors.push(
+      `SMTP configuration is incomplete. Missing: ${missingSmtpKeys.join(', ')}.\n` +
+        `  Falling back to jsonTransport here would silently drop every email (password resets ` +
+        `included) while the app looked perfectly healthy.`,
+    );
+  }
+
+  const frontendUrlError = checkFrontendUrl(config.FRONTEND_URL);
+  if (frontendUrlError) {
+    errors.push(frontendUrlError);
+  }
+
+  if (errors.length > 0) {
     throw new Error(
-      `❌ Environment variable validation failed:\n\n` +
-        `FRONTEND_URL: must be set to the real frontend URL in production ` +
-        `(got: ${frontendUrl || 'not set'}).\n\n` +
-        `It builds the links of every email (password reset included): left unset it falls back ` +
-        `to localhost and the links point nowhere, without a single error in the logs.\n` +
-        `See .env.example for reference.`,
+      `❌ Environment variable validation failed (production):\n\n${errors.join('\n\n')}\n\n` +
+        `The app will NOT start with an incomplete email setup.\n` +
+        `See .env.example and docs/EMAIL_SETUP.md for reference.`,
     );
   }
 }

--- a/backend/tarot-app/src/config/env-validator.ts
+++ b/backend/tarot-app/src/config/env-validator.ts
@@ -1,6 +1,37 @@
 import { validateSync } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { EnvironmentVariables } from './env.validation';
+import { Environment, EnvironmentVariables } from './env.validation';
+
+/**
+ * `FRONTEND_URL` tiene default, así que class-validator nunca la marca como faltante.
+ * En producción eso era una falla silenciosa: sin la variable, los links de todos los
+ * emails (reset de contraseña incluido) salían apuntando a localhost y no se registraba
+ * ningún error. En producción exigimos una URL real (T-PROD-012).
+ */
+function validateProductionOnlyVariables(
+  config: Record<string, unknown>,
+  validatedConfig: EnvironmentVariables,
+): void {
+  if (validatedConfig.NODE_ENV !== Environment.Production) {
+    return;
+  }
+
+  const frontendUrl =
+    typeof config.FRONTEND_URL === 'string' ? config.FRONTEND_URL.trim() : '';
+  const isLocal =
+    frontendUrl.includes('localhost') || frontendUrl.includes('127.0.0.1');
+
+  if (!frontendUrl || isLocal) {
+    throw new Error(
+      `❌ Environment variable validation failed:\n\n` +
+        `FRONTEND_URL: must be set to the real frontend URL in production ` +
+        `(got: ${frontendUrl || 'not set'}).\n\n` +
+        `It builds the links of every email (password reset included): left unset it falls back ` +
+        `to localhost and the links point nowhere, without a single error in the logs.\n` +
+        `See .env.example for reference.`,
+    );
+  }
+}
 
 export function validate(config: Record<string, unknown>) {
   const validatedConfig = plainToInstance(EnvironmentVariables, config, {
@@ -27,6 +58,8 @@ export function validate(config: Record<string, unknown>) {
         `See .env.example for reference.`,
     );
   }
+
+  validateProductionOnlyVariables(config, validatedConfig);
 
   return validatedConfig;
 }

--- a/backend/tarot-app/src/config/env.validation.ts
+++ b/backend/tarot-app/src/config/env.validation.ts
@@ -12,7 +12,7 @@ import {
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 
-enum Environment {
+export enum Environment {
   Development = 'development',
   Production = 'production',
   Test = 'test',
@@ -240,11 +240,37 @@ export class EnvironmentVariables {
   EMAIL_FROM?: string;
 
   /**
+   * Buzón al que se dirigen las respuestas de los usuarios a `noreply@`.
+   * Si no se setea, el `replyTo` cae a `EMAIL_FROM` (ver `mailer.config.ts`).
+   * Valor productivo: `consultas@auguriatarot.com` (T-PROD-012).
+   */
+  @IsString()
+  @IsOptional()
+  @Matches(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, {
+    message: 'EMAIL_REPLY_TO must be a valid email address',
+  })
+  EMAIL_REPLY_TO?: string;
+
+  /**
+   * Destinatario de las alertas de costo de los proveedores de IA (80% y 100% del
+   * límite mensual). Sin ella, `ai-provider-cost.service.ts` loguea un warning y no
+   * manda nada: si el gasto se dispara, nadie se entera (T-PROD-016).
+   */
+  @IsString()
+  @IsOptional()
+  @Matches(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, {
+    message: 'ADMIN_EMAIL_COST_ALERTS must be a valid email address',
+  })
+  ADMIN_EMAIL_COST_ALERTS?: string;
+
+  /**
    * URL del frontend. La usan los links de los emails (reset de contraseña, bienvenida)
    * y las back_urls de MercadoPago.
    *
-   * ⚠️ En producción DEBE estar seteada: si falta, cae al default y los links de los
-   * emails salen apuntando a localhost, sin un solo error en los logs.
+   * ⚠️ En producción DEBE estar seteada y no puede apuntar a localhost: el boot falla
+   * si no lo está (ver `validate()` en `env-validator.ts`). Antes caía al default en
+   * silencio y los links de todos los emails salían a localhost, sin un solo error en
+   * los logs (T-PROD-012).
    * El default es el puerto del FRONTEND (3001), no el del backend (3000).
    */
   @IsString()

--- a/backend/tarot-app/src/config/env.validation.ts
+++ b/backend/tarot-app/src/config/env.validation.ts
@@ -243,9 +243,14 @@ export class EnvironmentVariables {
    * Buzón al que se dirigen las respuestas de los usuarios a `noreply@`.
    * Si no se setea, el `replyTo` cae a `EMAIL_FROM` (ver `mailer.config.ts`).
    * Valor productivo: `consultas@auguriatarot.com` (T-PROD-012).
+   *
+   * El `@Transform` no es decorativo: `@IsOptional()` saltea `undefined`, pero **no** el
+   * string vacío. Sin él, dejar la variable vacía (la forma habitual de desactivarla)
+   * haría fallar el `@Matches` y **tumbaría el boot en cualquier entorno**.
    */
   @IsString()
   @IsOptional()
+  @Transform(({ value }) => (value ? String(value) : undefined))
   @Matches(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, {
     message: 'EMAIL_REPLY_TO must be a valid email address',
   })
@@ -255,9 +260,13 @@ export class EnvironmentVariables {
    * Destinatario de las alertas de costo de los proveedores de IA (80% y 100% del
    * límite mensual). Sin ella, `ai-provider-cost.service.ts` loguea un warning y no
    * manda nada: si el gasto se dispara, nadie se entera (T-PROD-016).
+   *
+   * Mismo `@Transform` que `EMAIL_REPLY_TO`: el string vacío significa "sin destinatario",
+   * no "config inválida".
    */
   @IsString()
   @IsOptional()
+  @Transform(({ value }) => (value ? String(value) : undefined))
   @Matches(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, {
     message: 'ADMIN_EMAIL_COST_ALERTS must be a valid email address',
   })
@@ -275,7 +284,9 @@ export class EnvironmentVariables {
    */
   @IsString()
   @IsOptional()
-  @Transform(({ value }) => (value ? String(value) : 'http://localhost:3001'))
+  @Transform(({ value }) =>
+    value ? String(value).trim() : 'http://localhost:3001',
+  )
   FRONTEND_URL: string = 'http://localhost:3001';
 
   // =============================================================================

--- a/backend/tarot-app/src/modules/email/email-templates.spec.ts
+++ b/backend/tarot-app/src/modules/email/email-templates.spec.ts
@@ -1,5 +1,9 @@
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { MailerModule, MailerService } from '@nestjs-modules/mailer';
+import { createMailerOptions } from './mailer.config';
 
 /**
  * Guarda de regresión (T-PROD-015).
@@ -54,5 +58,137 @@ describe('Email templates (build)', () => {
     expect(templatesAsset).toBeDefined();
     expect(templatesAsset?.include).toContain('.hbs');
     expect(templatesAsset?.outDir).toBe('dist/src');
+  });
+});
+
+/**
+ * Render real de los templates (T-PROD-012).
+ *
+ * Los tests de `EmailService` mockean `MailerService`, así que **nadie compilaba un
+ * `.hbs`**: un template roto (o un `{{placeholder}}` que el servicio no pasa en el
+ * contexto) pasaba todo el ciclo de calidad y explotaba en producción.
+ *
+ * Estos tests montan el `MailerModule` **de verdad** con `jsonTransport` — el mismo
+ * modo en que corre el dev local — y lo hacen renderizar. El `HandlebarsAdapter` corre
+ * con `strict: true`, así que una variable faltante en el contexto **lanza**.
+ */
+describe('Email templates (render)', () => {
+  /**
+   * jsonTransport no envía nada: serializa el mail (con el HTML ya renderizado) en
+   * `info.message` como JSON.
+   */
+  interface JsonTransportInfo {
+    message: string;
+  }
+
+  interface RenderedMail {
+    html: string;
+    subject: string;
+  }
+
+  async function render(
+    template: string,
+    context: Record<string, string>,
+  ): Promise<RenderedMail> {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        MailerModule.forRoot(
+          createMailerOptions(new ConfigService({ NODE_ENV: 'test' })),
+        ),
+      ],
+    }).compile();
+
+    const mailerService = moduleRef.get(MailerService);
+
+    const info = (await mailerService.sendMail({
+      to: 'destinatario@example.com',
+      subject: 'Asunto de prueba',
+      template,
+      context,
+    })) as JsonTransportInfo;
+
+    return JSON.parse(info.message) as RenderedMail;
+  }
+
+  /** El contexto que `email.service.ts` le pasa a cada template. */
+  const TEMPLATE_CONTEXTS: Record<string, Record<string, string>> = {
+    welcome: {
+      userName: 'Flavia',
+      email: 'flavia@example.com',
+      frontendUrl: 'https://auguriatarot.com',
+    },
+    'password-reset': {
+      userName: 'Flavia',
+      resetUrl: 'https://auguriatarot.com/restablecer-password?token=un-token',
+    },
+    'plan-change': {
+      userName: 'Flavia',
+      oldPlan: 'Free',
+      newPlan: 'Premium',
+      changeDate: '12/07/2026',
+    },
+    'quota-warning-80': {
+      userName: 'Flavia',
+      plan: 'Free',
+      requestsUsed: '8',
+      requestsRemaining: '2',
+      quotaLimit: '10',
+      percentageUsed: '80.0',
+      resetDate: '01/08/2026',
+      frontendUrl: 'https://auguriatarot.com',
+    },
+    'quota-limit-reached': {
+      userName: 'Flavia',
+      plan: 'Free',
+      requestsUsed: '10',
+      quotaLimit: '10',
+      resetDate: '01/08/2026',
+      frontendUrl: 'https://auguriatarot.com',
+    },
+    'provider-cost-warning': {
+      provider: 'groq',
+      currentCost: '16.50',
+      monthlyLimit: '20.00',
+      percentageUsed: '82.5',
+      adminUrl: 'https://auguriatarot.com/admin/consumo',
+    },
+    'provider-cost-limit-reached': {
+      provider: 'groq',
+      currentCost: '20.00',
+      monthlyLimit: '20.00',
+      adminUrl: 'https://auguriatarot.com/admin/consumo',
+    },
+    'holistic-service-confirmation': {
+      userName: 'Flavia',
+      serviceName: 'Lectura holística',
+      amountArs: '25000',
+      bookingUrl: 'https://auguriatarot.com/reservar',
+      whatsappNumber: '+54 9 11 1234-5678',
+      whatsappNumberForLink: '5491112345678',
+    },
+  };
+
+  it.each(Object.keys(TEMPLATE_CONTEXTS))(
+    'renderiza %s con el contexto que le pasa EmailService',
+    async (template) => {
+      const mail = await render(template, TEMPLATE_CONTEXTS[template]);
+
+      expect(mail.html).toBeTruthy();
+      // Si quedara un placeholder sin resolver, el .hbs y el servicio se habrían separado.
+      expect(mail.html).not.toContain('{{');
+    },
+  );
+
+  it('renderiza el link de recuperación en password-reset: es el email crítico, sin él el usuario queda afuera de su cuenta', async () => {
+    const resetUrl =
+      'https://auguriatarot.com/restablecer-password?token=un-token';
+
+    const mail = await render('password-reset', {
+      userName: 'Flavia',
+      resetUrl,
+    });
+
+    expect(mail.html).toContain(resetUrl);
+    expect(mail.html).toContain('Flavia');
   });
 });

--- a/backend/tarot-app/src/modules/email/email.module.ts
+++ b/backend/tarot-app/src/modules/email/email.module.ts
@@ -1,62 +1,15 @@
-import { Module, Logger } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { MailerModule } from '@nestjs-modules/mailer';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter';
-import { join } from 'path';
 import { EmailService } from './email.service';
+import { createMailerOptions } from './mailer.config';
 
 @Module({
   imports: [
     MailerModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => {
-        const logger = new Logger('EmailModule');
-        const smtpHost = configService.get<string>('SMTP_HOST');
-        const smtpPort = configService.get<number>('SMTP_PORT');
-        const smtpUser = configService.get<string>('SMTP_USER');
-        const smtpPass = configService.get<string>('SMTP_PASS');
-        const emailFrom = configService.get<string>('EMAIL_FROM');
-
-        // Si no hay configuración SMTP, usar configuración por defecto que no enviará emails
-        if (!smtpHost || !smtpPort || !smtpUser || !smtpPass || !emailFrom) {
-          logger.warn(
-            '⚠️  Email configuration is incomplete. Running in TEST MODE with jsonTransport. ' +
-              'Emails will be logged to console but not sent. ' +
-              'Configure SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, and EMAIL_FROM to enable real email sending.',
-          );
-          return {
-            transport: {
-              jsonTransport: true, // Modo de prueba que no envía emails reales
-            },
-            defaults: {
-              from: 'noreply@example.com',
-            },
-          };
-        }
-
-        return {
-          transport: {
-            host: smtpHost,
-            port: smtpPort,
-            secure: smtpPort === 465,
-            auth: {
-              user: smtpUser,
-              pass: smtpPass,
-            },
-          },
-          defaults: {
-            from: emailFrom,
-          },
-          template: {
-            dir: join(__dirname, 'templates'),
-            adapter: new HandlebarsAdapter(),
-            options: {
-              strict: true,
-            },
-          },
-        };
-      },
+      useFactory: createMailerOptions,
     }),
   ],
   providers: [EmailService],

--- a/backend/tarot-app/src/modules/email/mailer.config.spec.ts
+++ b/backend/tarot-app/src/modules/email/mailer.config.spec.ts
@@ -1,0 +1,128 @@
+import { ConfigService } from '@nestjs/config';
+import { createMailerOptions } from './mailer.config';
+
+/**
+ * Configuración SMTP completa y válida (la forma que tiene en Railway).
+ */
+const COMPLETE_SMTP: Record<string, string> = {
+  SMTP_HOST: 'smtp.resend.com',
+  SMTP_PORT: '587',
+  SMTP_USER: 'resend',
+  SMTP_PASS: 're_test_key',
+  EMAIL_FROM: 'noreply@auguriatarot.com',
+};
+
+/**
+ * ConfigService mockeado: devuelve lo que haya en `env` y `undefined` para el resto,
+ * igual que el ConfigService real cuando la variable no está seteada.
+ */
+function mockConfigService(env: Record<string, string>): ConfigService {
+  const configService: Pick<ConfigService, 'get'> = {
+    get: jest.fn((key: string) => env[key]),
+  } as Pick<ConfigService, 'get'>;
+
+  return configService as ConfigService;
+}
+
+describe('createMailerOptions', () => {
+  describe('fail-fast en producción (T-PROD-012)', () => {
+    it.each(['SMTP_HOST', 'SMTP_PORT', 'SMTP_USER', 'SMTP_PASS', 'EMAIL_FROM'])(
+      'lanza al arranque si falta %s en producción (nunca cae a jsonTransport)',
+      (missingKey) => {
+        const env = { ...COMPLETE_SMTP, NODE_ENV: 'production' };
+        delete env[missingKey];
+
+        expect(() => createMailerOptions(mockConfigService(env))).toThrow(
+          /SMTP configuration is incomplete/i,
+        );
+      },
+    );
+
+    it('nombra en el error TODAS las variables que faltan', () => {
+      const env = {
+        NODE_ENV: 'production',
+        SMTP_HOST: 'smtp.resend.com',
+        SMTP_PORT: '587',
+      };
+
+      expect(() => createMailerOptions(mockConfigService(env))).toThrow(
+        /SMTP_USER, SMTP_PASS, EMAIL_FROM/,
+      );
+    });
+
+    it('no lanza en producción cuando la configuración SMTP está completa', () => {
+      const env = { ...COMPLETE_SMTP, NODE_ENV: 'production' };
+
+      expect(() => createMailerOptions(mockConfigService(env))).not.toThrow();
+    });
+  });
+
+  describe('fallback a jsonTransport fuera de producción', () => {
+    it.each(['development', 'test'])(
+      'en %s con SMTP incompleto devuelve jsonTransport sin lanzar',
+      (nodeEnv) => {
+        const options = createMailerOptions(
+          mockConfigService({ NODE_ENV: nodeEnv }),
+        );
+
+        expect(options.transport).toEqual({ jsonTransport: true });
+      },
+    );
+
+    it('configura el HandlebarsAdapter también en modo jsonTransport (un template roto se detecta en los tests, no en producción)', () => {
+      const options = createMailerOptions(
+        mockConfigService({ NODE_ENV: 'development' }),
+      );
+
+      expect(options.template).toBeDefined();
+      expect(options.template?.adapter).toBeDefined();
+    });
+  });
+
+  describe('transporte real', () => {
+    it('arma el transporte con host, puerto y credenciales', () => {
+      const options = createMailerOptions(mockConfigService(COMPLETE_SMTP));
+
+      expect(options.transport).toMatchObject({
+        host: 'smtp.resend.com',
+        port: 587,
+        auth: { user: 'resend', pass: 're_test_key' },
+      });
+    });
+
+    it('usa TLS implícito (secure) solo en el puerto 465', () => {
+      const secure = createMailerOptions(
+        mockConfigService({ ...COMPLETE_SMTP, SMTP_PORT: '465' }),
+      );
+      const notSecure = createMailerOptions(mockConfigService(COMPLETE_SMTP));
+
+      expect(secure.transport).toMatchObject({ port: 465, secure: true });
+      expect(notSecure.transport).toMatchObject({ port: 587, secure: false });
+    });
+  });
+
+  describe('replyTo (T-PROD-012)', () => {
+    it('usa EMAIL_REPLY_TO cuando está seteado: responder a noreply@ aterriza en el buzón humano', () => {
+      const options = createMailerOptions(
+        mockConfigService({
+          ...COMPLETE_SMTP,
+          EMAIL_REPLY_TO: 'consultas@auguriatarot.com',
+        }),
+      );
+
+      expect(options.defaults).toMatchObject({
+        from: 'noreply@auguriatarot.com',
+        replyTo: 'consultas@auguriatarot.com',
+      });
+    });
+
+    it('cae a EMAIL_FROM cuando EMAIL_REPLY_TO no está seteado', () => {
+      const options = createMailerOptions(mockConfigService(COMPLETE_SMTP));
+
+      expect(options.defaults).toMatchObject({
+        from: 'noreply@auguriatarot.com',
+        replyTo: 'noreply@auguriatarot.com',
+      });
+    });
+  });
+});

--- a/backend/tarot-app/src/modules/email/mailer.config.spec.ts
+++ b/backend/tarot-app/src/modules/email/mailer.config.spec.ts
@@ -1,4 +1,5 @@
 import { ConfigService } from '@nestjs/config';
+import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter';
 import { createMailerOptions } from './mailer.config';
 
 /**
@@ -69,13 +70,26 @@ describe('createMailerOptions', () => {
       },
     );
 
-    it('configura el HandlebarsAdapter también en modo jsonTransport (un template roto se detecta en los tests, no en producción)', () => {
+    it('configura el HandlebarsAdapter también en modo jsonTransport (el render se ejercita de verdad en email-templates.spec.ts)', () => {
       const options = createMailerOptions(
         mockConfigService({ NODE_ENV: 'development' }),
       );
 
-      expect(options.template).toBeDefined();
-      expect(options.template?.adapter).toBeDefined();
+      expect(options.template?.adapter).toBeInstanceOf(HandlebarsAdapter);
+      expect(options.template?.dir).toMatch(/[\\/]templates$/);
+    });
+
+    it('también setea el replyTo en modo prueba: los dos modos se comportan igual', () => {
+      const options = createMailerOptions(
+        mockConfigService({
+          NODE_ENV: 'development',
+          EMAIL_REPLY_TO: 'consultas@auguriatarot.com',
+        }),
+      );
+
+      expect(options.defaults).toMatchObject({
+        replyTo: 'consultas@auguriatarot.com',
+      });
     });
   });
 
@@ -98,6 +112,16 @@ describe('createMailerOptions', () => {
 
       expect(secure.transport).toMatchObject({ port: 465, secure: true });
       expect(notSecure.transport).toMatchObject({ port: 587, secure: false });
+    });
+
+    it('rechaza un SMTP_PORT que no es un número: sin esto quedaba un NaN silencioso', () => {
+      // El EmailModule se monta standalone en los e2e, sin la validación de entorno
+      // que garantiza que SMTP_PORT sea un puerto.
+      expect(() =>
+        createMailerOptions(
+          mockConfigService({ ...COMPLETE_SMTP, SMTP_PORT: 'quinientos' }),
+        ),
+      ).toThrow(/SMTP_PORT/);
     });
   });
 

--- a/backend/tarot-app/src/modules/email/mailer.config.ts
+++ b/backend/tarot-app/src/modules/email/mailer.config.ts
@@ -1,0 +1,100 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { MailerOptions } from '@nestjs-modules/mailer';
+import { HandlebarsAdapter } from '@nestjs-modules/mailer/dist/adapters/handlebars.adapter';
+import { join } from 'path';
+
+/**
+ * Variables sin las cuales no se puede enviar un email real.
+ */
+const REQUIRED_SMTP_KEYS = [
+  'SMTP_HOST',
+  'SMTP_PORT',
+  'SMTP_USER',
+  'SMTP_PASS',
+  'EMAIL_FROM',
+] as const;
+
+/**
+ * El render de los `.hbs` va fuera del `if`: en modo jsonTransport también se
+ * ejercita el HandlebarsAdapter, así una plantilla rota se detecta en los tests
+ * y no en producción (T-PROD-012).
+ */
+const TEMPLATE_OPTIONS: MailerOptions['template'] = {
+  dir: join(__dirname, 'templates'),
+  adapter: new HandlebarsAdapter(),
+  options: {
+    strict: true,
+  },
+};
+
+/**
+ * Construye la configuración del MailerModule a partir del entorno.
+ *
+ * En **producción**, una configuración SMTP incompleta **detiene el arranque**: antes
+ * caía en silencio a `jsonTransport`, con lo cual la app levantaba perfecta, escribía
+ * un warning que nadie lee y ningún usuario recibía su email (T-PROD-012).
+ *
+ * Fuera de producción se conserva el fallback a `jsonTransport`, del que dependen el
+ * dev local y los tests.
+ *
+ * @throws {Error} en producción, si falta alguna variable SMTP.
+ */
+export function createMailerOptions(
+  configService: ConfigService,
+): MailerOptions {
+  const logger = new Logger('EmailModule');
+
+  const missingKeys = REQUIRED_SMTP_KEYS.filter(
+    (key) => !configService.get<string>(key),
+  );
+
+  if (missingKeys.length > 0) {
+    const isProduction = configService.get<string>('NODE_ENV') === 'production';
+
+    if (isProduction) {
+      throw new Error(
+        `❌ SMTP configuration is incomplete in production. Missing: ${missingKeys.join(', ')}.\n\n` +
+          `The app will NOT start with an incomplete SMTP setup: falling back to jsonTransport here ` +
+          `would silently drop every email (password resets included) while the app looked healthy.\n` +
+          `Set these variables in the deployment environment. See .env.example and docs/EMAIL_SETUP.md.`,
+      );
+    }
+
+    logger.warn(
+      `⚠️  Email configuration is incomplete (missing: ${missingKeys.join(', ')}). ` +
+        'Running in TEST MODE with jsonTransport: emails are logged to the console, not sent.',
+    );
+
+    return {
+      transport: {
+        jsonTransport: true,
+      },
+      defaults: {
+        from: 'noreply@example.com',
+      },
+      template: TEMPLATE_OPTIONS,
+    };
+  }
+
+  const smtpPort = Number(configService.get<string>('SMTP_PORT'));
+  const emailFrom = configService.get<string>('EMAIL_FROM');
+
+  return {
+    transport: {
+      host: configService.get<string>('SMTP_HOST'),
+      port: smtpPort,
+      secure: smtpPort === 465,
+      auth: {
+        user: configService.get<string>('SMTP_USER'),
+        pass: configService.get<string>('SMTP_PASS'),
+      },
+    },
+    defaults: {
+      from: emailFrom,
+      // Sin esto, la respuesta de un cliente a noreply@ se pierde (T-PROD-012).
+      replyTo: configService.get<string>('EMAIL_REPLY_TO') ?? emailFrom,
+    },
+    template: TEMPLATE_OPTIONS,
+  };
+}

--- a/backend/tarot-app/src/modules/email/mailer.config.ts
+++ b/backend/tarot-app/src/modules/email/mailer.config.ts
@@ -16,9 +16,9 @@ const REQUIRED_SMTP_KEYS = [
 ] as const;
 
 /**
- * El render de los `.hbs` va fuera del `if`: en modo jsonTransport también se
- * ejercita el HandlebarsAdapter, así una plantilla rota se detecta en los tests
- * y no en producción (T-PROD-012).
+ * El bloque `template` va fuera del `if`: en modo jsonTransport también se configura el
+ * HandlebarsAdapter, así el dev local renderiza los `.hbs` de verdad y no solo los
+ * serializa. El render está cubierto por `email-templates.spec.ts` (T-PROD-012).
  */
 const TEMPLATE_OPTIONS: MailerOptions['template'] = {
   dir: join(__dirname, 'templates'),
@@ -35,10 +35,16 @@ const TEMPLATE_OPTIONS: MailerOptions['template'] = {
  * caía en silencio a `jsonTransport`, con lo cual la app levantaba perfecta, escribía
  * un warning que nadie lee y ningún usuario recibía su email (T-PROD-012).
  *
+ * En el arranque normal de la app este chequeo es redundante: `validate()`
+ * (`env-validator.ts`) ya lo hace antes, en `ConfigModule.forRoot`, para que el boot
+ * muera **antes** de que TypeORM conecte y corra las migraciones. Se conserva igual
+ * porque el `EmailModule` se monta standalone en los e2e, sin esa validación.
+ *
  * Fuera de producción se conserva el fallback a `jsonTransport`, del que dependen el
  * dev local y los tests.
  *
  * @throws {Error} en producción, si falta alguna variable SMTP.
+ * @throws {Error} si `SMTP_PORT` no es un número.
  */
 export function createMailerOptions(
   configService: ConfigService,
@@ -66,12 +72,16 @@ export function createMailerOptions(
         'Running in TEST MODE with jsonTransport: emails are logged to the console, not sent.',
     );
 
+    const fallbackFrom = 'noreply@example.com';
+
     return {
       transport: {
         jsonTransport: true,
       },
       defaults: {
-        from: 'noreply@example.com',
+        from: fallbackFrom,
+        // Paridad con el transporte real: los dos modos se comportan igual.
+        replyTo: configService.get<string>('EMAIL_REPLY_TO') ?? fallbackFrom,
       },
       template: TEMPLATE_OPTIONS,
     };
@@ -79,6 +89,14 @@ export function createMailerOptions(
 
   const smtpPort = Number(configService.get<string>('SMTP_PORT'));
   const emailFrom = configService.get<string>('EMAIL_FROM');
+
+  // `@IsPort()` ya lo garantiza en el arranque de la app, pero el EmailModule se monta
+  // standalone en los e2e: sin este guard, un puerto no numérico quedaba en un NaN mudo.
+  if (!Number.isInteger(smtpPort)) {
+    throw new Error(
+      `❌ SMTP_PORT must be a number (got: ${configService.get<string>('SMTP_PORT')}).`,
+    );
+  }
 
   return {
     transport: {

--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -331,11 +331,12 @@ Además el frontend define tres tipos que el backend **nunca emite** (`reading_s
 | T-PROD-009 | AdSense fase 2: alta de cuenta, ads.txt, consentimiento y colocación en páginas | Full-stack | 🟡 Media | 3 pts |
 | T-PROD-010 | ✅ Selector de horóscopo: carrusel móvil con nombres completos (occidental + chino) | Frontend | 🟠 Alta | 2 pts |
 | T-PROD-011 | ✅ Ocultar y bloquear notificaciones tras feature flag + sincronizar el enum | Frontend | 🟠 Alta | 1.5 pts |
-| T-PROD-012 | Fail-fast de SMTP en producción (hoy el fallback a jsonTransport es silencioso) + Reply-To | Backend | 🟠 Alta | 1 pt |
+| T-PROD-012 | ✅ Fail-fast de SMTP en producción (hoy el fallback a jsonTransport es silencioso) + Reply-To | Backend | 🟠 Alta | 1 pt |
 | T-PROD-013 | ✅ Página de contacto: la dirección pública `contacto@auguria.com` no existe (dominio equivocado) | Frontend | 🔴 Crítica | 0.5 pt |
 | T-PROD-014 | Formulario de contacto: enviar de verdad (endpoint + EmailService); hoy los mensajes se pierden | Full-stack | 🟠 Alta | 3 pts |
 | T-PROD-015 | **Reset de contraseña no envía nada**: usuarios sin recuperación de cuenta + métodos huérfanos | Backend | 🔴 Crítica | 3 pts |
 | T-PROD-016 | **Alertas de costo al admin sin plantilla**: si el gasto de los proveedores se dispara, nadie se entera | Backend | 🟠 Alta | 1 pt |
+| T-PROD-017 | Geocoding: el `User-Agent` que enviamos a Nominatim declara un email inexistente (riesgo de bloqueo silencioso) | Backend | 🟠 Alta | 0.5 pt |
 
 ---
 
@@ -906,13 +907,19 @@ Además el frontend define tres tipos que el backend **nunca emite** (`reading_s
 
 ---
 
-### T-PROD-012: Fail-Fast de SMTP en Producción + Reply-To
+### T-PROD-012: Fail-Fast de SMTP en Producción + Reply-To — ✅ COMPLETADA
 
+**Estado:** ✅ COMPLETADA (2026-07-12)
 **Prioridad:** 🟠 Alta
 **Estimación:** 1 punto
 **Dependencias:** ninguna (pero cobra sentido junto con T-PROD-004)
 **Origen:** hallazgo al revisar la arquitectura de email de T-PROD-004
 **Tipo:** Backend (`docs/WORKFLOW_BACKEND.md`)
+
+> 📌 **Alcance ampliado por decisión del Delta:** la tarea absorbe los **dos hallazgos aparcados**
+> que T-PROD-015 y T-PROD-016 dejaron marcados como *"candidata a sumarse a T-PROD-012"*
+> (`FRONTEND_URL` y `ADMIN_EMAIL_COST_ALERTS`). Los tres agujeros son la misma falla:
+> **una variable mal cargada en Railway no rompe nada, solo apaga los emails en silencio.**
 
 #### 📋 Problema
 
@@ -924,18 +931,41 @@ Segundo problema, menor: el módulo no setea `replyTo`. Si un cliente le respond
 
 #### ✅ Tareas específicas
 
-- [ ] En el `useFactory` de `MailerModule`: si `NODE_ENV === 'production'` y la config SMTP está incompleta → **lanzar** (fail-fast al arranque) en lugar de caer a `jsonTransport`. Fuera de producción, mantener el fallback + warning actual (los tests y el dev local dependen de él).
-- [ ] Agregar `defaults: { from: emailFrom, replyTo: EMAIL_REPLY_TO ?? emailFrom }` y declarar `EMAIL_REPLY_TO` (opcional) en `env.validation.ts` con el mismo `@Matches` de email que `EMAIL_FROM`. Valor productivo: `consultas@auguriatarot.com`.
-- [ ] Mover el bloque `template` fuera del `if`: hoy la rama de `jsonTransport` **no** configura el `HandlebarsAdapter`, así que el modo de prueba no ejercita el render real de los `.hbs` — un template roto no se detecta hasta producción.
-- [ ] Tests: (a) en `production` con SMTP incompleto → el factory lanza; (b) en `development` con SMTP incompleto → devuelve `jsonTransport` sin lanzar; (c) con SMTP completo → transport real y `replyTo` presente en `defaults`.
-- [ ] Actualizar `.env.example` y `backend/tarot-app/docs/EMAIL_SETUP.md` (hoy documenta Mailtrap y dice que las variables de email son opcionales — quedó desactualizado y contradice el fail-fast).
+- [x] El `useFactory` de `MailerModule` se **extrajo** a [mailer.config.ts](../backend/tarot-app/src/modules/email/mailer.config.ts) (`createMailerOptions`): inline dentro del decorador era **imposible de testear**. `email.module.ts` queda en 17 líneas.
+- [x] **Fail-fast:** si `NODE_ENV === 'production'` y la config SMTP está incompleta → **lanza** al arranque, con un error que **nombra las variables que faltan**. Fuera de producción se conserva el fallback a `jsonTransport` + warning (los tests y el dev local dependen de él).
+- [x] `defaults: { from, replyTo: EMAIL_REPLY_TO ?? from }` y `EMAIL_REPLY_TO` declarada en `env.validation.ts` con el mismo `@Matches` de email que `EMAIL_FROM`. Valor productivo: `consultas@auguriatarot.com`.
+- [x] Bloque `template` **fuera del `if`**: la rama de `jsonTransport` ahora también configura el `HandlebarsAdapter`, así un `.hbs` roto se detecta corriendo los tests y no en producción.
+- [x] **Bug encontrado al extraer el factory:** `secure: smtpPort === 465` comparaba **string con number** (`ConfigService` devuelve `'465'`, porque `SMTP_PORT` es `@IsPort()` = string). El resultado era **siempre `false`**: en el puerto 465 se habría intentado conectar **sin TLS implícito**. Hoy no explota solo porque Resend usa 587. Corregido con `Number(...)` y cubierto por test.
+- [x] Tests (12 nuevos en `mailer.config.spec.ts`): fail-fast por cada una de las 5 variables, el error nombra todas las faltantes, `jsonTransport` en `development` y `test`, adapter presente en modo prueba, transporte real, `secure` solo en 465, y `replyTo` con y sin `EMAIL_REPLY_TO`.
+- [x] `.env.example` y [EMAIL_SETUP.md](../backend/tarot-app/docs/EMAIL_SETUP.md) reescritos: el doc seguía hablando de Mailtrap, de `tarotflavia.com` y de que las variables eran "opcionales" — contradecía el fail-fast.
+
+**Hallazgos aparcados que esta tarea cierra:**
+
+- [x] **`FRONTEND_URL` (venía de T-PROD-015):** tiene default, así que class-validator **nunca** la marcaba como faltante. En producción, sin ella los links de **todos** los emails salían apuntando a `localhost` sin un solo error en los logs. Ahora `validate()` ([env-validator.ts](../backend/tarot-app/src/config/env-validator.ts)) **falla el boot** en producción si no está seteada **o si apunta a localhost/127.0.0.1**.
+- [x] **`ADMIN_EMAIL_COST_ALERTS` (venía de T-PROD-016):** no estaba declarada en `env.validation.ts`, así que un typo pasaba sin ruido y las alertas de costo quedaban mudas. Declarada y validada como email.
 
 #### 🎯 Criterios de Aceptación
 
-- [ ] En `NODE_ENV=production`, arrancar sin SMTP completo **falla el boot** con un mensaje claro, en vez de simular silenciosamente que los emails se envían.
-- [ ] En dev/test, el comportamiento actual (jsonTransport + warning) se conserva intacto.
-- [ ] Las respuestas a `noreply@` aterrizan en el buzón humano.
-- [ ] Ciclo de calidad backend completo pasa (format, lint, test:cov ≥ 80%, build, validate-architecture).
+- [x] En `NODE_ENV=production`, arrancar sin SMTP completo **falla el boot** con un mensaje claro, en vez de simular silenciosamente que los emails se envían.
+- [x] En dev/test, el comportamiento actual (jsonTransport + warning) se conserva intacto.
+- [x] Las respuestas a `noreply@` aterrizan en el buzón humano (`replyTo` en los `defaults` del mailer).
+- [x] Ciclo de calidad backend completo pasa: format, lint (0 errores), **4511 tests**, coverage **84.77%**, build y `validate-architecture.js`.
+
+#### 🔬 Verificación contra el build (no solo tests)
+
+Aplicando la lección de T-PROD-015 (*"el ciclo de calidad no cubre el envío real: ts-jest corre desde
+`src/`"*), los tres caminos se ejercitaron **sobre `dist/`**, no solo en Jest:
+
+| Caso | Resultado |
+| --- | --- |
+| `NODE_ENV=production` sin SMTP | ❌ el boot **muere** (exit 1) nombrando las 5 variables faltantes |
+| `NODE_ENV=production` con `FRONTEND_URL` en localhost | ❌ el boot **muere** (exit 1) nombrando `FRONTEND_URL` |
+| `NODE_ENV=development` sin SMTP | ✅ warning + `jsonTransport`, la app sigue arrancando (sin regresión) |
+
+> ⚠️ **Acción de Ops pendiente al deployar:** setear **`EMAIL_REPLY_TO=consultas@auguriatarot.com`** en
+> Railway (opcional, pero sin ella las respuestas de los clientes caen en `noreply@`, que nadie lee).
+> Las 5 SMTP, `FRONTEND_URL` y `ADMIN_EMAIL_COST_ALERTS` ya están cargadas desde T-PROD-004 — si
+> alguna se hubiera perdido, **ahora el deploy falla en vez de callarse**, que es exactamente el punto.
 
 ---
 
@@ -966,12 +996,12 @@ Es un resto del rebrand: el mismo dominio equivocado aparece también en el `REA
 - [x] Ninguna dirección de un dominio que no sea `auguriatarot.com` queda publicada en el frontend. Verificado en el HTML prerenderizado de `/contacto` (0 ocurrencias de `auguria.com`); el único email en `src/` fuera de tests es la constante, el resto son placeholders `tu@email.com` de los formularios.
 - [x] Ciclo de calidad frontend completo pasa: format, lint (0 errores), type-check, 5291 tests, build y `validate-architecture.js`.
 
-#### 📌 Fuera de alcance (decisión del Delta — hallazgo abierto)
+#### 📌 Fuera de alcance (decisión del Delta — hallazgo derivado en **T-PROD-017**)
 
 El barrido encontró más `auguria.com` **no publicados** al usuario, que este PR **no** toca para mantenerlo Frontend puro:
 
-- 🟠 **Backend, funcional:** [geocode.service.ts](../backend/tarot-app/src/modules/birth-chart/application/services/geocode.service.ts) manda `User-Agent: Auguria/1.0 (contact@auguria.com)` a **Nominatim**, cuya política de uso exige un email de contacto **válido** para poder avisar antes de bloquear. Hoy es inexistente → merece su propia mini-tarea de backend (3 usos + 2 tests).
-- 🟡 **Placeholders y ejemplos** (sin impacto en runtime): `.env.example`, `system-config.entity.ts` (`example:` de Swagger), `docs/modules/birth-chart/*`, ADRs y `create-mp-preapproval-plan.ts`.
+- 🟠 **Backend, funcional:** [geocode.service.ts](../backend/tarot-app/src/modules/birth-chart/application/services/geocode.service.ts) manda `User-Agent: Auguria/1.0 (contact@auguria.com)` a **Nominatim**, cuya política de uso exige un email de contacto **válido** para poder avisar antes de bloquear. Hoy es inexistente → **derivado a T-PROD-017** (3 usos + 2 tests).
+- 🟡 **Placeholders y ejemplos** (sin impacto en runtime): `.env.example`, `system-config.entity.ts` (`example:` de Swagger), `docs/modules/birth-chart/*`, ADRs y `create-mp-preapproval-plan.ts`. Los dos primeros entran en **T-PROD-017**; la documentación histórica queda como está.
 
 ---
 
@@ -1121,7 +1151,8 @@ Es decir: hoy los únicos emails que la app manda de verdad son los de cuota, la
   Está declarada con default en `env.validation.ts`, así que `getOrThrow` nunca falla: si Railway no la
   tiene cargada, **los links de todos los emails salen apuntando a localhost y no se registra ningún
   error**. **Corregido** el default a `3001` y descomentada en `.env.example`. **Sigue siendo obligatoria
-  en producción** — candidata a sumarse al fail-fast de **T-PROD-012**.
+  en producción** → ✅ **cerrado en T-PROD-012**: en producción el boot falla si no está seteada o si
+  apunta a localhost.
 - 🟡 Los spies de los tests de integración corrían el envío **real** (`jest.spyOn` sin `mockResolvedValue`):
   con las credenciales de Resend descomentadas en el `.env` local, `npm run test:integration` mandaba
   mails de verdad a direcciones inexistentes (hard bounces + cuota). **Corregido.**
@@ -1201,8 +1232,79 @@ las dos mitades del aviso estaban rotas a la vez.
 
 > ⚠️ **Para que las alertas lleguen de verdad, `ADMIN_EMAIL_COST_ALERTS` debe estar seteada en
 > Railway** (se cargó durante T-PROD-004 apuntando a `consultas@auguriatarot.com`). Sin ella, el
-> servicio loguea un warning y no manda nada. Sigue sin estar declarada en `env.validation.ts`:
-> candidata a sumarse a **T-PROD-012**.
+> servicio loguea un warning y no manda nada. → ✅ **declarada y validada como email en
+> `env.validation.ts` en T-PROD-012**: ahora un typo en la dirección se detecta en el boot.
+
+---
+
+### T-PROD-017: El `User-Agent` del Geocoding Declara un Email Inexistente (Riesgo de Bloqueo Silencioso)
+
+**Prioridad:** 🟠 Alta
+**Estimación:** 0.5 punto
+**Dependencias:** ninguna — el buzón real ya existe (T-PROD-004)
+**Origen:** hallazgo abierto de T-PROD-013 (el barrido del dominio equivocado encontró usos **no publicados** al usuario que aquel PR no tocó por ser Frontend puro)
+**Tipo:** Backend (`docs/WORKFLOW_BACKEND.md`)
+
+#### 📋 Problema
+
+[geocode.service.ts](../backend/tarot-app/src/modules/birth-chart/application/services/geocode.service.ts)
+manda en **cada** llamada de geocoding el header:
+
+```
+User-Agent: Auguria/1.0 (contact@auguria.com)
+```
+
+Ese buzón **no existe** — es el mismo resto del rebrand que arregló T-PROD-013 en el frontend (el dominio
+real es `auguriatarot.com`). No es cosmético: la [política de uso de Nominatim](https://operations.osmfoundation.org/policies/nominatim/)
+exige identificar la aplicación con un **medio de contacto válido**, y ese contacto es su vía para
+avisarnos antes de bloquear. Con un email inexistente, el aviso rebota y **el bloqueo nos llega sin
+previo aviso**.
+
+El impacto es sobre la carta natal: el geocoding es lo que convierte el lugar de nacimiento en
+coordenadas + timezone. Si OSM nos corta, **no se puede generar ninguna carta natal nueva**.
+
+**3 usos del header** (2 de ellos contra Nominatim):
+
+| Línea | Destino | Nota |
+|---|---|---|
+| [:164](../backend/tarot-app/src/modules/birth-chart/application/services/geocode.service.ts#L164) | Photon (Komoot) — fuente primaria | no exige contacto, pero conviene ser consistente |
+| [:223](../backend/tarot-app/src/modules/birth-chart/application/services/geocode.service.ts#L223) | **Nominatim** — fallback de búsqueda | `// Requerido por Nominatim` |
+| [:354](../backend/tarot-app/src/modules/birth-chart/application/services/geocode.service.ts#L354) | **Nominatim** — reverse geocoding | |
+
+Además el string está **triplicado a mano**: es exactamente la forma en que este bug se volvió a filtrar.
+
+#### ✅ Tareas específicas
+
+- [ ] Extraer el `User-Agent` a una **constante única** (p. ej. `src/common/constants/contact.constants.ts`:
+      `CONTACT_EMAIL = 'consultas@auguriatarot.com'` + `GEOCODING_USER_AGENT`), espejando lo que
+      T-PROD-013 hizo en el frontend con `CONFIG.CONTACT_EMAIL`. Los 3 usos pasan a consumirla — que no
+      vuelva a divergir.
+- [ ] Reemplazar `contact@auguria.com` por **`consultas@auguriatarot.com`** (la casilla real creada en
+      T-PROD-004, que es la que efectivamente leemos).
+- [ ] Actualizar los 2 tests que fijan el string literal:
+      [geocode.service.spec.ts:155 y :616](../backend/tarot-app/src/modules/birth-chart/application/services/geocode.service.spec.ts#L155)
+      → deben aseverar **contra la constante**, no contra un literal repetido.
+- [ ] Test de regresión: ningún header saliente del geocoding contiene un dominio distinto de
+      `auguriatarot.com`.
+- [ ] **Limpieza del mismo dominio en el backend** (barato, mismo PR):
+  - [ ] `system-config.entity.ts:54` — el `example:` de Swagger publica `admin@auguria.com` en la
+        documentación de la API. Su spec (`system-config.entity.spec.ts:21,30`) usa el mismo fixture →
+        `example.com` (dominio reservado por RFC 2606), igual que se hizo con los fixtures del frontend.
+  - [ ] `.env.example` (`EMAIL_FROM=noreply@auguria.com`, `CORS_ORIGIN`, `API_URL`) → alinear con el
+        dominio real.
+
+#### 🎯 Criterios de Aceptación
+
+- [ ] `grep -r "auguria\.com" backend/tarot-app/src` (excluyendo `auguriatarot.com`) devuelve **0 resultados**.
+- [ ] El `User-Agent` que llega a Nominatim y Photon declara un buzón que **existe y leemos**.
+- [ ] El email del `User-Agent` está definido en **un solo lugar** del backend.
+- [ ] Ciclo de calidad backend completo pasa: format, lint, `test:cov` (≥80%), build y `validate-architecture.js`.
+
+#### 📌 Fuera de alcance
+
+Quedan `auguria.com` en **documentación histórica** (ADRs, `docs/modules/birth-chart/*`,
+`FEEDBACK_CA_001_*`) y en `scripts/create-mp-preapproval-plan.ts` (URL de ejemplo). No afectan runtime ni
+nada publicado al usuario; corregirlos reescribiría documentos que registran decisiones ya tomadas.
 
 ---
 
@@ -1219,7 +1321,8 @@ las dos mitades del aviso estaban rotas a la vez.
 9. **T-PROD-013** (dirección de contacto rota) — independiente de todo y trivial; puede salir **ya**, sin esperar al email. Es una dirección rota de cara al público.
 10. **T-PROD-015** (reset de contraseña) — 🔴 **inmediatamente después de T-PROD-004**. Es el consumidor que justifica todo el trabajo de email: sin esto, el SMTP anda pero ningún usuario puede recuperar su cuenta. **No se lanza sin esta tarea.**
 11. **T-PROD-014** (formulario de contacto que sí envía) — también después de T-PROD-004, pero puede esperar a 015.
+12. **T-PROD-017** (`User-Agent` del geocoding con email inexistente) — independiente de todo y acotado, como lo fue T-PROD-013. Puede salir en cualquier momento; conviene **antes del lanzamiento**, porque el riesgo que cubre (que OSM nos bloquee sin poder avisarnos) se materializa justamente cuando sube el tráfico real.
 
 ---
 
-**Nota:** las tareas de código (T-PROD-002/005/006/007/008/010/011/012/013/014 y las partes PR de 003/009) siguen el workflow correspondiente (`WORKFLOW_FRONTEND.md` / `WORKFLOW_BACKEND.md`): TDD, ciclo de calidad completo, PR a `develop`, y actualización de este backlog al completar cada una.
+**Nota:** las tareas de código (T-PROD-002/005/006/007/008/010/011/012/013/014/017 y las partes PR de 003/009) siguen el workflow correspondiente (`WORKFLOW_FRONTEND.md` / `WORKFLOW_BACKEND.md`): TDD, ciclo de calidad completo, PR a `develop`, y actualización de este backlog al completar cada una.

--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -936,7 +936,7 @@ Segundo problema, menor: el módulo no setea `replyTo`. Si un cliente le respond
 - [x] `defaults: { from, replyTo: EMAIL_REPLY_TO ?? from }` y `EMAIL_REPLY_TO` declarada en `env.validation.ts` con el mismo `@Matches` de email que `EMAIL_FROM`. Valor productivo: `consultas@auguriatarot.com`.
 - [x] Bloque `template` **fuera del `if`**: la rama de `jsonTransport` ahora también configura el `HandlebarsAdapter`, así un `.hbs` roto se detecta corriendo los tests y no en producción.
 - [x] **Bug encontrado al extraer el factory:** `secure: smtpPort === 465` comparaba **string con number** (`ConfigService` devuelve `'465'`, porque `SMTP_PORT` es `@IsPort()` = string). El resultado era **siempre `false`**: en el puerto 465 se habría intentado conectar **sin TLS implícito**. Hoy no explota solo porque Resend usa 587. Corregido con `Number(...)` y cubierto por test.
-- [x] Tests (12 nuevos en `mailer.config.spec.ts`): fail-fast por cada una de las 5 variables, el error nombra todas las faltantes, `jsonTransport` en `development` y `test`, adapter presente en modo prueba, transporte real, `secure` solo en 465, y `replyTo` con y sin `EMAIL_REPLY_TO`.
+- [x] Tests: fail-fast por cada una de las 5 variables, el error nombra todas las faltantes, `jsonTransport` en `development` y `test`, transporte real, `secure` solo en 465, y `replyTo` con y sin `EMAIL_REPLY_TO`. **+27 tests** en total sobre la suite (4511 → 4538).
 - [x] `.env.example` y [EMAIL_SETUP.md](../backend/tarot-app/docs/EMAIL_SETUP.md) reescritos: el doc seguía hablando de Mailtrap, de `tarotflavia.com` y de que las variables eran "opcionales" — contradecía el fail-fast.
 
 **Hallazgos aparcados que esta tarea cierra:**
@@ -951,15 +951,51 @@ Segundo problema, menor: el módulo no setea `replyTo`. Si un cliente le respond
 - [x] Las respuestas a `noreply@` aterrizan en el buzón humano (`replyTo` en los `defaults` del mailer).
 - [x] Ciclo de calidad backend completo pasa: format, lint (0 errores), **4511 tests**, coverage **84.77%**, build y `validate-architecture.js`.
 
+#### 🔍 Ronda de revisión (hallazgos aplicados en un 2º commit)
+
+El revisor encontró **tres cosas importantes** que el primer commit tenía mal. Todas verificadas y
+corregidas con TDD (test primero, en rojo, antes del fix):
+
+- [x] 🟠 **`EMAIL_REPLY_TO=""` tumbaba el boot en TODOS los entornos.** `@IsOptional()` de
+      class-validator saltea `undefined` pero **no** el string vacío, así que dejar la variable
+      vacía —la forma habitual de desactivarla, y la que el propio `.env.example` promueve para
+      otras— hacía fallar el `@Matches`. Era una **regresión** introducida por esta misma tarea.
+      Corregido con el `@Transform` que ya protegía a `SMTP_PORT`. Ídem `ADMIN_EMAIL_COST_ALERTS`.
+- [x] 🟠 **`FRONTEND_URL` sin esquema pasaba el guard.** Se validaba "no vacía" y "no localhost",
+      pero no el formato: con `FRONTEND_URL=www.auguriatarot.com` el boot pasaba y los links de los
+      emails salían **rotos, sin un solo error en los logs** — el mismo modo de falla que la tarea
+      vino a matar, un escalón más abajo. Ahora se **parsea** con `new URL()` y se compara el
+      `hostname` (de paso desaparece el falso positivo de `includes('localhost')`, que habría
+      rechazado un host legítimo como `localhost.auguriatarot.com`).
+- [x] 🟠 **La red de seguridad sobre los `.hbs` no existía.** El código, el doc y este backlog
+      afirmaban que sacar el `template` del `if` hacía que *"un `.hbs` roto se detecte corriendo los
+      tests"*. **Era falso**: ningún test renderizaba una plantilla (el `MailerService` está
+      mockeado en todos). Ahora [email-templates.spec.ts](../backend/tarot-app/src/modules/email/email-templates.spec.ts)
+      monta el `MailerModule` **real** con `jsonTransport` y **renderiza los 8 templates** con el
+      contexto que les pasa `EmailService`; con `strict: true`, una variable faltante rompe el test.
+      **Este test sí habría detectado el `dist/` sin plantillas de T-PROD-015.**
+- [x] 🟡 **El fail-fast corría demasiado tarde.** Vivía en el `useFactory` del `MailerModule`, que se
+      instancia **después** de que `TypeOrmModule` conecta y corre las migraciones
+      (`migrationsRun: true`): un deploy con SMTP incompleto **habría migrado la base y recién
+      después muerto**. Movido a `validate()` ([env-validator.ts](../backend/tarot-app/src/config/env-validator.ts)),
+      que corre en `ConfigModule.forRoot`, **antes de tocar la DB**, y ahora reporta **todas** las
+      variables faltantes en un solo error (Ops ya no descubre una por deploy). El throw del factory
+      se conserva como red de seguridad: el `EmailModule` se monta standalone en los e2e, sin esa
+      validación.
+- [x] 🟡 Aserción tautológica (`expect(adapter).toBeDefined()` sobre una constante de módulo) →
+      `toBeInstanceOf(HandlebarsAdapter)` + chequeo del `dir`.
+- [x] 💡 Guard de `NaN` en `SMTP_PORT` y `replyTo` también en los defaults de `jsonTransport`.
+
 #### 🔬 Verificación contra el build (no solo tests)
 
 Aplicando la lección de T-PROD-015 (*"el ciclo de calidad no cubre el envío real: ts-jest corre desde
-`src/`"*), los tres caminos se ejercitaron **sobre `dist/`**, no solo en Jest:
+`src/`"*), los caminos se ejercitaron **sobre `dist/`**, no solo en Jest:
 
 | Caso | Resultado |
 | --- | --- |
 | `NODE_ENV=production` sin SMTP | ❌ el boot **muere** (exit 1) nombrando las 5 variables faltantes |
-| `NODE_ENV=production` con `FRONTEND_URL` en localhost | ❌ el boot **muere** (exit 1) nombrando `FRONTEND_URL` |
+| `NODE_ENV=production` con `FRONTEND_URL` en localhost o sin esquema | ❌ el boot **muere** (exit 1) nombrando `FRONTEND_URL` |
+| `NODE_ENV=production` con ambos problemas | ❌ **un solo error con todo**, y **sin llegar a conectar la base** |
 | `NODE_ENV=development` sin SMTP | ✅ warning + `jsonTransport`, la app sigue arrancando (sin regresión) |
 
 > ⚠️ **Acción de Ops pendiente al deployar:** setear **`EMAIL_REPLY_TO=consultas@auguriatarot.com`** en
@@ -1290,8 +1326,8 @@ Además el string está **triplicado a mano**: es exactamente la forma en que es
   - [ ] `system-config.entity.ts:54` — el `example:` de Swagger publica `admin@auguria.com` en la
         documentación de la API. Su spec (`system-config.entity.spec.ts:21,30`) usa el mismo fixture →
         `example.com` (dominio reservado por RFC 2606), igual que se hizo con los fixtures del frontend.
-  - [ ] `.env.example` (`EMAIL_FROM=noreply@auguria.com`, `CORS_ORIGIN`, `API_URL`) → alinear con el
-        dominio real.
+  - [ ] `.env.example`: quedan `CORS_ORIGIN` (línea 187) y `API_URL` (línea 258) → alinear con el
+        dominio real. *(El `EMAIL_FROM` ya lo corrigió T-PROD-012 al reescribir el bloque de email.)*
 
 #### 🎯 Criterios de Aceptación
 


### PR DESCRIPTION
## 🎯 T-PROD-012 — Fail-Fast de SMTP en Producción + Reply-To

Una variable de email mal cargada en Railway **no rompía nada**: apagaba los emails **en silencio**. La app arrancaba perfecta, escribía un `logger.warn` que nadie lee, y ningún usuario recibía su reset de contraseña. El bug era invisible hasta que un cliente reclamaba.

Este PR cierra los **tres agujeros que compartían esa forma de fallar**.

## 🔧 Cambios

### Fail-fast de SMTP
- El `useFactory` del `MailerModule` se extrae a **`mailer.config.ts`** (`createMailerOptions`): inline dentro del decorador era **imposible de testear**. `email.module.ts` queda en 17 líneas.
- En **producción**, una config SMTP incompleta **detiene el boot** con un error que **nombra las variables faltantes**, en vez de caer a `jsonTransport`.
- Fuera de producción se **conserva intacto** el fallback a `jsonTransport` + warning (los tests y el dev local dependen de él).

### Reply-To
- `defaults: { from, replyTo: EMAIL_REPLY_TO ?? from }`. El remitente es `noreply@`, pero mucha gente **responde igual**: hasta ahora esas respuestas se perdían. Ahora aterrizan en el buzón humano.

### Template fuera del `if`
- El `HandlebarsAdapter` ahora se configura **también** en modo `jsonTransport`, así una plantilla `.hbs` rota se detecta **corriendo los tests** y no en producción.

### 🐛 Bug encontrado al extraer el factory
`secure: smtpPort === 465` comparaba **string con number** (`ConfigService` devuelve `'465'`, porque `SMTP_PORT` es `@IsPort()` = string), así que el resultado era **siempre `false`**: en el puerto 465 se habría intentado conectar **sin TLS implícito**. Hoy no explota solo porque Resend usa 587. Corregido y cubierto por test.

### 📌 Hallazgos aparcados que este PR cierra
- **`FRONTEND_URL`** (venía de T-PROD-015): tiene default, así que class-validator **nunca** la marcaba como faltante. Sin ella en producción, los links de **todos** los emails salían a `localhost` sin un solo error en los logs. Ahora el boot **falla** si no está seteada **o si apunta a localhost/127.0.0.1**.
- **`ADMIN_EMAIL_COST_ALERTS`** (venía de T-PROD-016): no estaba declarada en `env.validation.ts`; un typo dejaba **mudas** las alertas de costo. Declarada y validada como email.

### 📄 Documentación
- `.env.example` y **`EMAIL_SETUP.md`** reescritos: el doc todavía hablaba de **Mailtrap**, de **`tarotflavia.com`** y de que las variables de email eran *"opcionales"* — contradecía frontalmente el fail-fast.

## 🧪 Tests

**12 tests nuevos** en `mailer.config.spec.ts` + 8 en `env-validator.spec.ts`: fail-fast por cada una de las 5 variables SMTP, el error nombra **todas** las faltantes, `jsonTransport` en `development` y `test`, adapter presente en modo prueba, transporte real, `secure` solo en 465, `replyTo` con y sin `EMAIL_REPLY_TO`, y los guards de `FRONTEND_URL` y `ADMIN_EMAIL_COST_ALERTS`.

### 🔬 Verificación contra el build (no solo Jest)

Aplicando la lección de T-PROD-015 (*"el ciclo de calidad no cubre el envío real: ts-jest corre desde `src/`"*), los tres caminos se ejercitaron **sobre `dist/`**:

| Caso | Resultado |
| --- | --- |
| `NODE_ENV=production` sin SMTP | ❌ el boot **muere** (exit 1) nombrando las 5 variables |
| `NODE_ENV=production` con `FRONTEND_URL` en localhost | ❌ el boot **muere** (exit 1) nombrando `FRONTEND_URL` |
| `NODE_ENV=development` sin SMTP | ✅ warning + `jsonTransport`, la app arranca (sin regresión) |

## ✅ Ciclo de calidad

- [x] `npm run format`
- [x] `npm run lint` — 0 errores
- [x] `npm run test:cov` — **4511 tests**, coverage **84.77%** (≥ 80%)
- [x] `npm run build`
- [x] `node scripts/validate-architecture.js`
- [x] Sin `any`, sin `eslint-disable`, sin `@ts-ignore`
- [x] Backlog actualizado

## ⚠️ Acción de Ops al deployar

Setear **`EMAIL_REPLY_TO=consultas@auguriatarot.com`** en Railway (opcional, pero sin ella las respuestas de los clientes caen en `noreply@`, que nadie lee). Las 5 SMTP, `FRONTEND_URL` y `ADMIN_EMAIL_COST_ALERTS` ya están cargadas desde T-PROD-004 — si alguna se hubiera perdido, **ahora el deploy falla en vez de callarse**, que es exactamente el punto.

## 📋 Nota

El commit incluye además la redacción de **T-PROD-017** en el backlog (el `User-Agent` del geocoding declara un email inexistente a Nominatim), hallazgo derivado de T-PROD-013. Es solo documentación, no toca código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)