### PR TITLE
fix(premium): ReadingLimitReached no ofrece Premium a usuarios premium (T-PROD-019)

### DIFF
--- a/backend/tarot-app/src/modules/holistic-services/infrastructure/controllers/holistic-services.controller.spec.ts
+++ b/backend/tarot-app/src/modules/holistic-services/infrastructure/controllers/holistic-services.controller.spec.ts
@@ -5,6 +5,7 @@ import { HolisticServicesOrchestratorService } from '../../application/orchestra
 import { PurchaseResponseDto } from '../../application/dto/purchase-response.dto';
 import { CreatePurchaseDto } from '../../application/dto/purchase.dto';
 import { PurchaseStatus } from '../../domain/enums/purchase-status.enum';
+import { PurchaseWhitelistGuard } from '../../../../common/guards/purchase-whitelist.guard';
 
 describe('HolisticServicesController', () => {
   let controller: HolisticServicesController;
@@ -53,7 +54,12 @@ describe('HolisticServicesController', () => {
           useValue: mockOrchestrator,
         },
       ],
-    }).compile();
+    })
+      // El PurchaseWhitelistGuard necesita ConfigService (no está en este módulo de test);
+      // su comportamiento se cubre en purchase-whitelist.guard.spec.ts. Acá se anula.
+      .overrideGuard(PurchaseWhitelistGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get<HolisticServicesController>(
       HolisticServicesController,

--- a/backend/tarot-app/src/modules/subscriptions/subscriptions.controller.spec.ts
+++ b/backend/tarot-app/src/modules/subscriptions/subscriptions.controller.spec.ts
@@ -13,6 +13,7 @@ import {
   UserTarotistaSubscription,
 } from '../tarotistas/entities/user-tarotista-subscription.entity';
 import { CreatePreapprovalUseCase } from './application/use-cases/create-preapproval.use-case';
+import { PurchaseWhitelistGuard } from '../../common/guards/purchase-whitelist.guard';
 import { CancelSubscriptionUseCase } from './application/use-cases/cancel-subscription.use-case';
 import { CheckSubscriptionStatusUseCase } from './application/use-cases/check-subscription-status.use-case';
 import {
@@ -58,7 +59,12 @@ describe('SubscriptionsController', () => {
           },
         },
       ],
-    }).compile();
+    })
+      // El PurchaseWhitelistGuard necesita ConfigService (no está en este módulo de test);
+      // su comportamiento se cubre en purchase-whitelist.guard.spec.ts. Acá se anula.
+      .overrideGuard(PurchaseWhitelistGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get<SubscriptionsController>(SubscriptionsController);
     service = module.get<SubscriptionsService>(SubscriptionsService);

--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -1495,8 +1495,9 @@ indexación — y es también la evidencia que mira AdSense en T-PROD-009.
 
 ---
 
-### T-PROD-019: El CTA de "Límite Alcanzado" Manda a un 404 y Ofrece Premium a Usuarios Premium
+### T-PROD-019: El CTA de "Límite Alcanzado" Manda a un 404 y Ofrece Premium a Usuarios Premium — ✅ COMPLETADA
 
+**Estado:** ✅ COMPLETADA (2026-07-21)
 **Prioridad:** 🟠 Alta
 **Estimación:** 0.5 punto
 **Dependencias:** ninguna
@@ -1524,20 +1525,20 @@ Dos bugs en los componentes de "límite alcanzado" del flujo de tarot/carta del 
 #### ✅ Tareas específicas
 
 - [x] `/planes` → `ROUTES.PREMIUM` en ambos componentes (hecho en `develop`).
-- [ ] En `ReadingLimitReached`, agregar `const isPremium = capabilities?.plan === 'premium'` y ramificar
+- [x] En `ReadingLimitReached`, agregado `const isPremium = capabilities?.plan === 'premium'` y ramificado
       (espejando `DailyCardLimitReached`):
-  - **Premium:** título/descripción tipo *"Alcanzaste tus N tiradas de hoy — se reinician mañana"*, **sin** el
-    bloque "Actualiza a Premium" ni el botón de upgrade. Mantener las acciones de historial/carta del día.
+  - **Premium:** descripción *"Se reinician mañana"* + recordatorio *"Tu límite se reinicia mañana"*, **sin** el
+    bloque "Actualiza a Premium" ni el botón de upgrade. Se mantienen las acciones de historial/carta del día.
   - **Free:** el comportamiento actual (con el CTA a `/premium`).
-- [ ] Actualizar/añadir tests: caso premium (no aparece el botón de upgrade ni el bloque de beneficios) y caso
-      free (sí aparece y navega a `/premium`).
+- [x] Tests: bloque `usuario premium` (no aparece el botón de upgrade ni el bloque de beneficios; sí el mensaje
+      de reinicio) + los free existentes (navegan a `/premium`). 15/15 pasan.
 
 #### 🎯 Criterios de Aceptación
 
-- [ ] Un usuario **free** que agota su tirada ve el CTA y "Hazte Premium" lo lleva a `/premium` (no 404).
-- [ ] Un usuario **premium** que agota sus 3 tiradas ve un mensaje de "se reinicia mañana" **sin** ofertas de
+- [x] Un usuario **free** que agota su tirada ve el CTA y "Hazte Premium" lo lleva a `/premium` (no 404).
+- [x] Un usuario **premium** que agota sus 3 tiradas ve un mensaje de "se reinicia mañana" **sin** ofertas de
       upgrade.
-- [ ] Ciclo de calidad frontend completo pasa.
+- [x] Ciclo de calidad frontend completo pasa (15 tests, lint, type-check, build, validate-architecture).
 
 #### 📌 Fuera de alcance
 

--- a/frontend/src/components/features/readings/ReadingLimitReached.test.tsx
+++ b/frontend/src/components/features/readings/ReadingLimitReached.test.tsx
@@ -176,4 +176,16 @@ describe('ReadingLimitReached', () => {
       expect(screen.getByRole('button', { name: /Carta del día/i })).toBeInTheDocument();
     });
   });
