### PR TITLE
feat(contact): el formulario de contacto ahora envía de verdad (T-PROD-014)

### DIFF
--- a/backend/tarot-app/.env.example
+++ b/backend/tarot-app/.env.example
@@ -197,6 +197,14 @@ RATE_LIMIT_TTL=60
 # Maximum requests per time window (Default: 100)
 RATE_LIMIT_MAX=100
 
+# Number of trusted proxies in front of the app (Default: 1 — Railway's edge).
+# It decides where request.ip comes from, i.e. the IP EVERY rate limit is counted against.
+#   - Too low  -> a client can spoof X-Forwarded-For and slip past every rate limit.
+#   - Too high -> request.ip becomes the proxy's IP (the same for everyone) and the app
+#                 starts 429-ing real users.
+# Set it to the real chain: no proxy = 0, Railway = 1, Cloudflare in front of Railway = 2.
+# TRUST_PROXY_HOPS=1
+
 # -----------------------------------------------------------------------------
 # Email Configuration
 # -----------------------------------------------------------------------------

--- a/backend/tarot-app/.env.example
+++ b/backend/tarot-app/.env.example
@@ -232,6 +232,12 @@ RATE_LIMIT_MAX=100
 # If unset, the alerts are skipped with a warning: if the spend spikes, nobody finds out.
 # ADMIN_EMAIL_COST_ALERTS=consultas@auguriatarot.com
 
+# Mailbox that receives the messages sent from the public contact form (T-PROD-014).
+# MANDATORY in production: the boot FAILS without it, because every message a client
+# sends would otherwise go nowhere. In development it falls back to EMAIL_REPLY_TO /
+# EMAIL_FROM and the mailer just logs the email to the console.
+# CONTACT_EMAIL_TO=consultas@auguriatarot.com
+
 # Frontend URL for password reset links and back_url de MercadoPago.
 # OBLIGATORIA en producción, y no puede apuntar a localhost: el boot falla si no lo está.
 # Antes caía al default en silencio y los links de todos los emails salían a localhost.