+
+  describe('estado de carga (capabilities aún no resueltas)', () => {
+    it('renderiza sin romper y cae al comportamiento free por defecto', () => {
+      mockUseUserCapabilities.mockReturnValue({ data: undefined, isLoading: true });
+
+      render(<ReadingLimitReached />);
+
+      // No crashea y muestra el título; sin plan definido se trata como free (fail-safe)
+      expect(screen.getByText('Límite de tiradas alcanzado')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Mejorar a Premium/i })).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/features/readings/ReadingLimitReached.test.tsx
+++ b/frontend/src/components/features/readings/ReadingLimitReached.test.tsx
@@ -143,4 +143,37 @@ describe('ReadingLimitReached', () => {
     expect(historyButton).toBeInTheDocument();
     expect(dailyCardButton).toBeInTheDocument();
   });
+
+  describe('usuario premium (agotó sus tiradas del día)', () => {
+    beforeEach(() => {
+      mockUseUserCapabilities.mockReturnValue({
+        data: {
+          plan: 'premium',
+          tarotReadings: { used: 3, limit: 3 },
+        },
+        isLoading: false,
+      });
+    });
+
+    it('NO ofrece "Hazte Premium" a quien ya es premium', () => {
+      render(<ReadingLimitReached />);
+
+      expect(screen.queryByRole('button', { name: /Mejorar a Premium/i })).not.toBeInTheDocument();
+      expect(screen.queryByText('Actualiza a Premium')).not.toBeInTheDocument();
+      expect(screen.queryByText(/actualiza a PREMIUM para/i)).not.toBeInTheDocument();
+    });
+
+    it('muestra que el límite se reinicia mañana', () => {
+      render(<ReadingLimitReached />);
+
+      expect(screen.getByText(/se reinician mañana/i)).toBeInTheDocument();
+    });
+
+    it('mantiene las acciones de historial y carta del día', () => {
+      render(<ReadingLimitReached />);
+
+      expect(screen.getByRole('button', { name: /Ver historial/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Carta del día/i })).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/features/readings/ReadingLimitReached.tsx
+++ b/frontend/src/components/features/readings/ReadingLimitReached.tsx
@@ -84,12 +84,12 @@ export function ReadingLimitReached() {
           /* PREMIUM: recordatorio de reinicio, sin oferta de upgrade */
           <div className="bg-primary/5 rounded-lg p-4 text-center">
             <div className="mb-2 flex items-center justify-center gap-2">
-              <Sparkles className="text-primary h-5 w-5" />
+              <Calendar className="text-primary h-5 w-5" />
               <p className="font-semibold">Tu límite se reinicia mañana</p>
             </div>
             <p className="text-text-muted text-sm">
-              Ya usaste tus {tarotLimit} tiradas de hoy. Mientras tanto, podés revisar tu historial
-              o consultar tu carta del día.
+              Ya usaste tus {tarotLimit} {tarotLimit === 1 ? 'tirada' : 'tiradas'} de hoy. Mientras
+              tanto, podés revisar tu historial o consultar tu carta del día.
             </p>
           </div>
         ) : (

--- a/frontend/src/components/features/readings/ReadingLimitReached.tsx
+++ b/frontend/src/components/features/readings/ReadingLimitReached.tsx
@@ -37,6 +37,9 @@ export function ReadingLimitReached() {
   const tarotCount = capabilities?.tarotReadings.used ?? 0;
   const tarotLimit = capabilities?.tarotReadings.limit ?? 1;
 
+  // PREMIUM: no upgrade CTA — el usuario ya tiene el plan, solo espera el reinicio diario.
+  const isPremium = capabilities?.plan === 'premium';
+
   const handleViewHistory = () => {
     router.push('/historial');
   };
@@ -61,82 +64,110 @@ export function ReadingLimitReached() {
           <span className="font-semibold">
             {tarotCount} de {tarotLimit} {tarotLimit === 1 ? 'tirada' : 'tiradas'}
           </span>{' '}
-          de tarot hoy. Puedes crear una nueva tirada mañana, o{' '}
-          <span className="text-primary font-semibold">
-            actualiza a PREMIUM para 3 tiradas diarias
-          </span>
-          .
+          de tarot hoy.{' '}
+          {isPremium ? (
+            'Se reinician mañana.'
+          ) : (
+            <>
+              Puedes crear una nueva tirada mañana, o{' '}
+              <span className="text-primary font-semibold">
+                actualiza a PREMIUM para 3 tiradas diarias
+              </span>
+              .
+            </>
+          )}
         </CardDescription>
       </CardHeader>
 
       <CardContent className="space-y-4">
-        {/* Premium Benefits CTA */}
-        <div className="border-secondary/40 bg-secondary/10 rounded-lg border p-4">
-          <div className="mb-3 flex items-center gap-2">
-            <Crown className="text-secondary h-5 w-5" />
-            <p className="text-lg font-semibold">Actualiza a Premium</p>
+        {isPremium ? (
+          /* PREMIUM: recordatorio de reinicio, sin oferta de upgrade */
+          <div className="bg-primary/5 rounded-lg p-4 text-center">
+            <div className="mb-2 flex items-center justify-center gap-2">
+              <Sparkles className="text-primary h-5 w-5" />
+              <p className="font-semibold">Tu límite se reinicia mañana</p>
+            </div>
+            <p className="text-text-muted text-sm">
+              Ya usaste tus {tarotLimit} tiradas de hoy. Mientras tanto, podés revisar tu historial
+              o consultar tu carta del día.
+            </p>
           </div>
-          <ul className="space-y-2 text-sm">
-            <li className="flex items-start gap-2">
-              <Sparkles className="text-primary mt-0.5 h-4 w-4 shrink-0" />
-              <span>
-                <strong>3 tiradas completas por día</strong> (vs 1 tirada gratis)
-              </span>
-            </li>
-            <li className="flex items-start gap-2">
-              <Sparkles className="text-primary mt-0.5 h-4 w-4 shrink-0" />
-              <span>
-                <strong>Todas las tiradas disponibles</strong> (1, 3, 5 cartas y Cruz Céltica)
-              </span>
-            </li>
-            <li className="flex items-start gap-2">
-              <Sparkles className="text-primary mt-0.5 h-4 w-4 shrink-0" />
-              <span>
-                <strong>Interpretaciones personalizadas y profundas</strong> en todas tus lecturas
-              </span>
-            </li>
-            <li className="flex items-start gap-2">
-              <Sparkles className="text-primary mt-0.5 h-4 w-4 shrink-0" />
-              <span>
-                <strong>Preguntas personalizadas</strong> para lecturas más precisas
-              </span>
-            </li>
-            <li className="flex items-start gap-2">
-              <Sparkles className="text-primary mt-0.5 h-4 w-4 shrink-0" />
-              <span>
-                <strong>Carta del día con interpretación completa todos los días</strong>
-              </span>
-            </li>
-          </ul>
-        </div>
+        ) : (
+          <>
+            {/* Premium Benefits CTA */}
+            <div className="border-secondary/40 bg-secondary/10 rounded-lg border p-4">
+              <div className="mb-3 flex items-center gap-2">
+                <Crown className="text-secondary h-5 w-5" />
+                <p className="text-lg font-semibold">Actualiza a Premium</p>
+              </div>
+              <ul className="space-y-2 text-sm">
+                <li className="flex items-start gap-2">
+                  <Sparkles className="text-primary mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    <strong>3 tiradas completas por día</strong> (vs 1 tirada gratis)
+                  </span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <Sparkles className="text-primary mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    <strong>Todas las tiradas disponibles</strong> (1, 3, 5 cartas y Cruz Céltica)
+                  </span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <Sparkles className="text-primary mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    <strong>Interpretaciones personalizadas y profundas</strong> en todas tus
+                    lecturas
+                  </span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <Sparkles className="text-primary mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    <strong>Preguntas personalizadas</strong> para lecturas más precisas
+                  </span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <Sparkles className="text-primary mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    <strong>Carta del día con interpretación completa todos los días</strong>
+                  </span>
+                </li>
+              </ul>
+            </div>
 
-        {/* Quick Actions */}
-        <div className="bg-primary/5 rounded-lg p-4 text-center text-sm">
-          <p className="mb-2 font-medium">Mientras tanto, puedes:</p>
-          <ul className="space-y-1 text-left">
-            <li className="flex items-center gap-2">
-              <span className="text-primary">✓</span> Ver todas tus lecturas pasadas en el historial
-            </li>
-            <li className="flex items-center gap-2">
-              <span className="text-primary">✓</span> Obtener tu carta del día (si aún no la
-              recibiste)
-            </li>
-            <li className="flex items-center gap-2">
-              <span className="text-primary">✓</span> Volver mañana para una nueva lectura gratuita
-            </li>
-          </ul>
-        </div>
+            {/* Quick Actions */}
+            <div className="bg-primary/5 rounded-lg p-4 text-center text-sm">
+              <p className="mb-2 font-medium">Mientras tanto, puedes:</p>
+              <ul className="space-y-1 text-left">
+                <li className="flex items-center gap-2">
+                  <span className="text-primary">✓</span> Ver todas tus lecturas pasadas en el
+                  historial
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="text-primary">✓</span> Obtener tu carta del día (si aún no la
+                  recibiste)
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="text-primary">✓</span> Volver mañana para una nueva lectura
+                  gratuita
+                </li>
+              </ul>
+            </div>
+          </>
+        )}
       </CardContent>
 
       <CardFooter className="flex flex-col gap-3">
-        <Button
-          onClick={handleUpgradePremium}
-          className="focus-visible:ring-secondary/50 w-full"
-          size="lg"
-        >
-          <Crown className="h-4 w-4" />
-          {CTA_PREMIUM.LIMIT_REACHED}
-        </Button>
+        {!isPremium && (
+          <Button
+            onClick={handleUpgradePremium}
+            className="focus-visible:ring-secondary/50 w-full"
+            size="lg"
+          >
+            <Crown className="h-4 w-4" />
+            {CTA_PREMIUM.LIMIT_REACHED}
+          </Button>
+        )}
         <div className="flex w-full flex-col gap-2 sm:flex-row">
           <Button
             onClick={handleViewHistory}


### PR DESCRIPTION
## 🎯 Tarea

**T-PROD-019** — El CTA de "límite alcanzado" mandaba a un 404 y ofrecía Premium a usuarios que ya son premium.

## 📋 Problema

1. **404**: el CTA "Hazte Premium" hacía `router.push('/planes')` (ruta inexistente). → ya corregido en `develop` a `ROUTES.PREMIUM`.
2. **`ReadingLimitReached` no diferenciaba premium**: a un premium que agota sus 3 tiradas/día le mostraba *"actualiza a PREMIUM para 3 tiradas diarias"* (que ya tiene). `DailyCardLimitReached` sí diferencia; este no.

## ✅ Cambios (este PR)

- `ReadingLimitReached` ahora detecta `capabilities.plan === 'premium'` y ramifica, espejando `DailyCardLimitReached`:
  - **Premium**: descripción *"Se reinician mañana"* + recordatorio *"Tu límite se reinicia mañana"*, **sin** el bloque "Actualiza a Premium" ni el botón de upgrade.
  - **Free**: comportamiento de siempre (CTA → `/premium`).
- Tests: nuevo bloque `usuario premium` (no aparece el botón ni el bloque de beneficios; sí el mensaje de reinicio) + los free existentes. **15/15**.

## 🧪 Validaciones

- [x] TDD (test premium en rojo → verde)
- [x] `format`, `lint:fix` (0 errores), `type-check`
- [x] `test:run` afectados: 15/15
- [x] `build` + `validate-architecture.js`
- [x] Backlog T-PROD-019 marcado completado

🤖 Generated with [Claude Code](https://claude.com/claude-code)