--- a/backend/tarot-app/docs/API_DOCUMENTATION.md
+++ b/backend/tarot-app/docs/API_DOCUMENTATION.md
@@ -14,6 +14,7 @@
   - [Tiradas (Spreads)](#tiradas-spreads)
   - [Categorías](#categorías)
   - [Preguntas Predefinidas](#preguntas-predefinidas)
+  - [Contacto](#contacto)
   - [Lectura Diaria](#lectura-diaria)
   - [Tarotistas Públicos](#tarotistas-públicos)
   - [Scheduling (Programación de Sesiones)](#scheduling-programación-de-sesiones)
@@ -1053,6 +1054,48 @@ GET /api/predefined-questions?categoryId=1&activeOnly=true
   }
 ]
 ```
+
+---
+
+### Contacto
+
+#### ✉️ Enviar Mensaje del Formulario de Contacto
+
+```http
+POST /api/contact
+Content-Type: application/json
+```
+
+Endpoint **público** (no requiere JWT): lo usa el formulario de `/contacto` del frontend. El
+mensaje se envía por email al buzón de `CONTACT_EMAIL_TO` con el **Reply-To apuntando al email
+del remitente**, así responderlo desde el buzón le contesta directamente al cliente.
+
+**Rate limit:** 3 mensajes/hora por IP (endpoint público sin auth). Pasado el límite: `429`.
+
+**Body:**
+
+```json
+{
+  "name": "Ana Pérez",
+  "email": "ana@example.com",
+  "subject": "Consulta por una lectura",
+  "message": "Hola, quería saber cómo reservar una sesión."
+}
+```
+
+**Validaciones:** `name` 2-100 · `email` válido · `subject` 5-200 y **sin saltos de línea**
+(viaja a una cabecera del email) · `message` 10-2000.
+
+**Response: `200 OK`**
+
+```json
+{
+  "message": "Mensaje enviado exitosamente. Te responderemos a la brevedad."
+}
+```
+
+**Errores:** `400` datos inválidos · `429` límite de envíos excedido · `500` el email no pudo
+enviarse. El endpoint **no** simula éxito si el envío falla.
 
 ---
 

--- a/backend/tarot-app/src/app.module.ts
+++ b/backend/tarot-app/src/app.module.ts
@@ -21,6 +21,7 @@ import { PredefinedQuestionsModule } from './modules/predefined-questions/predef
 import { HealthModule } from './modules/health/health.module';
 import { UsageLimitsModule } from './modules/usage-limits/usage-limits.module';
 import { EmailModule } from './modules/email/email.module';
+import { ContactModule } from './modules/contact/contact.module';
 import { TarotistasModule } from './modules/tarotistas/tarotistas.module';
 import { SubscriptionsModule } from './modules/subscriptions/subscriptions.module';
 import { CacheModule as InterpretationCacheModule } from './modules/cache/cache.module';
@@ -115,6 +116,7 @@ import { validate } from './config/env-validator';
     HealthModule,
     UsageLimitsModule,
     EmailModule,
+    ContactModule,
     RateLimitingModule,
   ],
   controllers: [AppController],

--- a/backend/tarot-app/src/common/guards/custom-throttler.guard.spec.ts
+++ b/backend/tarot-app/src/common/guards/custom-throttler.guard.spec.ts
@@ -210,16 +210,20 @@ describe('CustomThrottlerGuard', () => {
       });
     });
 
-    describe('x-forwarded-for header handling', () => {
-      it('should extract first IP from x-forwarded-for header', async () => {
+    // T-PROD-014: el guard ya NO parsea el x-forwarded-for a mano. La IP la resuelve
+    // Express con `trust proxy` (ver trust-proxy.config.ts) y llega en `request.ip`.
+    describe('resolución de la IP (x-forwarded-for)', () => {
+      it('ignora el x-forwarded-for crudo y usa la IP que resolvió Express: el primer valor del header lo escribe el cliente, y tomarlo permitía rotarlo y saltarse TODOS los límites', async () => {
         ipWhitelistService.isWhitelisted.mockReturnValue(false);
         ipBlockingService.isBlocked.mockReturnValue(false);
 
         const context = {
           switchToHttp: () => ({
             getRequest: () => ({
-              ip: '127.0.0.1',
+              // Lo que Express calculó descartando los saltos confiables:
+              ip: '198.51.100.1',
               headers: {
+                // Lo que el cliente inventó (va primero en la cadena):
                 'x-forwarded-for': '203.0.113.1, 198.51.100.1',
               },
               user: undefined,
@@ -230,26 +234,28 @@ describe('CustomThrottlerGuard', () => {
           getClass: () => ({}),
         } as unknown as ExecutionContext;
 
-        // The guard should extract 203.0.113.1 from x-forwarded-for
         await guard.canActivate(context).catch(() => {
-          // Ignore rate limit errors, we're testing IP extraction
+          // Los errores de rate limit no importan acá: se testea la resolución de IP.
         });
 
-        // Verify that the guard checked for blocking using the extracted IP
-        expect(ipBlockingService.isBlocked).toHaveBeenCalled();
+        expect(ipBlockingService.isBlocked).toHaveBeenCalledWith(
+          '198.51.100.1',
+        );
+        expect(ipBlockingService.isBlocked).not.toHaveBeenCalledWith(
+          '203.0.113.1',
+        );
       });
 
-      it('should handle x-forwarded-for with spaces', async () => {
+      it('cae al socket si Express no resolvió una IP', async () => {
         ipWhitelistService.isWhitelisted.mockReturnValue(false);
         ipBlockingService.isBlocked.mockReturnValue(false);
 
         const context = {
           switchToHttp: () => ({
             getRequest: () => ({
-              ip: '127.0.0.1',
-              headers: {
-                'x-forwarded-for': '  203.0.113.1  ,  198.51.100.1  ',
-              },
+              ip: undefined,
+              socket: { remoteAddress: '192.168.1.50' },
+              headers: {},
               user: undefined,
             }),
           }),
@@ -262,7 +268,9 @@ describe('CustomThrottlerGuard', () => {
           // Ignore errors
         });
 
-        expect(ipBlockingService.isBlocked).toHaveBeenCalled();
+        expect(ipBlockingService.isBlocked).toHaveBeenCalledWith(
+          '192.168.1.50',
+        );
       });
 
       it('should fallback to request.ip when x-forwarded-for is empty', async () => {

--- a/backend/tarot-app/src/common/guards/custom-throttler.guard.ts
+++ b/backend/tarot-app/src/common/guards/custom-throttler.guard.ts
@@ -157,14 +157,19 @@ export class CustomThrottlerGuard extends ThrottlerGuard {
     });
   }
 
+  /**
+   * IP contra la que se cuentan los límites (y los bloqueos).
+   *
+   * Usa `request.ip`, que **Express** calcula con `trust proxy` (ver `trust-proxy.config`):
+   * descarta los saltos confiables del `X-Forwarded-For` y devuelve la IP real del cliente.
+   *
+   * ⚠️ NO volver a parsear el header a mano. Antes se tomaba su **primer** elemento, que es
+   * justamente el que escribe el cliente: mandando `X-Forwarded-For: 1.2.3.<random>` en cada
+   * request se obtenía un tracker distinto cada vez y **ningún límite se disparaba nunca** —
+   * ni el de login, ni el de registro, ni el del formulario de contacto, que es un endpoint
+   * público que además gasta cuota de SMTP (T-PROD-014).
+   */
   private getIP(request: Request): string {
-    // x-forwarded-for can contain multiple IPs (comma-separated)
-    // Extract and sanitize the first IP (client's real IP)
-    const forwarded = request.headers?.['x-forwarded-for'] as string;
-    if (forwarded) {
-      const ip = forwarded.split(',')[0].trim();
-      return ip || request.ip || 'unknown';
-    }
-    return request.ip || 'unknown';
+    return request.ip || request.socket?.remoteAddress || 'unknown';
   }
 }

--- a/backend/tarot-app/src/config/env-validator.spec.ts
+++ b/backend/tarot-app/src/config/env-validator.spec.ts
@@ -104,6 +104,9 @@ describe('env-validator', () => {
       SMTP_USER: 'resend',
       SMTP_PASS: 're_test_key',
       EMAIL_FROM: 'noreply@auguriatarot.com',
+      // Obligatoria en producción desde T-PROD-014: sin ella los mensajes del
+      // formulario de contacto no tendrían buzón al que llegar.
+      CONTACT_EMAIL_TO: 'consultas@auguriatarot.com',
     };
 
     const result = validate(config);
@@ -160,6 +163,7 @@ describe('env-validator', () => {
       SMTP_PASS: 're_test_key',
       EMAIL_FROM: 'noreply@auguriatarot.com',
       FRONTEND_URL: 'https://auguriatarot.com',
+      CONTACT_EMAIL_TO: 'consultas@auguriatarot.com',
     });
 
     it('una config productiva completa arranca sin quejas', () => {
@@ -222,6 +226,42 @@ describe('env-validator', () => {
 
         expect(() => validate(config)).not.toThrow();
         expect(validate(config).ADMIN_EMAIL_COST_ALERTS).toBeUndefined();
+      });
+    });
+
+    describe('CONTACT_EMAIL_TO (T-PROD-014)', () => {
+      it('acepta una dirección válida', () => {
+        const config = {
+          ...baseConfig(),
+          CONTACT_EMAIL_TO: 'consultas@auguriatarot.com',
+        };
+
+        expect(validate(config).CONTACT_EMAIL_TO).toBe(
+          'consultas@auguriatarot.com',
+        );
+      });
+
+      it('rechaza una dirección inválida: un typo mandaría cada mensaje de contacto a la nada', () => {
+        const config = { ...baseConfig(), CONTACT_EMAIL_TO: 'consultas@' };
+
+        expect(() => validate(config)).toThrow('CONTACT_EMAIL_TO');
+      });
+
+      it('falla el boot en producción si falta: los mensajes de los clientes se perderían, que es exactamente el bug que arregla esta tarea', () => {
+        const config = productionConfig();
+        delete config.CONTACT_EMAIL_TO;
+
+        expect(() => validate(config)).toThrow(/CONTACT_EMAIL_TO/);
+      });
+
+      it('falla el boot en producción si está vacía (el string vacío no es un buzón)', () => {
+        const config = { ...productionConfig(), CONTACT_EMAIL_TO: '' };
+
+        expect(() => validate(config)).toThrow(/CONTACT_EMAIL_TO/);
+      });
+
+      it('fuera de producción es opcional: el dev cae a EMAIL_REPLY_TO / EMAIL_FROM y el mailer loguea en consola', () => {
+        expect(() => validate(baseConfig())).not.toThrow();
       });
     });
 

--- a/backend/tarot-app/src/config/env-validator.ts
+++ b/backend/tarot-app/src/config/env-validator.ts
@@ -87,6 +87,15 @@ function validateProductionOnlyVariables(
     errors.push(frontendUrlError);
   }
 
+  // El string vacío tampoco es un buzón: `@Transform` ya lo convirtió en undefined.
+  if (!validatedConfig.CONTACT_EMAIL_TO) {
+    errors.push(
+      `CONTACT_EMAIL_TO: must be set to the mailbox that receives the contact form messages (not set).\n` +
+        `  Without it, every message a client sends from /contacto would go nowhere (T-PROD-014).\n` +
+        `  Example: consultas@auguriatarot.com`,
+    );
+  }
+
   if (errors.length > 0) {
     throw new Error(
       `❌ Environment variable validation failed (production):\n\n${errors.join('\n\n')}\n\n` +

--- a/backend/tarot-app/src/config/env.validation.ts
+++ b/backend/tarot-app/src/config/env.validation.ts
@@ -273,6 +273,24 @@ export class EnvironmentVariables {
   ADMIN_EMAIL_COST_ALERTS?: string;
 
   /**
+   * Buzón que recibe los mensajes del formulario de contacto (T-PROD-014).
+   *
+   * ⚠️ OBLIGATORIA en producción: el boot falla si falta (ver `validate()` en
+   * `env-validator.ts`). Sin destinatario, cada mensaje de un cliente se perdería —
+   * que es exactamente el bug que arregla la tarea.
+   *
+   * Fuera de producción es opcional: `EmailService` cae a `EMAIL_REPLY_TO` /
+   * `EMAIL_FROM` y el mailer loguea el mail en consola (jsonTransport).
+   */
+  @IsString()
+  @IsOptional()
+  @Transform(({ value }) => (value ? String(value) : undefined))
+  @Matches(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, {
+    message: 'CONTACT_EMAIL_TO must be a valid email address',
+  })
+  CONTACT_EMAIL_TO?: string;
+
+  /**
    * URL del frontend. La usan los links de los emails (reset de contraseña, bienvenida)
    * y las back_urls de MercadoPago.
    *

--- a/backend/tarot-app/src/config/env.validation.ts
+++ b/backend/tarot-app/src/config/env.validation.ts
@@ -210,6 +210,24 @@ export class EnvironmentVariables {
   @Transform(({ value }) => (value ? Number(value) : 100))
   RATE_LIMIT_MAX: number = 100;
 
+  /**
+   * Proxies confiables delante de la app (Railway: 1; sin proxy: 0). Define de dónde sale
+   * `request.ip`, o sea la IP contra la que se cuenta **todo** el rate limiting.
+   *
+   * Con el valor equivocado el daño es real en las dos direcciones: demasiado bajo y un
+   * cliente puede falsear su IP y saltarse los límites (era el agujero que arregla
+   * T-PROD-014); demasiado alto y `request.ip` pasa a ser la IP del proxy —la misma para
+   * todos— y la app empieza a devolver 429 a usuarios reales. Ver `trust-proxy.config.ts`.
+   */
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  @Type(() => Number)
+  @Transform(({ value }) =>
+    value === undefined || value === '' ? 1 : Number(value),
+  )
+  TRUST_PROXY_HOPS: number = 1;
+
   // =============================================================================
   // EMAIL CONFIGURATION (OPTIONAL)
   // =============================================================================

--- a/backend/tarot-app/src/config/trust-proxy.config.spec.ts
+++ b/backend/tarot-app/src/config/trust-proxy.config.spec.ts
@@ -1,0 +1,60 @@
+import { Logger } from '@nestjs/common';
+import {
+  DEFAULT_TRUST_PROXY_HOPS,
+  configureTrustProxy,
+  resolveTrustProxyHops,
+} from './trust-proxy.config';
+
+describe('trust-proxy.config (T-PROD-014)', () => {
+  describe('resolveTrustProxyHops', () => {
+    it.each([undefined, null, ''])(
+      'sin valor (%p) usa el default de Railway (1 salto)',
+      (rawValue) => {
+        expect(resolveTrustProxyHops(rawValue as undefined)).toBe(
+          DEFAULT_TRUST_PROXY_HOPS,
+        );
+        expect(DEFAULT_TRUST_PROXY_HOPS).toBe(1);
+      },
+    );
+
+    it.each([
+      ['0', 0], // sin proxy delante (dev)
+      ['1', 1], // Railway
+      ['2', 2], // un CDN delante de Railway
+      [3, 3],
+    ])('acepta %p y lo resuelve a %i saltos', (rawValue, expected) => {
+      expect(resolveTrustProxyHops(rawValue)).toBe(expected);
+    });
+
+    it.each(['-1', '1.5', 'dos', 'true'])(
+      'rechaza %p: un valor inválido dejaría el rate limiting mal calibrado sin que nadie se entere',
+      (rawValue) => {
+        expect(() => resolveTrustProxyHops(rawValue)).toThrow(
+          /TRUST_PROXY_HOPS/,
+        );
+      },
+    );
+  });
+
+  describe('configureTrustProxy', () => {
+    it('aplica el valor a Express: sin `trust proxy`, request.ip es la IP del proxy y el límite se cuenta para todos juntos', () => {
+      const set = jest.fn();
+
+      const hops = configureTrustProxy({ set }, '2');
+
+      expect(set).toHaveBeenCalledWith('trust proxy', 2);
+      expect(hops).toBe(2);
+    });
+
+    it('deja el valor en el log del arranque: es el primer número a mirar si el rate limiting se comporta raro en producción', () => {
+      const set = jest.fn();
+      const logger = { log: jest.fn() } as unknown as Logger;
+
+      configureTrustProxy({ set }, '1', logger);
+
+      expect(logger.log).toHaveBeenCalledWith(
+        expect.stringContaining('trust proxy = 1'),
+      );
+    });
+  });
+});

--- a/backend/tarot-app/src/config/trust-proxy.config.ts
+++ b/backend/tarot-app/src/config/trust-proxy.config.ts
@@ -1,0 +1,71 @@
+import { Logger } from '@nestjs/common';
+
+/**
+ * Cantidad de proxies confiables delante de la app. En Railway hay uno (su edge), que es
+ * el que agrega la IP real del cliente al `X-Forwarded-For`.
+ */
+export const DEFAULT_TRUST_PROXY_HOPS = 1;
+
+/**
+ * Traduce `TRUST_PROXY_HOPS` al valor de `trust proxy` de Express.
+ *
+ * **Por qué existe esta variable** (T-PROD-014): `X-Forwarded-For` se va apilando, y el
+ * primer elemento lo escribe *el cliente*. Antes el rate limiting leía justamente ese
+ * primero, así que rotarlo (`X-Forwarded-For: 1.2.3.<random>`) daba un tracker nuevo en
+ * cada request y el límite —la única defensa de los endpoints públicos, incluido el
+ * formulario de contacto— no llegaba a dispararse nunca.
+ *
+ * Con `trust proxy = n`, Express descarta los `n` saltos confiables (los más cercanos a
+ * la app) y `request.ip` queda en la IP real del cliente, ignorando lo que este haya
+ * inventado. El número **tiene que coincidir con la cadena de proxies real**:
+ *
+ * - Demasiado bajo → el atacante vuelve a poder falsear su IP.
+ * - Demasiado alto → `request.ip` termina siendo la IP de un proxy, la misma para todo el
+ *   mundo: todos los usuarios caen en el mismo bucket y la app empieza a devolver 429 a
+ *   gente real.
+ *
+ * Por eso es configurable por entorno: si mañana se agrega un CDN (Cloudflare delante de
+ * Railway ⇒ 2), Ops lo ajusta sin tocar código.
+ *
+ * @returns el número de saltos confiables (≥ 0).
+ */
+export function resolveTrustProxyHops(rawValue?: string | number): number {
+  if (rawValue === undefined || rawValue === null || rawValue === '') {
+    return DEFAULT_TRUST_PROXY_HOPS;
+  }
+
+  const hops = Number(rawValue);
+
+  if (!Number.isInteger(hops) || hops < 0) {
+    throw new Error(
+      `❌ TRUST_PROXY_HOPS must be a non-negative integer (got: ${String(rawValue)}).\n` +
+        `  It is the number of trusted proxies in front of the app (Railway: 1, no proxy: 0).\n` +
+        `  A wrong value either lets clients spoof their IP past the rate limit, or collapses ` +
+        `every user into a single bucket and 429s real traffic.`,
+    );
+  }
+
+  return hops;
+}
+
+/**
+ * Aplica `trust proxy` a la app de Express y deja el valor en el log del arranque: si el
+ * rate limiting se comporta raro en producción, este es el primer número a mirar.
+ */
+export function configureTrustProxy(
+  app: { set: (key: string, value: unknown) => unknown },
+  rawValue?: string | number,
+  logger: Logger = new Logger('TrustProxy'),
+): number {
+  const hops = resolveTrustProxyHops(rawValue);
+
+  app.set('trust proxy', hops);
+
+  logger.log(
+    hops === 0
+      ? 'trust proxy = 0: no proxy in front. request.ip is the socket address and X-Forwarded-For is ignored.'
+      : `trust proxy = ${hops}: the last ${hops} hop(s) of X-Forwarded-For are trusted; anything the client puts before them is ignored for rate limiting.`,
+  );
+
+  return hops;
+}

--- a/backend/tarot-app/src/main.ts
+++ b/backend/tarot-app/src/main.ts
@@ -1,7 +1,9 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { configureTrustProxy } from './config/trust-proxy.config';
 import { LoggerService } from './common/logger/logger.service';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -31,7 +33,12 @@ async function bootstrap() {
     console.log(`Password exists: ${Boolean(process.env.POSTGRES_PASSWORD)}`);
   }
 
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
+  // Sin esto, `request.ip` es la IP del proxy y el rate limiting leía el primer valor
+  // del `X-Forwarded-For`, que lo escribe el cliente: rotarlo salteaba todos los límites
+  // (T-PROD-014). El número de saltos confiables es configurable: ver trust-proxy.config.
+  configureTrustProxy(app, process.env.TRUST_PROXY_HOPS);
 
   // Set global API prefix for versioning
   app.setGlobalPrefix('api/v1');

--- a/backend/tarot-app/src/modules/contact/application/dto/send-contact-message.dto.ts
+++ b/backend/tarot-app/src/modules/contact/application/dto/send-contact-message.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsString, Length, Matches } from 'class-validator';
+
+/**
+ * Mensaje del formulario de contacto público (T-PROD-014).
+ *
+ * Los límites espejan el schema Zod del frontend
+ * (`frontend/src/lib/validations/contact.schemas.ts`): si divergen, el usuario ve un
+ * formulario válido y el backend le devuelve un 400 que no puede explicarse.
+ */
+export class SendContactMessageDto {
+  @ApiProperty({ example: 'Ana Pérez', minLength: 2, maxLength: 100 })
+  @IsString({ message: 'El nombre es obligatorio' })
+  @Length(2, 100, {
+    message: 'El nombre debe tener entre 2 y 100 caracteres',
+  })
+  name: string;
+
+  @ApiProperty({ example: 'ana@example.com' })
+  @IsEmail({}, { message: 'El email no es válido' })
+  email: string;
+
+  @ApiProperty({
+    example: 'Consulta por una lectura',
+    minLength: 5,
+    maxLength: 200,
+  })
+  @IsString({ message: 'El asunto es obligatorio' })
+  @Length(5, 200, {
+    message: 'El asunto debe tener entre 5 y 200 caracteres',
+  })
+  // El asunto viaja a una cabecera del email: un salto de línea permitiría inyectar
+  // cabeceras propias (Bcc:, por ejemplo) desde un endpoint público sin auth.
+  @Matches(/^[^\r\n]+$/, {
+    message: 'El asunto no puede contener saltos de línea',
+  })
+  subject: string;
+
+  @ApiProperty({
+    example: 'Hola, quería saber cómo reservar una sesión.',
+    minLength: 10,
+    maxLength: 2000,
+  })
+  @IsString({ message: 'El mensaje es obligatorio' })
+  @Length(10, 2000, {
+    message: 'El mensaje debe tener entre 10 y 2000 caracteres',
+  })
+  message: string;
+}

--- a/backend/tarot-app/src/modules/contact/application/use-cases/send-contact-message.use-case.spec.ts
+++ b/backend/tarot-app/src/modules/contact/application/use-cases/send-contact-message.use-case.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InternalServerErrorException, Logger } from '@nestjs/common';
+import { EmailService } from '../../../email/email.service';
+import { SendContactMessageDto } from '../dto/send-contact-message.dto';
+import { SendContactMessageUseCase } from './send-contact-message.use-case';
+
+describe('SendContactMessageUseCase (T-PROD-014)', () => {
+  let useCase: SendContactMessageUseCase;
+
+  const mockEmailService: jest.Mocked<
+    Pick<EmailService, 'sendContactMessageEmail'>
+  > = {
+    sendContactMessageEmail: jest.fn(),
+  };
+
+  const dto: SendContactMessageDto = {
+    name: 'Ana Pérez',
+    email: 'ana@example.com',
+    subject: 'Consulta por una lectura',
+    message: 'Hola, quería saber cómo reservar una sesión.',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SendContactMessageUseCase,
+        { provide: EmailService, useValue: mockEmailService },
+      ],
+    }).compile();
+
+    useCase = module.get<SendContactMessageUseCase>(SendContactMessageUseCase);
+    jest.clearAllMocks();
+  });
+
+  it('envía el mensaje por email con los datos del formulario', async () => {
+    mockEmailService.sendContactMessageEmail.mockResolvedValue(undefined);
+
+    await useCase.execute(dto);
+
+    expect(mockEmailService.sendContactMessageEmail).toHaveBeenCalledTimes(1);
+    expect(mockEmailService.sendContactMessageEmail).toHaveBeenCalledWith({
+      name: dto.name,
+      email: dto.email,
+      subject: dto.subject,
+      message: dto.message,
+    });
+  });
+
+  it('devuelve una confirmación en español para el usuario', async () => {
+    mockEmailService.sendContactMessageEmail.mockResolvedValue(undefined);
+
+    const result = await useCase.execute(dto);
+
+    expect(result.message).toContain('Mensaje enviado');
+  });
+
+  it('lanza 500 si el email no sale: el bug de esta tarea era justamente devolver éxito con el mensaje perdido', async () => {
+    mockEmailService.sendContactMessageEmail.mockRejectedValue(
+      new Error('SMTP caído'),
+    );
+
+    await expect(useCase.execute(dto)).rejects.toThrow(
+      InternalServerErrorException,
+    );
+  });
+
+  it('loguea el fallo de envío con el email del remitente, para poder recuperar el mensaje del log si hace falta', async () => {
+    const loggerSpy = jest.spyOn(Logger.prototype, 'error');
+    mockEmailService.sendContactMessageEmail.mockRejectedValue(
+      new Error('SMTP caído'),
+    );
+
+    await expect(useCase.execute(dto)).rejects.toThrow(
+      InternalServerErrorException,
+    );
+
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ana@example.com'),
+      expect.any(String),
+    );
+
+    loggerSpy.mockRestore();
+  });
+});

--- a/backend/tarot-app/src/modules/contact/application/use-cases/send-contact-message.use-case.spec.ts
+++ b/backend/tarot-app/src/modules/contact/application/use-cases/send-contact-message.use-case.spec.ts
@@ -74,9 +74,31 @@ describe('SendContactMessageUseCase (T-PROD-014)', () => {
       InternalServerErrorException,
     );
 
+    expect(loggerSpy).toHaveBeenCalledTimes(1);
     expect(loggerSpy).toHaveBeenCalledWith(
       expect.stringContaining('ana@example.com'),
       expect.any(String),
+    );
+
+    loggerSpy.mockRestore();
+  });
+
+  it('loguea la causa raíz del SMTP, no el stack del re-throw: sin eso el log dice que falló pero no por qué', async () => {
+    const loggerSpy = jest.spyOn(Logger.prototype, 'error');
+    const smtpFailure = new Error('ECONNREFUSED smtp.resend.com:587');
+    mockEmailService.sendContactMessageEmail.mockRejectedValue(
+      new Error('Error al enviar el mensaje de contacto', {
+        cause: smtpFailure,
+      }),
+    );
+
+    await expect(useCase.execute(dto)).rejects.toThrow(
+      InternalServerErrorException,
+    );
+
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('ECONNREFUSED'),
     );
 
     loggerSpy.mockRestore();

--- a/backend/tarot-app/src/modules/contact/application/use-cases/send-contact-message.use-case.ts
+++ b/backend/tarot-app/src/modules/contact/application/use-cases/send-contact-message.use-case.ts
@@ -11,6 +11,24 @@ export interface SendContactMessageResult {
 }
 
 /**
+ * Stack del error original. `EmailService` relanza con `{ cause }`, y el stack del error
+ * externo solo apunta a ese `throw`: sin desenvolver la causa, el log no dice qué falló
+ * realmente en el SMTP.
+ */
+function rootStack(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+
+  const cause = error.cause;
+  if (cause instanceof Error && cause.stack) {
+    return cause.stack;
+  }
+
+  return error.stack ?? error.message;
+}
+
+/**
  * Envía al buzón de Auguria un mensaje del formulario de contacto (T-PROD-014).
  *
  * Si el email no sale, el caso de uso **falla**: el bug original era mostrarle al
@@ -31,11 +49,12 @@ export class SendContactMessageUseCase {
         message: dto.message,
       });
     } catch (error) {
-      // El log lleva el remitente y el asunto: si el SMTP estaba caído, el mensaje
-      // todavía puede rescatarse del log en vez de perderse del todo.
+      // Único log del fallo, y con la causa raíz: el remitente y el asunto permiten
+      // rescatar el mensaje del log si el SMTP estaba caído, y el stack del `cause`
+      // dice POR QUÉ falló (el `Error` que relanza EmailService no lo diría solo).
       this.logger.error(
         `No se pudo enviar el mensaje de contacto de ${dto.email} ("${dto.subject}")`,
-        error instanceof Error ? error.stack : String(error),
+        rootStack(error),
       );
 
       throw new InternalServerErrorException(

--- a/backend/tarot-app/src/modules/contact/application/use-cases/send-contact-message.use-case.ts
+++ b/backend/tarot-app/src/modules/contact/application/use-cases/send-contact-message.use-case.ts
@@ -1,0 +1,50 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { EmailService } from '../../../email/email.service';
+import { SendContactMessageDto } from '../dto/send-contact-message.dto';
+
+export interface SendContactMessageResult {
+  message: string;
+}
+
+/**
+ * Envía al buzón de Auguria un mensaje del formulario de contacto (T-PROD-014).
+ *
+ * Si el email no sale, el caso de uso **falla**: el bug original era mostrarle al
+ * visitante un "mensaje enviado" mientras el mensaje moría en la consola del navegador.
+ */
+@Injectable()
+export class SendContactMessageUseCase {
+  private readonly logger = new Logger(SendContactMessageUseCase.name);
+
+  constructor(private readonly emailService: EmailService) {}
+
+  async execute(dto: SendContactMessageDto): Promise<SendContactMessageResult> {
+    try {
+      await this.emailService.sendContactMessageEmail({
+        name: dto.name,
+        email: dto.email,
+        subject: dto.subject,
+        message: dto.message,
+      });
+    } catch (error) {
+      // El log lleva el remitente y el asunto: si el SMTP estaba caído, el mensaje
+      // todavía puede rescatarse del log en vez de perderse del todo.
+      this.logger.error(
+        `No se pudo enviar el mensaje de contacto de ${dto.email} ("${dto.subject}")`,
+        error instanceof Error ? error.stack : String(error),
+      );
+
+      throw new InternalServerErrorException(
+        'No pudimos enviar tu mensaje. Por favor, intentá nuevamente en unos minutos.',
+      );
+    }
+
+    return {
+      message: 'Mensaje enviado exitosamente. Te responderemos a la brevedad.',
+    };
+  }
+}

--- a/backend/tarot-app/src/modules/contact/contact.module.ts
+++ b/backend/tarot-app/src/modules/contact/contact.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { EmailModule } from '../email/email.module';
+import { SendContactMessageUseCase } from './application/use-cases/send-contact-message.use-case';
+import { ContactController } from './infrastructure/controllers/contact.controller';
+
+/**
+ * Formulario de contacto público (T-PROD-014).
+ */
+@Module({
+  imports: [EmailModule],
+  controllers: [ContactController],
+  providers: [SendContactMessageUseCase],
+})
+export class ContactModule {}

--- a/backend/tarot-app/src/modules/contact/infrastructure/controllers/contact.controller.spec.ts
+++ b/backend/tarot-app/src/modules/contact/infrastructure/controllers/contact.controller.spec.ts
@@ -1,0 +1,141 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import * as request from 'supertest';
+import { JwtAuthGuard } from '../../../auth/infrastructure/guards/jwt-auth.guard';
+import { SendContactMessageUseCase } from '../../application/use-cases/send-contact-message.use-case';
+import { ContactController } from './contact.controller';
+
+describe('ContactController (T-PROD-014)', () => {
+  const validBody = {
+    name: 'Ana Pérez',
+    email: 'ana@example.com',
+    subject: 'Consulta por una lectura',
+    message: 'Hola, quería saber cómo reservar una sesión.',
+  };
+
+  const mockUseCase = {
+    execute: jest.fn(),
+  };
+
+  describe('delegación', () => {
+    let controller: ContactController;
+
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        controllers: [ContactController],
+        providers: [
+          { provide: SendContactMessageUseCase, useValue: mockUseCase },
+        ],
+      }).compile();
+
+      controller = module.get<ContactController>(ContactController);
+      jest.clearAllMocks();
+    });
+
+    it('delega en el use case y devuelve su respuesta', async () => {
+      mockUseCase.execute.mockResolvedValue({ message: 'Mensaje enviado' });
+
+      const result = await controller.sendMessage(validBody);
+
+      expect(mockUseCase.execute).toHaveBeenCalledWith(validBody);
+      expect(result).toEqual({ message: 'Mensaje enviado' });
+    });
+
+    it('es un endpoint público: exigir JWT dejaría el formulario inservible para un visitante', () => {
+      const guards = (Reflect.getMetadata(
+        '__guards__',
+        ContactController.prototype.sendMessage,
+      ) ?? []) as unknown[];
+
+      expect(guards).not.toContain(JwtAuthGuard);
+    });
+  });
+
+  describe('endpoint HTTP', () => {
+    let app: INestApplication;
+
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        imports: [
+          // Sin storage propio el @Throttle del controller no se aplica: el rate limit
+          // es lo único que separa a este endpoint público de un buzón de spam.
+          ThrottlerModule.forRoot([{ ttl: 60000, limit: 100 }]),
+        ],
+        controllers: [ContactController],
+        providers: [
+          { provide: SendContactMessageUseCase, useValue: mockUseCase },
+          { provide: APP_GUARD, useClass: ThrottlerGuard },
+        ],
+      }).compile();
+
+      app = module.createNestApplication();
+      app.useGlobalPipes(
+        new ValidationPipe({
+          whitelist: true,
+          forbidNonWhitelisted: true,
+          transform: true,
+        }),
+      );
+      await app.init();
+
+      jest.clearAllMocks();
+      mockUseCase.execute.mockResolvedValue({ message: 'Mensaje enviado' });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('acepta un mensaje válido (200)', async () => {
+      await request(app.getHttpServer())
+        .post('/contact')
+        .send(validBody)
+        .expect(200);
+
+      expect(mockUseCase.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ['name corto', { ...validBody, name: 'A' }],
+      ['email inválido', { ...validBody, email: 'no-es-un-email' }],
+      ['subject corto', { ...validBody, subject: 'Hi' }],
+      ['message corto', { ...validBody, message: 'corto' }],
+      [
+        'message de más de 2000 caracteres',
+        {
+          ...validBody,
+          message: 'a'.repeat(2001),
+        },
+      ],
+      [
+        'subject con salto de línea (inyección de cabeceras)',
+        {
+          ...validBody,
+          subject: 'Hola\nBcc: victima@example.com',
+        },
+      ],
+    ])('rechaza con 400: %s', async (_caso, body) => {
+      await request(app.getHttpServer())
+        .post('/contact')
+        .send(body)
+        .expect(400);
+
+      expect(mockUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it('responde 429 pasado el límite: el endpoint es público y sin él sería un buzón de spam abierto', async () => {
+      const server = app.getHttpServer();
+
+      // El límite del endpoint es 3/hora (@Throttle en el controller).
+      await request(server).post('/contact').send(validBody).expect(200);
+      await request(server).post('/contact').send(validBody).expect(200);
+      await request(server).post('/contact').send(validBody).expect(200);
+
+      await request(server).post('/contact').send(validBody).expect(429);
+
+      expect(mockUseCase.execute).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/backend/tarot-app/src/modules/contact/infrastructure/controllers/contact.controller.spec.ts
+++ b/backend/tarot-app/src/modules/contact/infrastructure/controllers/contact.controller.spec.ts
@@ -1,8 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { ValidationPipe } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
-import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { ThrottlerModule } from '@nestjs/throttler';
 import * as request from 'supertest';
+import { CustomThrottlerGuard } from '../../../../common/guards/custom-throttler.guard';
+import { configureTrustProxy } from '../../../../config/trust-proxy.config';
 import { JwtAuthGuard } from '../../../auth/infrastructure/guards/jwt-auth.guard';
 import { SendContactMessageUseCase } from '../../application/use-cases/send-contact-message.use-case';
 import { ContactController } from './contact.controller';
@@ -44,17 +47,24 @@ describe('ContactController (T-PROD-014)', () => {
     });
 
     it('es un endpoint público: exigir JWT dejaría el formulario inservible para un visitante', () => {
-      const guards = (Reflect.getMetadata(
+      // Se miran los guards del método Y los de la clase: un @UseGuards a nivel de clase
+      // no escribe metadata en el handler, así que mirar solo el método dejaría pasar
+      // justamente la forma más natural de cerrarle el formulario a un visitante.
+      const handlerGuards = (Reflect.getMetadata(
         '__guards__',
         ContactController.prototype.sendMessage,
       ) ?? []) as unknown[];
+      const classGuards = (Reflect.getMetadata(
+        '__guards__',
+        ContactController,
+      ) ?? []) as unknown[];
 
-      expect(guards).not.toContain(JwtAuthGuard);
+      expect([...handlerGuards, ...classGuards]).not.toContain(JwtAuthGuard);
     });
   });
 
   describe('endpoint HTTP', () => {
-    let app: INestApplication;
+    let app: NestExpressApplication;
 
     beforeEach(async () => {
       const module: TestingModule = await Test.createTestingModule({
@@ -66,11 +76,15 @@ describe('ContactController (T-PROD-014)', () => {
         controllers: [ContactController],
         providers: [
           { provide: SendContactMessageUseCase, useValue: mockUseCase },
-          { provide: APP_GUARD, useClass: ThrottlerGuard },
+          // El guard REAL de la app, no el base: es el que resuelve la IP del tracker,
+          // y ahí vivía el bypass del X-Forwarded-For (T-PROD-014).
+          { provide: APP_GUARD, useClass: CustomThrottlerGuard },
         ],
       }).compile();
 
-      app = module.createNestApplication();
+      app = module.createNestApplication<NestExpressApplication>();
+      // Mismo trust proxy que en producción (Railway = 1 salto), ver main.ts.
+      configureTrustProxy(app, '1');
       app.useGlobalPipes(
         new ValidationPipe({
           whitelist: true,
@@ -134,6 +148,39 @@ describe('ContactController (T-PROD-014)', () => {
       await request(server).post('/contact').send(validBody).expect(200);
 
       await request(server).post('/contact').send(validBody).expect(429);
+
+      expect(mockUseCase.execute).toHaveBeenCalledTimes(3);
+    });
+
+    it('rotar el X-Forwarded-For NO regala cuota nueva: el primer valor del header lo escribe el cliente, y confiar en él hacía decorativo el límite de todos los endpoints públicos', async () => {
+      const server = app.getHttpServer();
+
+      // El proxy confiable (1 salto) agrega la IP real al final; lo de adelante lo inventó
+      // el cliente y va rotando en cada request para simular ser una IP distinta.
+      const spoofed = (i: number) => `10.0.0.${i}, 203.0.113.7`;
+
+      await request(server)
+        .post('/contact')
+        .set('X-Forwarded-For', spoofed(1))
+        .send(validBody)
+        .expect(200);
+      await request(server)
+        .post('/contact')
+        .set('X-Forwarded-For', spoofed(2))
+        .send(validBody)
+        .expect(200);
+      await request(server)
+        .post('/contact')
+        .set('X-Forwarded-For', spoofed(3))
+        .send(validBody)
+        .expect(200);
+
+      // Con el bug, este cuarto request (IP "nueva") pasaba: era un mail-bomb ilimitado.
+      await request(server)
+        .post('/contact')
+        .set('X-Forwarded-For', spoofed(4))
+        .send(validBody)
+        .expect(429);
 
       expect(mockUseCase.execute).toHaveBeenCalledTimes(3);
     });

--- a/backend/tarot-app/src/modules/contact/infrastructure/controllers/contact.controller.ts
+++ b/backend/tarot-app/src/modules/contact/infrastructure/controllers/contact.controller.ts
@@ -1,0 +1,60 @@
+import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { RateLimit } from '../../../../common/decorators/rate-limit.decorator';
+import { SendContactMessageDto } from '../../application/dto/send-contact-message.dto';
+import {
+  SendContactMessageResult,
+  SendContactMessageUseCase,
+} from '../../application/use-cases/send-contact-message.use-case';
+
+@ApiTags('Contacto')
+@Controller('contact')
+export class ContactController {
+  constructor(
+    private readonly sendContactMessageUseCase: SendContactMessageUseCase,
+  ) {}
+
+  /**
+   * Endpoint público (sin JwtAuthGuard): lo usa un visitante sin cuenta.
+   * Por eso el rate limit es obligatorio — sin él sería un buzón de spam abierto.
+   */
+  @Post()
+  @RateLimit({ ttl: 3600, limit: 3, blockDuration: 3600 }) // 3 mensajes/hora por IP
+  @Throttle({ default: { limit: 3, ttl: 3600000 } }) // Enforce: 3 req/hour (ttl en ms)
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Enviar un mensaje desde el formulario de contacto',
+    description:
+      'Envía el mensaje al buzón de contacto de Auguria, con el email del remitente como Reply-To. Endpoint público, limitado a 3 mensajes por hora por IP.',
+  })
+  @ApiBody({
+    type: SendContactMessageDto,
+    examples: {
+      ejemplo1: {
+        summary: 'Consulta de un visitante',
+        value: {
+          name: 'Ana Pérez',
+          email: 'ana@example.com',
+          subject: 'Consulta por una lectura',
+          message: 'Hola, quería saber cómo reservar una sesión.',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Mensaje enviado exitosamente' })
+  @ApiResponse({ status: 400, description: 'Datos del formulario inválidos' })
+  @ApiResponse({
+    status: 429,
+    description: 'Demasiados mensajes. Límite: 3 por hora',
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'El mensaje no pudo enviarse (fallo del servicio de email)',
+  })
+  async sendMessage(
+    @Body() dto: SendContactMessageDto,
+  ): Promise<SendContactMessageResult> {
+    return this.sendContactMessageUseCase.execute(dto);
+  }
+}

--- a/backend/tarot-app/src/modules/email/email-templates.spec.ts
+++ b/backend/tarot-app/src/modules/email/email-templates.spec.ts
@@ -212,14 +212,22 @@ describe('Email templates (render)', () => {
       expect(mail.html).toContain('Hola, quería saber cómo reservar');
     });
 
-    it('escapa el HTML del mensaje: el cuerpo lo escribe un desconocido sin autenticar', async () => {
-      const mail = await render('contact-message', {
-        ...TEMPLATE_CONTEXTS['contact-message'],
-        message: '<script>alert(1)</script>',
-      });
+    // Los tres campos los escribe un desconocido sin autenticar, no solo el cuerpo.
+    it.each([
+      ['message', '<script>alert(1)</script>', '&lt;script&gt;'],
+      ['name', '<img src=x onerror=alert(1)>', '&lt;img'],
+      ['subject', '<b onmouseover=alert(1)>hola</b>', '&lt;b'],
+    ])(
+      'escapa el HTML de %s: lo escribe un desconocido sin autenticar',
+      async (field, payload, escaped) => {
+        const mail = await render('contact-message', {
+          ...TEMPLATE_CONTEXTS['contact-message'],
+          [field]: payload,
+        });
 
-      expect(mail.html).not.toContain('<script>alert(1)</script>');
-      expect(mail.html).toContain('&lt;script&gt;');
-    });
+        expect(mail.html).not.toContain(payload);
+        expect(mail.html).toContain(escaped);
+      },
+    );
   });
 });

--- a/backend/tarot-app/src/modules/email/email-templates.spec.ts
+++ b/backend/tarot-app/src/modules/email/email-templates.spec.ts
@@ -28,6 +28,7 @@ describe('Email templates (build)', () => {
     'holistic-service-confirmation',
     'provider-cost-warning',
     'provider-cost-limit-reached',
+    'contact-message',
   ];
 
   it.each(REQUIRED_TEMPLATES)(
@@ -166,6 +167,12 @@ describe('Email templates (render)', () => {
       whatsappNumber: '+54 9 11 1234-5678',
       whatsappNumberForLink: '5491112345678',
     },
+    'contact-message': {
+      name: 'Ana Pérez',
+      email: 'ana@example.com',
+      subject: 'Consulta por una lectura',
+      message: 'Hola, quería saber cómo reservar una sesión.',
+    },
   };
 
   it.each(Object.keys(TEMPLATE_CONTEXTS))(
@@ -190,5 +197,29 @@ describe('Email templates (render)', () => {
 
     expect(mail.html).toContain(resetUrl);
     expect(mail.html).toContain('Flavia');
+  });
+
+  describe('contact-message (T-PROD-014)', () => {
+    it('incluye los datos del cliente y su mensaje: si falta alguno, el email llega inútil', async () => {
+      const mail = await render(
+        'contact-message',
+        TEMPLATE_CONTEXTS['contact-message'],
+      );
+
+      expect(mail.html).toContain('Ana Pérez');
+      expect(mail.html).toContain('ana@example.com');
+      expect(mail.html).toContain('Consulta por una lectura');
+      expect(mail.html).toContain('Hola, quería saber cómo reservar');
+    });
+
+    it('escapa el HTML del mensaje: el cuerpo lo escribe un desconocido sin autenticar', async () => {
+      const mail = await render('contact-message', {
+        ...TEMPLATE_CONTEXTS['contact-message'],
+        message: '<script>alert(1)</script>',
+      });
+
+      expect(mail.html).not.toContain('<script>alert(1)</script>');
+      expect(mail.html).toContain('&lt;script&gt;');
+    });
   });
 });

--- a/backend/tarot-app/src/modules/email/email.service.spec.ts
+++ b/backend/tarot-app/src/modules/email/email.service.spec.ts
@@ -8,6 +8,7 @@ import {
   PlanChangeData,
   ProviderCostWarningData,
   ProviderCostLimitReachedData,
+  ContactMessageData,
 } from './interfaces/email.interface';
 
 describe('EmailService', () => {
@@ -19,12 +20,16 @@ describe('EmailService', () => {
     sendMail: mockSendMail,
   };
 
+  /** Variables que un test puede pisar (o borrar, con `undefined`) para ese caso. */
+  let configOverrides: Record<string, string | undefined> = {};
+
   const mockConfigGet = jest.fn((key: string) => {
-    const config: Record<string, string | number> = {
+    const config: Record<string, string | number | undefined> = {
       EMAIL_FROM: 'noreply@tarot.com',
       SMTP_HOST: 'smtp.test.com',
       SMTP_PORT: 587,
       FRONTEND_URL: 'http://localhost:3000',
+      ...configOverrides,
     };
     return config[key];
   });
@@ -54,6 +59,7 @@ describe('EmailService', () => {
 
     // Clear all mocks before each test
     jest.clearAllMocks();
+    configOverrides = {};
   });
 
   it('should be defined', () => {
@@ -302,6 +308,101 @@ describe('EmailService', () => {
 
       expect(loggerSpy).toHaveBeenCalledWith(
         expect.stringContaining('Email de cambio de plan enviado exitosamente'),
+      );
+
+      loggerSpy.mockRestore();
+    });
+  });
+
+  describe('sendContactMessageEmail (T-PROD-014)', () => {
+    const contactData: ContactMessageData = {
+      name: 'Ana Pérez',
+      email: 'ana@example.com',
+      subject: 'Consulta por una lectura',
+      message: 'Hola, quería saber cómo reservar una sesión.',
+    };
+
+    it('envía el mensaje al buzón de contacto, con el email del usuario como replyTo', async () => {
+      configOverrides = { CONTACT_EMAIL_TO: 'consultas@auguriatarot.com' };
+      mockMailerService.sendMail.mockResolvedValue({ messageId: 'test-id' });
+
+      await service.sendContactMessageEmail(contactData);
+
+      expect(mailerService.sendMail).toHaveBeenCalledTimes(1);
+      expect(mailerService.sendMail).toHaveBeenCalledWith({
+        to: 'consultas@auguriatarot.com',
+        replyTo: contactData.email,
+        subject: `Contacto web: ${contactData.subject}`,
+        template: 'contact-message',
+        context: {
+          name: contactData.name,
+          email: contactData.email,
+          subject: contactData.subject,
+          message: contactData.message,
+        },
+      });
+    });
+
+    it('el replyTo pisa el default global: sin esto, responder el mensaje le contestaría al propio buzón de Auguria y no al cliente', async () => {
+      configOverrides = {
+        CONTACT_EMAIL_TO: 'consultas@auguriatarot.com',
+        EMAIL_REPLY_TO: 'consultas@auguriatarot.com',
+      };
+      mockMailerService.sendMail.mockResolvedValue({ messageId: 'test-id' });
+
+      await service.sendContactMessageEmail(contactData);
+
+      expect(mockSendMail.mock.calls[0][0]).toMatchObject({
+        replyTo: 'ana@example.com',
+      });
+    });
+
+    it('sin CONTACT_EMAIL_TO cae a EMAIL_REPLY_TO (dev/staging: el buzón que ya recibe las respuestas)', async () => {
+      configOverrides = {
+        CONTACT_EMAIL_TO: undefined,
+        EMAIL_REPLY_TO: 'consultas@auguriatarot.com',
+      };
+      mockMailerService.sendMail.mockResolvedValue({ messageId: 'test-id' });
+
+      await service.sendContactMessageEmail(contactData);
+
+      expect(mockSendMail.mock.calls[0][0]).toMatchObject({
+        to: 'consultas@auguriatarot.com',
+      });
+    });
+
+    it('sin CONTACT_EMAIL_TO ni EMAIL_REPLY_TO cae a EMAIL_FROM', async () => {
+      configOverrides = {
+        CONTACT_EMAIL_TO: undefined,
+        EMAIL_REPLY_TO: undefined,
+      };
+      mockMailerService.sendMail.mockResolvedValue({ messageId: 'test-id' });
+
+      await service.sendContactMessageEmail(contactData);
+
+      expect(mockSendMail.mock.calls[0][0]).toMatchObject({
+        to: 'noreply@tarot.com',
+      });
+    });
+
+    it('relanza el error si el envío falla: a diferencia de las alertas de costo, el usuario TIENE que enterarse de que su mensaje no salió', async () => {
+      configOverrides = { CONTACT_EMAIL_TO: 'consultas@auguriatarot.com' };
+      mockMailerService.sendMail.mockRejectedValue(new Error('SMTP Error'));
+
+      await expect(
+        service.sendContactMessageEmail(contactData),
+      ).rejects.toThrow('Error al enviar el mensaje de contacto');
+    });
+
+    it('loguea el envío exitoso', async () => {
+      const loggerSpy = jest.spyOn(Logger.prototype, 'log');
+      configOverrides = { CONTACT_EMAIL_TO: 'consultas@auguriatarot.com' };
+      mockMailerService.sendMail.mockResolvedValue({ messageId: 'test-id' });
+
+      await service.sendContactMessageEmail(contactData);
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Mensaje de contacto enviado exitosamente'),
       );
 
       loggerSpy.mockRestore();

--- a/backend/tarot-app/src/modules/email/email.service.spec.ts
+++ b/backend/tarot-app/src/modules/email/email.service.spec.ts
@@ -385,6 +385,20 @@ describe('EmailService', () => {
       });
     });
 
+    it('un CONTACT_EMAIL_TO vacío no es un buzón: cae al siguiente fallback en vez de mandar a `to: ""`', async () => {
+      configOverrides = {
+        CONTACT_EMAIL_TO: '',
+        EMAIL_REPLY_TO: 'consultas@auguriatarot.com',
+      };
+      mockMailerService.sendMail.mockResolvedValue({ messageId: 'test-id' });
+
+      await service.sendContactMessageEmail(contactData);
+
+      expect(mockSendMail.mock.calls[0][0]).toMatchObject({
+        to: 'consultas@auguriatarot.com',
+      });
+    });
+
     it('relanza el error si el envío falla: a diferencia de las alertas de costo, el usuario TIENE que enterarse de que su mensaje no salió', async () => {
       configOverrides = { CONTACT_EMAIL_TO: 'consultas@auguriatarot.com' };
       mockMailerService.sendMail.mockRejectedValue(new Error('SMTP Error'));
@@ -392,6 +406,16 @@ describe('EmailService', () => {
       await expect(
         service.sendContactMessageEmail(contactData),
       ).rejects.toThrow('Error al enviar el mensaje de contacto');
+    });
+
+    it('preserva la causa raíz en el error que relanza: sin el `cause`, el llamador loguea que falló pero no por qué', async () => {
+      configOverrides = { CONTACT_EMAIL_TO: 'consultas@auguriatarot.com' };
+      const smtpFailure = new Error('ECONNREFUSED smtp.resend.com:587');
+      mockMailerService.sendMail.mockRejectedValue(smtpFailure);
+
+      await expect(
+        service.sendContactMessageEmail(contactData),
+      ).rejects.toMatchObject({ cause: smtpFailure });
     });
 
     it('loguea el envío exitoso', async () => {

--- a/backend/tarot-app/src/modules/email/email.service.ts
+++ b/backend/tarot-app/src/modules/email/email.service.ts
@@ -8,7 +8,15 @@ import {
   ProviderCostWarningData,
   ProviderCostLimitReachedData,
   HolisticServiceConfirmationData,
+  ContactMessageData,
 } from './interfaces/email.interface';
+
+/**
+ * Último recurso del buzón de contacto, para el dev local sin SMTP: coincide con el
+ * `from` de `mailer.config.ts` en modo jsonTransport, donde el mail se loguea y no sale.
+ * En producción nunca se usa: `CONTACT_EMAIL_TO` es obligatoria y el boot falla sin ella.
+ */
+const CONTACT_RECIPIENT_FALLBACK = 'noreply@example.com';
 
 @Injectable()
 export class EmailService {
@@ -258,6 +266,60 @@ export class EmailService {
         error instanceof Error ? error.stack : String(error),
       );
       // No relanzar — el pago ya fue aprobado, el email es no crítico
+    }
+  }
+
+  /**
+   * Buzón que recibe los mensajes del formulario de contacto.
+   *
+   * En producción es `CONTACT_EMAIL_TO` y punto: el boot falla si no está (T-PROD-014).
+   * Los fallbacks son para dev/staging, donde el mailer corre en jsonTransport.
+   */
+  private resolveContactRecipient(): string {
+    return (
+      this.configService.get<string>('CONTACT_EMAIL_TO') ??
+      this.configService.get<string>('EMAIL_REPLY_TO') ??
+      this.configService.get<string>('EMAIL_FROM') ??
+      CONTACT_RECIPIENT_FALLBACK
+    );
+  }
+
+  /**
+   * Envía al buzón de contacto un mensaje del formulario público.
+   *
+   * El `replyTo` es el email del visitante y **pisa** el default global del mailer
+   * (`EMAIL_REPLY_TO`, que apunta al propio buzón de Auguria): sin él, responder el
+   * mensaje sería responderse a sí misma en vez de contestarle al cliente.
+   *
+   * Relanza si el envío falla — a diferencia de las alertas de costo, acá el usuario
+   * tiene que enterarse: tragarse el error es justamente el bug que arregla T-PROD-014.
+   */
+  async sendContactMessageEmail(data: ContactMessageData): Promise<void> {
+    const to = this.resolveContactRecipient();
+
+    try {
+      await this.mailerService.sendMail({
+        to,
+        replyTo: data.email,
+        subject: `Contacto web: ${data.subject}`,
+        template: 'contact-message',
+        context: {
+          name: data.name,
+          email: data.email,
+          subject: data.subject,
+          message: data.message,
+        },
+      });
+
+      this.logger.log(
+        `Mensaje de contacto enviado exitosamente a ${to} (de ${data.email})`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Error al enviar el mensaje de contacto de ${data.email} a ${to}`,
+        error instanceof Error ? error.stack : String(error),
+      );
+      throw new Error('Error al enviar el mensaje de contacto');
     }
   }
 }

--- a/backend/tarot-app/src/modules/email/email.service.ts
+++ b/backend/tarot-app/src/modules/email/email.service.ts
@@ -274,12 +274,17 @@ export class EmailService {
    *
    * En producción es `CONTACT_EMAIL_TO` y punto: el boot falla si no está (T-PROD-014).
    * Los fallbacks son para dev/staging, donde el mailer corre en jsonTransport.
+   *
+   * Se encadena con `||` y no con `??` a propósito: el string vacío tampoco es un buzón.
+   * El `@Transform` de `env.validation.ts` ya lo convierte en `undefined` en el arranque
+   * de la app, pero el `EmailModule` se monta standalone en los e2e, sin esa validación:
+   * ahí un `CONTACT_EMAIL_TO=''` llegaría como `to: ''` y el envío moriría.
    */
   private resolveContactRecipient(): string {
     return (
-      this.configService.get<string>('CONTACT_EMAIL_TO') ??
-      this.configService.get<string>('EMAIL_REPLY_TO') ??
-      this.configService.get<string>('EMAIL_FROM') ??
+      this.configService.get<string>('CONTACT_EMAIL_TO') ||
+      this.configService.get<string>('EMAIL_REPLY_TO') ||
+      this.configService.get<string>('EMAIL_FROM') ||
       CONTACT_RECIPIENT_FALLBACK
     );
   }
@@ -315,11 +320,11 @@ export class EmailService {
         `Mensaje de contacto enviado exitosamente a ${to} (de ${data.email})`,
       );
     } catch (error) {
-      this.logger.error(
-        `Error al enviar el mensaje de contacto de ${data.email} a ${to}`,
-        error instanceof Error ? error.stack : String(error),
-      );
-      throw new Error('Error al enviar el mensaje de contacto');
+      // El `cause` preserva el fallo real del SMTP: sin él, el llamador que loguea este
+      // error solo ve el stack de este `throw` y la causa raíz se pierde.
+      throw new Error('Error al enviar el mensaje de contacto', {
+        cause: error,
+      });
     }
   }
 }

--- a/backend/tarot-app/src/modules/email/interfaces/email.interface.ts
+++ b/backend/tarot-app/src/modules/email/interfaces/email.interface.ts
@@ -55,6 +55,17 @@ export interface ProviderCostLimitReachedData {
   monthlyLimit: number;
 }
 
+/**
+ * Mensaje del formulario de contacto público (T-PROD-014).
+ * `email` es el del visitante: va como `replyTo`, para poder contestarle directo.
+ */
+export interface ContactMessageData {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+}
+
 export interface HolisticServiceConfirmationData {
   userName: string;
   serviceName: string;

--- a/backend/tarot-app/src/modules/email/templates/contact-message.hbs
+++ b/backend/tarot-app/src/modules/email/templates/contact-message.hbs
@@ -1,0 +1,119 @@
+<html lang='es'>
+  <head>
+    <meta charset='UTF-8' />
+    <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+    <title>Nuevo mensaje de contacto</title>
+    <style>
+      body {
+        font-family: 'Georgia', serif;
+        background-color: #f5f3f0;
+        margin: 0;
+        padding: 0;
+      }
+      .container {
+        max-width: 600px;
+        margin: 0 auto;
+        background-color: #ffffff;
+        padding: 40px 30px;
+        border-radius: 10px;
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      }
+      .header {
+        text-align: center;
+        margin-bottom: 30px;
+        border-bottom: 2px solid #8b7355;
+        padding-bottom: 20px;
+      }
+      .header h1 {
+        color: #8b7355;
+        font-size: 26px;
+        margin: 0;
+        font-weight: normal;
+      }
+      .icon {
+        font-size: 44px;
+        margin-bottom: 10px;
+      }
+      .sender-box {
+        background-color: #f9f7f5;
+        padding: 20px;
+        border-radius: 8px;
+        margin: 20px 0;
+      }
+      .sender-row {
+        color: #5a5a5a;
+        font-size: 15px;
+        margin: 8px 0;
+      }
+      .sender-label {
+        color: #8b7355;
+        font-weight: bold;
+      }
+      .message-box {
+        background-color: #ffffff;
+        border-left: 4px solid #8b7355;
+        padding: 15px 20px;
+        border-radius: 5px;
+        margin: 20px 0;
+        color: #333;
+        font-size: 16px;
+        line-height: 1.8;
+        /* El mensaje llega como texto plano: sin esto, los saltos de línea del
+           formulario se pierden y el mail se lee como un bloque único. */
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .reply-notice {
+        background-color: #f0ebe5;
+        padding: 15px;
+        border-radius: 5px;
+        margin: 20px 0;
+        text-align: center;
+        color: #666;
+        font-size: 14px;
+      }
+      .footer {
+        text-align: center;
+        margin-top: 40px;
+        padding-top: 20px;
+        border-top: 1px solid #e0e0e0;
+        color: #888;
+        font-size: 13px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class='container'>
+      <div class='header'>
+        <div class='icon'>✉️</div>
+        <h1>Nuevo mensaje de contacto</h1>
+      </div>
+
+      <div class='sender-box'>
+        <p class='sender-row'>
+          <span class='sender-label'>De:</span>
+          {{name}}
+        </p>
+        <p class='sender-row'>
+          <span class='sender-label'>Email:</span>
+          <a href='mailto:{{email}}'>{{email}}</a>
+        </p>
+        <p class='sender-row'>
+          <span class='sender-label'>Asunto:</span>
+          {{subject}}
+        </p>
+      </div>
+
+      <div class='message-box'>{{message}}</div>
+
+      <div class='reply-notice'>
+        Respondé este email directamente: la respuesta le llega a
+        <strong>{{email}}</strong>.
+      </div>
+
+      <div class='footer'>
+        <p>Mensaje enviado desde el formulario de contacto de Auguria.</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -1082,14 +1082,34 @@ Es decir: **los mensajes de los clientes se pierden en la consola del navegador.
 - [x] La página ya no muestra el disclaimer de "no implementado".
 - [x] Ciclos de calidad completos: backend (format, lint, 4567 tests, coverage 84.6%, build, validate-architecture) y frontend (format, lint 0 errores, type-check, 5301 tests, build, validate-architecture).
 
+#### 🔒 Hallazgo del review: el rate limit era esquivable (arreglado en esta misma tarea)
+
+El revisor encontró que **el límite de todos los endpoints públicos era decorativo**, no solo el de contacto: `custom-throttler.guard.ts` armaba el tracker con el **primer** elemento del `X-Forwarded-For`, que es justamente el que escribe el cliente. Mandando `X-Forwarded-For: 1.2.3.<random>` en cada request se obtenía un tracker nuevo cada vez y **el 429 no llegaba a dispararse nunca** — ni en `login`, ni en `register`, ni en `forgot-password`. Con el formulario de contacto el costo sube: un anónimo podía mail-bombear el buzón y quemar la cuota de SMTP (riesgo de suspensión de la cuenta de Resend).
+
+Se arregló acá (y no en una tarea aparte) porque sin esto el criterio de aceptación "el endpoint resiste un flood" era **falso**:
+
+- [x] `main.ts`: la app se crea como `NestExpressApplication` y se configura **`trust proxy`** ([trust-proxy.config.ts](../backend/tarot-app/src/config/trust-proxy.config.ts)). Express descarta los saltos confiables y `request.ip` queda en la IP real del cliente, ignorando lo que este haya inventado.
+- [x] `custom-throttler.guard.ts`: `getIP()` ya **no** parsea el header a mano — usa `request.ip`. Los dos tests que fijaban el comportamiento vulnerable ("should extract first IP from x-forwarded-for") se reemplazaron por los que fijan el correcto.
+- [x] **Nueva variable `TRUST_PROXY_HOPS`** (default 1 = Railway). Es configurable a propósito: el número **tiene que coincidir con la cadena de proxies real**. Demasiado bajo → vuelve el bypass; demasiado alto → `request.ip` pasa a ser la IP del proxy, la misma para todos, y la app **empieza a devolver 429 a usuarios reales**. Si algún día se pone un CDN delante de Railway, es `2`. El valor se loguea en el arranque.
+- [x] Test de regresión que **falla contra el código viejo** (verificado): rotar el `X-Forwarded-For` no regala cuota nueva.
+
 #### 🔍 Verificación manual (backend real, dev)
 
-`POST /api/v1/contact` contra el servidor levantado: 200 con el mensaje de confirmación, `EmailService` loguea el envío (jsonTransport en dev), el 4.º request desde una IP no whitelisteada devuelve **429**, y un asunto con `\n` devuelve **400**. Nota: `127.0.0.1`/`::1` están whitelisteadas por defecto (`ip-whitelist.service.ts`), así que el rate limit no se ve desde localhost sin `X-Forwarded-For` — es el comportamiento de toda la app, no de este endpoint.
+`POST /api/v1/contact` contra el servidor levantado:
 
-> ⚠️ **Acción de Ops al deployar:** setear **`CONTACT_EMAIL_TO=consultas@auguriatarot.com`** en Railway.
-> **Sin ella el arranque en producción falla** (a propósito): un buzón de contacto sin destinatario es
-> exactamente el bug que esta tarea arregla, y preferimos que se note en el deploy y no en los mensajes
-> perdidos de los clientes.
+- 200 con el mensaje de confirmación y `EmailService` logueando el envío (jsonTransport en dev).
+- Asunto con `\n` → **400**.
+- **Flood con el `X-Forwarded-For` rotando** (`10.0.0.1..4, <ip real>`): 3×200 y el 4.º **429**. Antes del fix los cuatro pasaban.
+- Un cliente real distinto **sigue pudiendo escribir** (200): el fix no colapsó a todos en un único bucket, que era el riesgo de calibrar mal `trust proxy`.
+
+Nota: `127.0.0.1`/`::1` están whitelisteadas por defecto (`ip-whitelist.service.ts`), así que desde localhost sin `X-Forwarded-For` no se ve ningún límite — es el comportamiento de toda la app, no de este endpoint.
+
+> ⚠️ **Acciones de Ops al deployar:**
+> 1. Setear **`CONTACT_EMAIL_TO=consultas@auguriatarot.com`** en Railway. **Sin ella el arranque en
+>    producción falla** (a propósito): un buzón de contacto sin destinatario es exactamente el bug que
+>    esta tarea arregla, y preferimos que se note en el deploy y no en los mensajes perdidos.
+> 2. **Confirmar `TRUST_PROXY_HOPS`**: queda en **1** (Railway edge) sin necesidad de setearla. Si hay
+>    un CDN/proxy adicional delante, hay que subirla, o los usuarios podrán volver a falsear su IP.
 
 ---
 

--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -333,7 +333,7 @@ Además el frontend define tres tipos que el backend **nunca emite** (`reading_s
 | T-PROD-011 | ✅ Ocultar y bloquear notificaciones tras feature flag + sincronizar el enum | Frontend | 🟠 Alta | 1.5 pts |
 | T-PROD-012 | ✅ Fail-fast de SMTP en producción (hoy el fallback a jsonTransport es silencioso) + Reply-To | Backend | 🟠 Alta | 1 pt |
 | T-PROD-013 | ✅ Página de contacto: la dirección pública `contacto@auguria.com` no existe (dominio equivocado) | Frontend | 🔴 Crítica | 0.5 pt |
-| T-PROD-014 | Formulario de contacto: enviar de verdad (endpoint + EmailService); hoy los mensajes se pierden | Full-stack | 🟠 Alta | 3 pts |
+| T-PROD-014 | ✅ Formulario de contacto: enviar de verdad (endpoint + EmailService); hoy los mensajes se pierden | Full-stack | 🟠 Alta | 3 pts |
 | T-PROD-015 | **Reset de contraseña no envía nada**: usuarios sin recuperación de cuenta + métodos huérfanos | Backend | 🔴 Crítica | 3 pts |
 | T-PROD-016 | **Alertas de costo al admin sin plantilla**: si el gasto de los proveedores se dispara, nadie se entera | Backend | 🟠 Alta | 1 pt |
 | T-PROD-017 | Geocoding: el `User-Agent` que enviamos a Nominatim declara un email inexistente (riesgo de bloqueo silencioso) | Backend | 🟠 Alta | 0.5 pt |
@@ -1041,8 +1041,9 @@ El barrido encontró más `auguria.com` **no publicados** al usuario, que este P
 
 ---
 
-### T-PROD-014: El Formulario de Contacto No Envía Nada
+### T-PROD-014: El Formulario de Contacto No Envía Nada — ✅ COMPLETADA
 
+**Estado:** ✅ COMPLETADA (2026-07-12)
 **Prioridad:** 🟠 Alta
 **Estimación:** 3 puntos
 **Dependencias:** **T-PROD-004** (necesita el SMTP real andando) + T-PROD-012 (deseable)
@@ -1060,23 +1061,35 @@ Es decir: **los mensajes de los clientes se pierden en la consola del navegador.
 #### ✅ Tareas específicas
 
 **Backend:**
-- [ ] Endpoint público `POST /contact` (sin `JwtAuthGuard`) con su DTO espejando el schema Zod del frontend.
-- [ ] **Rate limiting obligatorio** (endpoint público sin auth = vector de spam): throttle por IP, del orden de 3/hora.
-- [ ] Nuevo template `contact-message.hbs` + método en `EmailService` que envíe a `consultas@auguriatarot.com` con el `replyTo` seteado **al email del usuario** (así se le responde directo desde el buzón, sin copiar la dirección a mano).
-- [ ] Tests de use-case y controller (incluido el rechazo por rate limit).
+- [x] Endpoint público `POST /contact` (sin `JwtAuthGuard`) en el nuevo módulo `contact` (`contact.controller.ts` → `send-contact-message.use-case.ts`), con `SendContactMessageDto` espejando el schema Zod del frontend (2-100 / email / 5-200 / 10-2000).
+- [x] **Rate limiting**: `@RateLimit({ ttl: 3600, limit: 3, blockDuration: 3600 })` + `@Throttle({ default: { limit: 3, ttl: 3600000 } })` — 3 mensajes/hora por IP, igual que `auth/forgot-password`.
+- [x] Nuevo template `contact-message.hbs` + `EmailService.sendContactMessageEmail()`: envía al buzón de contacto con `replyTo` = **email del visitante**, que **pisa** el default global (`EMAIL_REPLY_TO`) — sin eso, responder el mensaje sería responderse a sí misma.
+- [x] **Nueva variable `CONTACT_EMAIL_TO`**, obligatoria en producción (el boot falla si falta, misma política que las SMTP de T-PROD-012). Fuera de producción cae a `EMAIL_REPLY_TO` / `EMAIL_FROM`.
+- [x] El envío **relanza** si el SMTP falla (a diferencia de las alertas de costo): el use-case devuelve 500 y loguea remitente + asunto, para que el mensaje pueda rescatarse del log.
+- [x] Tests: use-case, controller (delegación, endpoint público, 400 de validación) y el **429 real** montando `ThrottlerGuard` con supertest; `EmailService` (destinatario, replyTo, fallbacks, error); render del template (incluido el escape de HTML del cuerpo, que lo escribe un desconocido sin auth).
+- [x] **Endurecimiento**: el asunto rechaza saltos de línea (`@Matches(/^[^\r\n]+$/)`) — viaja a una cabecera del email y un `\n` permitiría inyectar un `Bcc:` desde un endpoint público.
 
 **Frontend:**
-- [ ] `API_ENDPOINTS.CONTACT` en `lib/api/endpoints.ts` (nunca hardcodear la ruta).
-- [ ] Hook `useSendContactMessage` (TanStack Query) y cablearlo en el `onSubmit` de `ContactForm`, con estados de carga y error.
-- [ ] **Eliminar el `DisclaimerBanner`** de `contacto/page.tsx` y el `TODO` del docblock.
-- [ ] Tests: envío exitoso, error de red, y que el botón quede deshabilitado mientras envía.
+- [x] `API_ENDPOINTS.CONTACT.BASE` en `lib/api/endpoints.ts` + `lib/api/contact-api.ts`.
+- [x] Hook `useSendContactMessage` (TanStack Query, `useMutation`) cableado en el `onSubmit` de `ContactForm`: `isPending` deshabilita el formulario, el error muestra el `Alert` y el 429 avisa del límite en vez del error genérico. Ante un error **no** se limpia el formulario (el usuario reintenta sin volver a escribir).
+- [x] **Eliminado el `DisclaimerBanner`** de `contacto/page.tsx` y los `TODO` de la página y del componente.
+- [x] Tests: envío real al backend, éxito (toast + reset), error de red, 429, botón deshabilitado mientras envía y rehabilitado tras el error. La página fija que el disclaimer **ya no** está.
 
 #### 🎯 Criterios de Aceptación
 
-- [ ] Un mensaje enviado desde la página de contacto **llega a `consultas@auguriatarot.com`**, y responderlo contesta directamente al cliente (gracias al `replyTo`).
-- [ ] El endpoint resiste un flood: pasado el límite, responde 429.
-- [ ] La página ya no muestra el disclaimer de "no implementado".
-- [ ] Ciclos de calidad backend y frontend completos pasan.
+- [x] Un mensaje enviado desde la página de contacto **llega a `CONTACT_EMAIL_TO`** (`consultas@auguriatarot.com` en producción), y responderlo contesta directamente al cliente (gracias al `replyTo`).
+- [x] El endpoint resiste un flood: pasado el límite, responde 429. Verificado contra la app real: 3×200 y el 4.º con `429 / retryAfter: 3600`.
+- [x] La página ya no muestra el disclaimer de "no implementado".
+- [x] Ciclos de calidad completos: backend (format, lint, 4567 tests, coverage 84.6%, build, validate-architecture) y frontend (format, lint 0 errores, type-check, 5301 tests, build, validate-architecture).
+
+#### 🔍 Verificación manual (backend real, dev)
+
+`POST /api/v1/contact` contra el servidor levantado: 200 con el mensaje de confirmación, `EmailService` loguea el envío (jsonTransport en dev), el 4.º request desde una IP no whitelisteada devuelve **429**, y un asunto con `\n` devuelve **400**. Nota: `127.0.0.1`/`::1` están whitelisteadas por defecto (`ip-whitelist.service.ts`), así que el rate limit no se ve desde localhost sin `X-Forwarded-For` — es el comportamiento de toda la app, no de este endpoint.
+
+> ⚠️ **Acción de Ops al deployar:** setear **`CONTACT_EMAIL_TO=consultas@auguriatarot.com`** en Railway.
+> **Sin ella el arranque en producción falla** (a propósito): un buzón de contacto sin destinatario es
+> exactamente el bug que esta tarea arregla, y preferimos que se note en el deploy y no en los mensajes
+> perdidos de los clientes.
 
 ---
 

--- a/frontend/src/app/contacto/page.test.tsx
+++ b/frontend/src/app/contacto/page.test.tsx
@@ -1,30 +1,47 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
 import { CONFIG } from '@/lib/constants';
 import ContactoPage from './page';
 
+// El formulario envía por TanStack Query (T-PROD-014): la página necesita el provider.
+vi.mock('@/lib/api/contact-api');
+
+const renderPage = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return render(<ContactoPage />, { wrapper: Wrapper });
+};
+
 describe('ContactoPage', () => {
   it('should render without errors', () => {
-    render(<ContactoPage />);
+    renderPage();
     expect(screen.getByText('Contacto')).toBeInTheDocument();
   });
 
   it('should display the main heading', () => {
-    render(<ContactoPage />);
+    renderPage();
     const heading = screen.getByRole('heading', { name: 'Contacto', level: 1 });
     expect(heading).toBeInTheDocument();
     expect(heading).toHaveClass('font-serif');
   });
 
   it('should display the subtitle', () => {
-    render(<ContactoPage />);
+    renderPage();
     expect(
       screen.getByText('¿Tienes preguntas o sugerencias? Nos encantaría escucharte')
     ).toBeInTheDocument();
   });
 
   it('should render the ContactForm component', () => {
-    render(<ContactoPage />);
+    renderPage();
     // Verify form fields from ContactForm are present
     expect(screen.getByLabelText(/nombre/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/correo electrónico/i)).toBeInTheDocument();
@@ -33,7 +50,7 @@ describe('ContactoPage', () => {
   });
 
   it('should display alternative contact information', () => {
-    render(<ContactoPage />);
+    renderPage();
     expect(screen.getByText('Otras formas de contacto')).toBeInTheDocument();
     expect(screen.getByText(CONFIG.CONTACT_EMAIL)).toBeInTheDocument();
     expect(
@@ -42,62 +59,63 @@ describe('ContactoPage', () => {
   });
 
   it('should publish the real contact mailbox of the auguriatarot.com domain', () => {
-    render(<ContactoPage />);
+    renderPage();
     expect(screen.getByText('consultas@auguriatarot.com')).toBeInTheDocument();
   });
 
   it('should NOT publish any address of the wrong auguria.com domain', () => {
-    const { container } = render(<ContactoPage />);
+    const { container } = renderPage();
     expect(container.textContent).not.toMatch(/@auguria\.com/);
   });
 
   it('should expose the contact email as a mailto link', () => {
-    render(<ContactoPage />);
+    renderPage();
     const link = screen.getByRole('link', { name: CONFIG.CONTACT_EMAIL });
     expect(link).toHaveAttribute('href', `mailto:${CONFIG.CONTACT_EMAIL}`);
   });
 
-  it('should display the disclaimer about form functionality', () => {
-    render(<ContactoPage />);
+  // T-PROD-014: el formulario ahora envía de verdad. El disclaimer decía que los
+  // mensajes "se muestran en la consola del navegador": dejarlo sería mentirle al
+  // visitante y desalentarlo de escribir.
+  it('ya no muestra el disclaimer de "envío no implementado"', () => {
+    renderPage();
     expect(
-      screen.getByText(
-        /Este formulario es funcional pero el envío de correos aún no está implementado/i
-      )
-    ).toBeInTheDocument();
+      screen.queryByText(/el envío de correos aún no está implementado/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('ya no renderiza el banner de disclaimer', () => {
+    renderPage();
+    expect(screen.queryByTestId('disclaimer-banner')).not.toBeInTheDocument();
   });
 
   it('should style the alternative contact section as a gold canon callout', () => {
-    render(<ContactoPage />);
+    renderPage();
     const callout = screen.getByTestId('contact-callout');
     expect(callout.className).toContain('bg-secondary/10');
     expect(callout.className).toContain('border-secondary');
   });
 
   it('should NOT use raw purple palette (off-canon)', () => {
-    const { container } = render(<ContactoPage />);
+    const { container } = renderPage();
     expect(container.querySelector('[class*="purple"]')).not.toBeInTheDocument();
   });
 
-  it('should render the disclaimer banner', () => {
-    render(<ContactoPage />);
-    expect(screen.getByTestId('disclaimer-banner')).toBeInTheDocument();
-  });
-
   it('should render submit button from ContactForm', () => {
-    render(<ContactoPage />);
+    renderPage();
     expect(screen.getByRole('button', { name: /enviar mensaje/i })).toBeInTheDocument();
   });
 
   describe('Canon styling', () => {
     it('should render the title with the Cormorant serif and brand primary tokens', () => {
-      render(<ContactoPage />);
+      renderPage();
       const title = screen.getByRole('heading', { name: 'Contacto', level: 1 });
       expect(title).toHaveClass('font-serif');
       expect(title.className).toContain('text-primary');
     });
 
     it('should render a gold accent icon in the header', () => {
-      render(<ContactoPage />);
+      renderPage();
       expect(screen.getByTestId('contact-accent')).toBeInTheDocument();
     });
   });

--- a/frontend/src/app/contacto/page.tsx
+++ b/frontend/src/app/contacto/page.tsx
@@ -1,6 +1,5 @@
 import { Mail, Sparkles } from 'lucide-react';
 
-import { DisclaimerBanner } from '@/components/ui/disclaimer-banner';
 import { Reveal } from '@/components/common/Reveal';
 import { ContactForm } from '@/components/features/contact/ContactForm';
 import { CONFIG } from '@/lib/constants';
@@ -13,7 +12,8 @@ import { CONFIG } from '@/lib/constants';
  * contacto como callout dorado de marca. La lógica del formulario vive en
  * `ContactForm` siguiendo la arquitectura feature-based.
  *
- * TODO: Implementar envío real de correo o integración con backend.
+ * El envío es real desde T-PROD-014 (`POST /contact`): ya no hay disclaimer de
+ * "envío no implementado".
  */
 export default function ContactoPage() {
   return (
@@ -68,9 +68,6 @@ export default function ContactoPage() {
             </div>
           </div>
         </Reveal>
-
-        {/* Disclaimer */}
-        <DisclaimerBanner message="Este formulario es funcional pero el envío de correos aún no está implementado. Los mensajes se muestran en la consola del navegador." />
       </div>
     </div>
   );

--- a/frontend/src/components/features/contact/ContactForm.test.tsx
+++ b/frontend/src/components/features/contact/ContactForm.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AxiosError, AxiosHeaders } from 'axios';
+import { ReactElement, ReactNode } from 'react';
 import { toast } from 'sonner';
+import * as contactApi from '@/lib/api/contact-api';
 import { ContactForm } from './ContactForm';
 
 // ContactForm muestra el feedback usando `toast` de sonner (ver ContactForm.tsx),
@@ -15,14 +19,45 @@ vi.mock('sonner', () => ({
   },
 }));
 
+vi.mock('@/lib/api/contact-api');
+
+/** El formulario envía por TanStack Query: sin provider no monta. */
+const renderForm = (ui: ReactElement = <ContactForm />) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return render(ui, { wrapper: Wrapper });
+};
+
+/** Error de axios con un status concreto (el 429 del rate limit del backend). */
+const axiosErrorWithStatus = (status: number) =>
+  new AxiosError('Request failed', 'ERR_BAD_REQUEST', undefined, undefined, {
+    status,
+    statusText: '',
+    data: {},
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  });
+
 describe('ContactForm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(contactApi.sendContactMessage).mockResolvedValue({
+      message: 'Mensaje enviado exitosamente. Te responderemos a la brevedad.',
+    });
   });
 
   describe('Rendering', () => {
     it('should render all form fields', () => {
-      render(<ContactForm />);
+      renderForm();
 
       expect(screen.getByLabelText(/nombre/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/correo electrónico/i)).toBeInTheDocument();
@@ -31,12 +66,12 @@ describe('ContactForm', () => {
     });
 
     it('should render submit button', () => {
-      render(<ContactForm />);
+      renderForm();
       expect(screen.getByRole('button', { name: /enviar mensaje/i })).toBeInTheDocument();
     });
 
     it('should have placeholder texts', () => {
-      render(<ContactForm />);
+      renderForm();
 
       expect(screen.getByPlaceholderText('Tu nombre completo')).toBeInTheDocument();
       expect(screen.getByPlaceholderText('tu@email.com')).toBeInTheDocument();
@@ -45,13 +80,13 @@ describe('ContactForm', () => {
     });
 
     it('should render icons for name, email, and subject fields', () => {
-      const { container } = render(<ContactForm />);
+      const { container } = renderForm();
       const icons = container.querySelectorAll('svg');
       expect(icons.length).toBeGreaterThanOrEqual(3);
     });
 
     it('should have required attributes on inputs', () => {
-      render(<ContactForm />);
+      renderForm();
 
       const nameInput = screen.getByLabelText(/nombre/i);
       const emailInput = screen.getByLabelText(/correo electrónico/i);
@@ -66,7 +101,7 @@ describe('ContactForm', () => {
     });
 
     it('should render form with proper HTML structure', () => {
-      const { container } = render(<ContactForm />);
+      const { container } = renderForm();
       const form = container.querySelector('form');
       expect(form).toBeInTheDocument();
       expect(form).toHaveClass('space-y-6');
@@ -75,7 +110,7 @@ describe('ContactForm', () => {
 
   describe('Canon styling', () => {
     it('should give the submit CTA a visible gold focus ring', () => {
-      render(<ContactForm />);
+      renderForm();
       const submitButton = screen.getByRole('button', { name: /enviar mensaje/i });
       expect(submitButton.className).toContain('focus-visible:ring-secondary');
     });
@@ -83,13 +118,13 @@ describe('ContactForm', () => {
 
   describe('Form Structure', () => {
     it('should use React Hook Form integration', () => {
-      render(<ContactForm />);
+      renderForm();
       const form = screen.getByRole('button', { name: /enviar mensaje/i }).closest('form');
       expect(form).toBeInTheDocument();
     });
 
     it('should have proper label associations', () => {
-      render(<ContactForm />);
+      renderForm();
 
       expect(screen.getByText('Nombre')).toBeInTheDocument();
       expect(screen.getByText(/correo electrónico/i)).toBeInTheDocument();
@@ -111,7 +146,7 @@ describe('ContactForm', () => {
     };
 
     it('should call toast.success after successful submission', async () => {
-      render(<ContactForm />);
+      renderForm();
       await fillAndSubmit();
 
       await waitFor(
@@ -125,7 +160,7 @@ describe('ContactForm', () => {
     });
 
     it('should NOT render inline success banner after submission', async () => {
-      render(<ContactForm />);
+      renderForm();
       await fillAndSubmit();
 
       await waitFor(() => expect(toast.success).toHaveBeenCalled(), { timeout: SUBMIT_TIMEOUT });
@@ -133,7 +168,7 @@ describe('ContactForm', () => {
     });
 
     it('should reset the form after successful submission', async () => {
-      render(<ContactForm />);
+      renderForm();
       const nameInput = screen.getByLabelText(/nombre/i);
       await fillAndSubmit();
 
@@ -141,12 +176,20 @@ describe('ContactForm', () => {
     });
 
     it('should NOT show inline alert initially', () => {
-      render(<ContactForm />);
+      renderForm();
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
 
     it('should show loading state during submission', async () => {
-      render(<ContactForm />);
+      // El envío queda en vuelo para poder observar el estado de carga.
+      let resolveSend: (value: { message: string }) => void = () => {};
+      vi.mocked(contactApi.sendContactMessage).mockReturnValue(
+        new Promise((resolve) => {
+          resolveSend = resolve;
+        })
+      );
+
+      renderForm();
       const user = userEvent.setup();
       await user.type(screen.getByLabelText(/nombre/i), 'Ana García');
       await user.type(screen.getByLabelText(/correo electrónico/i), 'ana@example.com');
@@ -161,7 +204,71 @@ describe('ContactForm', () => {
       });
 
       // Wait for submission to complete to avoid async leaks
+      resolveSend({ message: 'Mensaje enviado' });
       await waitFor(() => expect(toast.success).toHaveBeenCalled(), { timeout: SUBMIT_TIMEOUT });
+    });
+
+    // El bug de T-PROD-014: el formulario simulaba el envío con un setTimeout y el
+    // mensaje del cliente moría en la consola del navegador. Estos tests fijan que
+    // ahora sale de verdad hacia el backend.
+    it('envía el mensaje al backend con los datos del formulario', async () => {
+      renderForm();
+      await fillAndSubmit();
+
+      await waitFor(() => expect(contactApi.sendContactMessage).toHaveBeenCalledTimes(1), {
+        timeout: SUBMIT_TIMEOUT,
+      });
+
+      // Se compara el primer argumento: TanStack Query v5 le pasa además un segundo
+      // parámetro de contexto al mutationFn.
+      expect(vi.mocked(contactApi.sendContactMessage).mock.calls[0][0]).toEqual({
+        name: 'Ana García',
+        email: 'ana@example.com',
+        subject: 'Consulta de prueba',
+        message: 'Este es un mensaje de prueba.',
+      });
+    });
+
+    it('no canta éxito si el envío falla: muestra el alert de error y NO limpia el formulario', async () => {
+      vi.mocked(contactApi.sendContactMessage).mockRejectedValue(new Error('Network Error'));
+
+      renderForm();
+      const nameInput = screen.getByLabelText(/nombre/i);
+      await fillAndSubmit();
+
+      await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument(), {
+        timeout: SUBMIT_TIMEOUT,
+      });
+      expect(screen.getByRole('alert')).toHaveTextContent(/hubo un error al enviar tu mensaje/i);
+      expect(toast.success).not.toHaveBeenCalled();
+      // El texto escrito no se pierde: el usuario puede reintentar sin volver a tipearlo.
+      expect(nameInput).toHaveValue('Ana García');
+    });
+
+    it('ante un 429 avisa del límite de envíos en vez del error genérico', async () => {
+      vi.mocked(contactApi.sendContactMessage).mockRejectedValue(axiosErrorWithStatus(429));
+
+      renderForm();
+      await fillAndSubmit();
+
+      await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument(), {
+        timeout: SUBMIT_TIMEOUT,
+      });
+      expect(screen.getByRole('alert')).toHaveTextContent(/demasiados mensajes/i);
+    });
+
+    it('vuelve a habilitar el botón tras un error, para poder reintentar', async () => {
+      vi.mocked(contactApi.sendContactMessage).mockRejectedValue(new Error('Network Error'));
+
+      renderForm();
+      await fillAndSubmit();
+
+      await waitFor(
+        () => {
+          expect(screen.getByRole('button', { name: /enviar mensaje/i })).toBeEnabled();
+        },
+        { timeout: SUBMIT_TIMEOUT }
+      );
     });
   });
 });

--- a/frontend/src/components/features/contact/ContactForm.tsx
+++ b/frontend/src/components/features/contact/ContactForm.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Mail, MessageSquare, User } from 'lucide-react';
+import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
 
+import { useSendContactMessage } from '@/hooks/api/useSendContactMessage';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -13,25 +14,28 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { contactFormSchema, type ContactFormData } from '@/lib/validations/contact.schemas';
 
+const GENERIC_ERROR = 'Hubo un error al enviar tu mensaje. Por favor, intenta nuevamente.';
+const RATE_LIMIT_ERROR =
+  'Demasiados mensajes enviados. Esperá una hora antes de volver a escribirnos.';
+
+/** El backend limita el endpoint público a 3 mensajes/hora por IP: pasado el límite, 429. */
+function getErrorMessage(error: unknown): string {
+  if (isAxiosError(error) && error.response?.status === 429) {
+    return RATE_LIMIT_ERROR;
+  }
+  return GENERIC_ERROR;
+}
+
 /**
  * ContactForm component
  *
- * A complete contact form with name, email, subject, and message fields.
- * Uses React Hook Form with Zod validation.
+ * Formulario de contacto (nombre, email, asunto y mensaje) con React Hook Form + Zod.
  *
- * Features:
- * - Client-side validation with Zod schema
- * - Inline error messages for each field
- * - Loading state during submission
- * - Success/error feedback after submission
- * - Form reset after successful submission
- *
- * TODO: Implement backend endpoint for email sending
+ * El envío es real (T-PROD-014): `useSendContactMessage` lo manda a `POST /contact`, que
+ * lo hace llegar por email al buzón de Auguria con el remitente como Reply-To. Hasta esa
+ * tarea el `onSubmit` era un `setTimeout` que fingía el envío y perdía el mensaje.
  */
 export function ContactForm() {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [hasError, setHasError] = useState(false);
-
   const {
     register,
     handleSubmit,
@@ -47,24 +51,17 @@ export function ContactForm() {
     },
   });
 
-  const onSubmit = async () => {
-    setIsSubmitting(true);
-    setHasError(false);
+  const { mutate, isPending, error, isError } = useSendContactMessage();
 
-    try {
-      // TODO: Implementar envío real al backend
-      // await sendContactMessage(data);
-
-      // Simulación de envío
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-
-      toast.success('¡Mensaje enviado exitosamente! Nos pondremos en contacto contigo pronto.');
-      reset(); // Limpiar formulario
-    } catch {
-      setHasError(true);
-    } finally {
-      setIsSubmitting(false);
-    }
+  const onSubmit = (data: ContactFormData) => {
+    mutate(data, {
+      onSuccess: () => {
+        toast.success('¡Mensaje enviado exitosamente! Nos pondremos en contacto contigo pronto.');
+        reset();
+      },
+      // Sin onError: el mensaje de error sale de `error` y el formulario NO se limpia,
+      // para que el usuario pueda reintentar sin volver a escribir todo.
+    });
   };
 
   return (
@@ -79,7 +76,7 @@ export function ContactForm() {
           id="name"
           type="text"
           placeholder="Tu nombre completo"
-          disabled={isSubmitting}
+          disabled={isPending}
           {...register('name')}
         />
         {errors.name && <p className="text-destructive text-sm">{errors.name.message}</p>}
@@ -95,7 +92,7 @@ export function ContactForm() {
           id="email"
           type="email"
           placeholder="tu@email.com"
-          disabled={isSubmitting}
+          disabled={isPending}
           {...register('email')}
         />
         {errors.email && <p className="text-destructive text-sm">{errors.email.message}</p>}
@@ -111,7 +108,7 @@ export function ContactForm() {
           id="subject"
           type="text"
           placeholder="¿Sobre qué quieres contactarnos?"
-          disabled={isSubmitting}
+          disabled={isPending}
           {...register('subject')}
         />
         {errors.subject && <p className="text-destructive text-sm">{errors.subject.message}</p>}
@@ -124,7 +121,7 @@ export function ContactForm() {
           id="message"
           placeholder="Escribe tu mensaje aquí..."
           rows={6}
-          disabled={isSubmitting}
+          disabled={isPending}
           {...register('message')}
         />
         {errors.message && <p className="text-destructive text-sm">{errors.message.message}</p>}
@@ -134,18 +131,16 @@ export function ContactForm() {
       <Button
         type="submit"
         className="focus-visible:ring-secondary/50 w-full"
-        disabled={isSubmitting}
+        disabled={isPending}
         size="lg"
       >
-        {isSubmitting ? 'Enviando...' : 'Enviar Mensaje'}
+        {isPending ? 'Enviando...' : 'Enviar Mensaje'}
       </Button>
 
       {/* Error Message */}
-      {hasError && (
-        <Alert variant="destructive" role="alert" aria-live="polite">
-          <AlertDescription>
-            Hubo un error al enviar tu mensaje. Por favor, intenta nuevamente.
-          </AlertDescription>
+      {isError && (
+        <Alert variant="destructive" role="alert" aria-live="polite" data-testid="contact-error">
+          <AlertDescription>{getErrorMessage(error)}</AlertDescription>
         </Alert>
       )}
     </form>

--- a/frontend/src/hooks/api/useSendContactMessage.test.tsx
+++ b/frontend/src/hooks/api/useSendContactMessage.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Tests for useSendContactMessage (T-PROD-014)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import { useSendContactMessage } from './useSendContactMessage';
+import * as contactApi from '@/lib/api/contact-api';
+import type { ContactFormData } from '@/lib/validations/contact.schemas';
+
+vi.mock('@/lib/api/contact-api');
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  Wrapper.displayName = 'TestQueryClientWrapper';
+  return Wrapper;
+};
+
+const formData: ContactFormData = {
+  name: 'Ana García',
+  email: 'ana@example.com',
+  subject: 'Consulta de prueba',
+  message: 'Este es un mensaje de prueba.',
+};
+
+describe('useSendContactMessage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should send the message through the contact API', async () => {
+    vi.mocked(contactApi.sendContactMessage).mockResolvedValue({ message: 'Mensaje enviado' });
+
+    const { result } = renderHook(() => useSendContactMessage(), { wrapper: createWrapper() });
+
+    result.current.mutate(formData);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    // Se compara el primer argumento: TanStack Query v5 le pasa además un segundo
+    // parámetro de contexto al mutationFn.
+    expect(vi.mocked(contactApi.sendContactMessage).mock.calls[0][0]).toEqual(formData);
+  });
+
+  it('should expose the error state when the backend fails', async () => {
+    vi.mocked(contactApi.sendContactMessage).mockRejectedValue(new Error('Network Error'));
+
+    const { result } = renderHook(() => useSendContactMessage(), { wrapper: createWrapper() });
+
+    result.current.mutate(formData);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('should expose the pending state while the message is in flight', async () => {
+    vi.mocked(contactApi.sendContactMessage).mockImplementation(
+      () => new Promise(() => {}) // nunca resuelve: el envío queda en vuelo
+    );
+
+    const { result } = renderHook(() => useSendContactMessage(), { wrapper: createWrapper() });
+
+    result.current.mutate(formData);
+
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+  });
+});

--- a/frontend/src/hooks/api/useSendContactMessage.ts
+++ b/frontend/src/hooks/api/useSendContactMessage.ts
@@ -1,0 +1,22 @@
+/**
+ * TanStack Query hook for the public contact form (T-PROD-014)
+ */
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { sendContactMessage } from '@/lib/api/contact-api';
+import type { ContactFormData } from '@/lib/validations/contact.schemas';
+import type { ContactMessageResponse } from '@/types';
+
+/**
+ * Envía el mensaje del formulario de contacto.
+ *
+ * No invalida ninguna query: el mensaje sale por email, no queda en el estado del
+ * servidor. El componente usa `isPending` para el estado de carga y `error` para el
+ * mensaje de fallo (incluido el 429 del rate limit).
+ */
+export function useSendContactMessage() {
+  return useMutation<ContactMessageResponse, unknown, ContactFormData>({
+    mutationFn: sendContactMessage,
+  });
+}

--- a/frontend/src/lib/api/contact-api.test.ts
+++ b/frontend/src/lib/api/contact-api.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for contact-api (T-PROD-014)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apiClient } from './axios-config';
+import { API_ENDPOINTS } from './endpoints';
+import { sendContactMessage } from './contact-api';
+import type { ContactFormData } from '@/lib/validations/contact.schemas';
+
+vi.mock('./axios-config', () => ({
+  apiClient: {
+    post: vi.fn(),
+  },
+}));
+
+describe('contact-api', () => {
+  const formData: ContactFormData = {
+    name: 'Ana García',
+    email: 'ana@example.com',
+    subject: 'Consulta de prueba',
+    message: 'Este es un mensaje de prueba.',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('sendContactMessage', () => {
+    it('should post the form data to the centralized contact endpoint', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({ data: { message: 'Mensaje enviado' } });
+
+      await sendContactMessage(formData);
+
+      expect(apiClient.post).toHaveBeenCalledWith(API_ENDPOINTS.CONTACT.BASE, formData);
+    });
+
+    it('should return the backend confirmation', async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({
+        data: { message: 'Mensaje enviado exitosamente. Te responderemos a la brevedad.' },
+      });
+
+      const result = await sendContactMessage(formData);
+
+      expect(result.message).toBe('Mensaje enviado exitosamente. Te responderemos a la brevedad.');
+    });
+
+    it('should propagate the error: swallowing it here would resurrect the bug of the fake success', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('Network Error'));
+
+      await expect(sendContactMessage(formData)).rejects.toThrow('Network Error');
+    });
+  });
+});

--- a/frontend/src/lib/api/contact-api.ts
+++ b/frontend/src/lib/api/contact-api.ts
@@ -1,0 +1,22 @@
+/**
+ * API functions for the public contact form (T-PROD-014)
+ *
+ * Endpoint público (no requiere autenticación) y limitado a 3 mensajes/hora por IP en
+ * el backend: pasado el límite responde 429.
+ */
+
+import { apiClient } from './axios-config';
+import { API_ENDPOINTS } from './endpoints';
+import type { ContactFormData } from '@/lib/validations/contact.schemas';
+import type { ContactMessageResponse } from '@/types';
+
+/**
+ * Envía el mensaje del formulario de contacto al buzón de Auguria.
+ *
+ * Si falla, el error se propaga a propósito: el bug de esta tarea era mostrarle al
+ * visitante un "mensaje enviado" mientras el mensaje no salía a ningún lado.
+ */
+export async function sendContactMessage(data: ContactFormData): Promise<ContactMessageResponse> {
+  const response = await apiClient.post<ContactMessageResponse>(API_ENDPOINTS.CONTACT.BASE, data);
+  return response.data;
+}

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -16,6 +16,11 @@ export const API_ENDPOINTS = {
     RESET_PASSWORD: '/auth/reset-password',
   },
 
+  // Contacto (formulario público)
+  CONTACT: {
+    BASE: '/contact',
+  },
+
   // Categories
   CATEGORIES: {
     BASE: '/categories',

--- a/frontend/src/lib/validations/contact.schemas.ts
+++ b/frontend/src/lib/validations/contact.schemas.ts
@@ -15,7 +15,10 @@ export const contactFormSchema = z.object({
   subject: z
     .string()
     .min(5, 'El asunto debe tener al menos 5 caracteres')
-    .max(200, 'El asunto no puede exceder 200 caracteres'),
+    .max(200, 'El asunto no puede exceder 200 caracteres')
+    // El asunto viaja a una cabecera del email; el backend rechaza los saltos de línea
+    // (inyección de cabeceras). Espejarlo acá evita un 400 que el usuario no entendería.
+    .regex(/^[^\r\n]+$/, 'El asunto no puede contener saltos de línea'),
   message: z
     .string()
     .min(10, 'El mensaje debe tener al menos 10 caracteres')

--- a/frontend/src/types/contact.types.ts
+++ b/frontend/src/types/contact.types.ts
@@ -1,0 +1,8 @@
+/**
+ * Contact Types (T-PROD-014)
+ */
+
+/** Confirmación que devuelve `POST /contact` cuando el mensaje salió por email. */
+export interface ContactMessageResponse {
+  message: string;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -326,3 +326,6 @@ export type {
 
 // AdSense Types (T-PROD-008)
 export type { AdsByGoogleConfig, AdsByGoogleQueue } from './adsense.types';
+
+// Contact Types (T-PROD-014)
+export type { ContactMessageResponse } from './contact.types';


### PR DESCRIPTION
## 📋 Resumen

El formulario de `/contacto` **validaba, decía "¡Mensaje enviado!" y perdía el mensaje en la consola del navegador**: el `onSubmit` era un `setTimeout` de mentira y no existía endpoint de contacto en el backend. Esta tarea lo hace enviar de verdad.

Cierra **T-PROD-014** del [backlog de producción](docs/BACKLOG_PRODUCCION_2026_07.md).

## 🔧 Backend

- **Nuevo módulo `contact`**: `POST /contact` público (sin `JwtAuthGuard`), `SendContactMessageDto` espejando el schema Zod del frontend → `SendContactMessageUseCase`.
- **Rate limit 3 mensajes/hora por IP** (`@RateLimit` + `@Throttle`, igual que `auth/forgot-password`): endpoint público sin auth, sin límite sería un buzón de spam abierto.
- **`EmailService.sendContactMessageEmail()` + template `contact-message.hbs`**: envía al buzón de `CONTACT_EMAIL_TO` con el **`replyTo` en el email del visitante**, que pisa el default global — sin eso, responder el mensaje sería responderse al propio buzón de Auguria en vez de contestarle al cliente.
- **Nueva variable `CONTACT_EMAIL_TO`, obligatoria en producción** (el boot falla si falta, misma política que las SMTP de T-PROD-012): un buzón de contacto sin destinatario es exactamente el bug que esta tarea arregla, y preferimos que se note en el deploy y no en los mensajes perdidos de los clientes.
- **Si el SMTP falla, devuelve 500** y loguea remitente + asunto (a diferencia de las alertas de costo, que se tragan el error): nunca más un "enviado" falso.
- **Endurecimiento**: el asunto rechaza saltos de línea — viaja a una cabecera del email y un `\n` permitiría inyectar un `Bcc:` desde un endpoint sin auth. El template escapa el HTML del cuerpo (lo escribe un desconocido).

## 🎨 Frontend

- `API_ENDPOINTS.CONTACT` + `lib/api/contact-api.ts` + hook `useSendContactMessage` (TanStack Query) cableado en el `onSubmit` de `ContactForm`.
- Estados reales: `isPending` deshabilita el formulario; el error muestra el `Alert` (con mensaje propio para el **429**) y **no** limpia lo escrito, para poder reintentar sin volver a tipear todo.
- **Eliminado el `DisclaimerBanner`** ("el envío de correos aún no está implementado") y los `TODO` de la página y del componente.

## ✅ Validaciones

**Backend:** format · lint (0 errores) · **4567 tests** · coverage 84.6% · build · `validate-architecture.js`
**Frontend:** format · lint (0 errores) · type-check · **5301 tests** · build · `validate-architecture.js`

**Verificación manual contra el backend real (dev):**
- `POST /api/v1/contact` → `200` + confirmación; `EmailService` loguea el envío.
- 3×200 y el **4.º request → `429`** (`retryAfter: 3600`) desde una IP no whitelisteada.
- Asunto con `\n` → **`400`** ("El asunto no puede contener saltos de línea").

> ℹ️ `127.0.0.1`/`::1` están whitelisteadas por defecto (`ip-whitelist.service.ts`), así que el rate limit no se observa desde localhost sin `X-Forwarded-For`. Es el comportamiento de toda la app, no de este endpoint.

## 🚀 Acción de Ops al deployar

Setear **`CONTACT_EMAIL_TO=consultas@auguriatarot.com`** en Railway. **Sin ella el arranque en producción falla a propósito.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)