### PR TITLE
fix(subscriptions): resetear consumo del día al activar Premium

### DIFF
--- a/backend/tarot-app/src/modules/subscriptions/application/use-cases/process-subscription-webhook.use-case.spec.ts
+++ b/backend/tarot-app/src/modules/subscriptions/application/use-cases/process-subscription-webhook.use-case.spec.ts
@@ -7,6 +7,7 @@ import { MercadoPagoService } from '../../../payments/infrastructure/services/me
 import { USER_REPOSITORY } from '../../../users/domain/interfaces/repository.tokens';
 import { IUserRepository } from '../../../users/domain/interfaces/user-repository.interface';
 import { EmailService } from '../../../email/email.service';
+import { UsageLimitsService } from '../../../usage-limits/usage-limits.service';
 import {
   User,
   UserPlan,
@@ -53,6 +54,12 @@ describe('ProcessSubscriptionWebhookUseCase', () => {
     sendPlanChangeEmail: jest.fn(),
   };
 
+  const mockUsageLimitsService: jest.Mocked<
+    Pick<UsageLimitsService, 'resetTodayUsage'>
+  > = {
+    resetTodayUsage: jest.fn(),
+  };
+
   const makeUser = (overrides: Partial<User> = {}): User => {
     const user = new User();
     user.id = 42;
@@ -77,6 +84,7 @@ describe('ProcessSubscriptionWebhookUseCase', () => {
         { provide: USER_REPOSITORY, useValue: mockUserRepo },
         { provide: MercadoPagoService, useValue: mockMercadoPagoService },
         { provide: EmailService, useValue: mockEmailService },
+        { provide: UsageLimitsService, useValue: mockUsageLimitsService },
       ],
     }).compile();
 
@@ -93,6 +101,7 @@ describe('ProcessSubscriptionWebhookUseCase', () => {
     // Default: signature is valid
     mockMercadoPagoService.validateSignature.mockReturnValue(true);
     mockEmailService.sendPlanChangeEmail.mockResolvedValue(undefined);
+    mockUsageLimitsService.resetTodayUsage.mockResolvedValue(0);
   });
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -220,6 +229,81 @@ describe('ProcessSubscriptionWebhookUseCase', () => {
 
       expect(result.processed).toBe(true);
       expect(mockUserRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('debe resetear el consumo del día al activar premium (evita que las tiradas free descuenten de la cuota premium)', async () => {
+      const user = makeUser({ id: 42, plan: UserPlan.FREE });
+
+      mockMercadoPagoService.getPreapproval.mockResolvedValue(
+        buildPreapprovalResponse({
+          id: 'preapproval-123',
+          status: 'authorized',
+          external_reference: 'sub_42',
+        }),
+      );
+      mockUserRepo.findById.mockResolvedValue(user);
+      mockUserRepo.save.mockResolvedValue({ ...user } as User);
+      mockUsageLimitsService.resetTodayUsage.mockResolvedValue(1);
+
+      await useCase.execute(
+        makePreapprovalPayload('preapproval-123'),
+        xSignature,
+        xRequestId,
+      );
+
+      expect(mockUsageLimitsService.resetTodayUsage).toHaveBeenCalledWith(42);
+    });
+
+    it('no debe fallar la activación si el reseteo del consumo del día falla', async () => {
+      const user = makeUser({ id: 42, plan: UserPlan.FREE });
+
+      mockMercadoPagoService.getPreapproval.mockResolvedValue(
+        buildPreapprovalResponse({
+          id: 'preapproval-123',
+          status: 'authorized',
+          external_reference: 'sub_42',
+        }),
+      );
+      mockUserRepo.findById.mockResolvedValue(user);
+      mockUserRepo.save.mockResolvedValue({ ...user } as User);
+      mockUsageLimitsService.resetTodayUsage.mockRejectedValue(
+        new Error('DB caída'),
+      );
+
+      const result = await useCase.execute(
+        makePreapprovalPayload('preapproval-123'),
+        xSignature,
+        xRequestId,
+      );
+
+      expect(result.processed).toBe(true);
+      expect(mockUserRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('no debe resetear el consumo del día en una notificación duplicada', async () => {
+      const user = makeUser({
+        id: 42,
+        plan: UserPlan.PREMIUM,
+        subscriptionStatus: SubscriptionStatus.ACTIVE,
+        mpPreapprovalId: 'preapproval-123',
+      });
+
+      mockMercadoPagoService.getPreapproval.mockResolvedValue(
+        buildPreapprovalResponse({
+          id: 'preapproval-123',
+          status: 'authorized',
+          external_reference: 'sub_42',
+        }),
+      );
+      mockUserRepo.findById.mockResolvedValue(user);
+
+      await useCase.execute(
+        makePreapprovalPayload('preapproval-123'),
+        xSignature,
+        xRequestId,
+      );
+
+      expect(mockUsageLimitsService.resetTodayUsage).not.toHaveBeenCalled();
     });
 
     it('no debe enviar el email de cambio de plan en una notificación duplicada', async () => {

--- a/backend/tarot-app/src/modules/subscriptions/application/use-cases/process-subscription-webhook.use-case.spec.ts
+++ b/backend/tarot-app/src/modules/subscriptions/application/use-cases/process-subscription-webhook.use-case.spec.ts
@@ -281,11 +281,16 @@ describe('ProcessSubscriptionWebhookUseCase', () => {
     });
 
     it('no debe resetear el consumo del día en una notificación duplicada', async () => {
+      // Idempotencia estricta: mismo preapprovalId Y misma fecha de expiración,
+      // para garantizar que se ejercita el path de "notificación duplicada real"
+      // (no el de "actualizar campos de suscripción").
+      const nextPaymentDate = '2026-04-26T10:00:00.000Z';
       const user = makeUser({
         id: 42,
         plan: UserPlan.PREMIUM,
         subscriptionStatus: SubscriptionStatus.ACTIVE,
         mpPreapprovalId: 'preapproval-123',
+        planExpiresAt: new Date(nextPaymentDate),
       });
 
       mockMercadoPagoService.getPreapproval.mockResolvedValue(
@@ -293,6 +298,7 @@ describe('ProcessSubscriptionWebhookUseCase', () => {
           id: 'preapproval-123',
           status: 'authorized',
           external_reference: 'sub_42',
+          next_payment_date: nextPaymentDate,
         }),
       );
       mockUserRepo.findById.mockResolvedValue(user);

--- a/backend/tarot-app/src/modules/subscriptions/application/use-cases/process-subscription-webhook.use-case.ts
+++ b/backend/tarot-app/src/modules/subscriptions/application/use-cases/process-subscription-webhook.use-case.ts
@@ -13,6 +13,7 @@ import {
   SubscriptionStatus,
 } from '../../../users/entities/user.entity';
 import { EmailService } from '../../../email/email.service';
+import { UsageLimitsService } from '../../../usage-limits/usage-limits.service';
 
 /** Etiquetas de los planes tal como se muestran al usuario en el email */
 const PLAN_LABELS: Record<UserPlan, string> = {
@@ -30,6 +31,7 @@ export class ProcessSubscriptionWebhookUseCase {
     private readonly userRepo: IUserRepository,
     private readonly mercadoPagoService: MercadoPagoService,
     private readonly emailService: EmailService,
+    private readonly usageLimitsService: UsageLimitsService,
   ) {}
 
   async execute(
@@ -242,6 +244,23 @@ export class ProcessSubscriptionWebhookUseCase {
     this.logger.log(
       `Usuario ${user.id} activado como PREMIUM (preapproval: ${preapprovalId})`,
     );
+
+    // Resetear el consumo de hoy para que las lecturas hechas bajo el plan
+    // anterior no descuenten de la cuota del plan Premium en la misma ventana
+    // diaria. No crítico: un fallo aquí no debe romper la activación del pago.
+    try {
+      const deleted = await this.usageLimitsService.resetTodayUsage(user.id);
+      if (deleted > 0) {
+        this.logger.log(
+          `Consumo del día reseteado para usuario ${user.id} tras upgrade a Premium (${deleted} registros)`,
+        );
+      }
+    } catch (error) {
+      this.logger.error(
+        `Error al resetear el consumo del día del usuario ${user.id} tras upgrade a Premium`,
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
 
     await this.notifyPlanChange(user, previousPlan);
 

--- a/backend/tarot-app/src/modules/subscriptions/subscriptions.module.ts
+++ b/backend/tarot-app/src/modules/subscriptions/subscriptions.module.ts
@@ -8,6 +8,7 @@ import { Tarotista } from '../tarotistas/entities/tarotista.entity';
 import { UsersModule } from '../users/users.module';
 import { PaymentsModule } from '../payments/payments.module';
 import { EmailModule } from '../email/email.module';
+import { UsageLimitsModule } from '../usage-limits/usage-limits.module';
 import { CreatePreapprovalUseCase } from './application/use-cases/create-preapproval.use-case';
 import { CancelSubscriptionUseCase } from './application/use-cases/cancel-subscription.use-case';
 import { CheckSubscriptionStatusUseCase } from './application/use-cases/check-subscription-status.use-case';
@@ -21,6 +22,7 @@ import { SUBSCRIPTION_WEBHOOK_USE_CASE } from '../payments/tokens/payment.tokens
     TypeOrmModule.forFeature([UserTarotistaSubscription, User, Tarotista]),
     UsersModule,
     EmailModule,
+    UsageLimitsModule,
     forwardRef(() => PaymentsModule),
   ],
   controllers: [SubscriptionsController],

--- a/backend/tarot-app/src/modules/usage-limits/usage-limits.service.spec.ts
+++ b/backend/tarot-app/src/modules/usage-limits/usage-limits.service.spec.ts
@@ -875,4 +875,47 @@ describe('UsageLimitsService', () => {
       });
     });
   });
+
+  describe('resetTodayUsage', () => {
+    it("should delete today's usage records for the user and return affected count", async () => {
+      const mockQueryBuilder = {
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 2 }),
+      };
+
+      mockUsageLimitRepository.createQueryBuilder.mockReturnValue(
+        mockQueryBuilder,
+      );
+
+      const result = await service.resetTodayUsage(1);
+
+      expect(result).toBe(2);
+      expect(mockQueryBuilder.delete).toHaveBeenCalled();
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith('userId = :userId', {
+        userId: 1,
+      });
+      expect(mockQueryBuilder.execute).toHaveBeenCalled();
+    });
+
+    it('should return 0 when there are no records for today', async () => {
+      const mockQueryBuilder = {
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 0 }),
+      };
+
+      mockUsageLimitRepository.createQueryBuilder.mockReturnValue(
+        mockQueryBuilder,
+      );
+
+      const result = await service.resetTodayUsage(999);
+
+      expect(result).toBe(0);
+    });
+  });
 });

--- a/backend/tarot-app/src/modules/usage-limits/usage-limits.service.ts
+++ b/backend/tarot-app/src/modules/usage-limits/usage-limits.service.ts
@@ -196,6 +196,10 @@ export class UsageLimitsService {
    * para que el consumo acumulado bajo el plan anterior no se descuente de la
    * cuota del nuevo plan dentro de la misma ventana diaria.
    *
+   * NOTA: borra el consumo de TODAS las features del día (tarot, carta del día,
+   * péndulo, etc.), no solo tarot. Es intencional: al cambiar de plan el usuario
+   * "empieza limpio" el día con la cuota completa del plan nuevo en cada feature.
+   *
    * @returns Cantidad de registros eliminados.
    */
   async resetTodayUsage(userId: number): Promise<number> {

--- a/backend/tarot-app/src/modules/usage-limits/usage-limits.service.ts
+++ b/backend/tarot-app/src/modules/usage-limits/usage-limits.service.ts
@@ -190,6 +190,27 @@ export class UsageLimitsService {
     return Math.max(0, limit - currentCount);
   }
 
+  /**
+   * Resetea el consumo de HOY de un usuario borrando todos sus registros de uso
+   * del día en curso. Se usa al activar/cambiar el plan (p.ej. upgrade a Premium)
+   * para que el consumo acumulado bajo el plan anterior no se descuente de la
+   * cuota del nuevo plan dentro de la misma ventana diaria.
+   *
+   * @returns Cantidad de registros eliminados.
+   */
+  async resetTodayUsage(userId: number): Promise<number> {
+    const todayStr = getTodayUTCDateString();
+
+    const result = await this.usageLimitRepository
+      .createQueryBuilder()
+      .delete()
+      .where('userId = :userId', { userId })
+      .andWhere('date = :date', { date: todayStr })
+      .execute();
+
+    return result.affected || 0;
+  }
+
   async cleanOldRecords(): Promise<number> {
     const cutoffDateStr = getDateDaysAgoUTCString(USAGE_RETENTION_DAYS);
 


### PR DESCRIPTION
## Contexto

Bug reportado en producción: **una tirada hecha como usuario `free` seguía contando para la cuota diaria de `premium` tras el upgrade.**

## Causa raíz

El consumo se contabiliza por `(userId, feature, date)` sin dimensión de plan. Como el límite Premium de tiradas **no es ilimitado** (3/día en los seeds), el `count` acumulado bajo el plan Free se seguía descontando de la cuota Premium dentro de la misma ventana diaria. El flujo de activación (`activatePremium`) nunca reseteaba ese consumo.

## Cambios

- **`UsageLimitsService.resetTodayUsage(userId)`**: borra los registros de uso de HOY del usuario (delete por `userId + date`).
- **`ProcessSubscriptionWebhookUseCase.activatePremium`**: invoca el reset tras persistir el cambio a Premium, en la rama de *activación completa* (no en notificaciones duplicadas). Es no crítico: un fallo del reset se loguea pero no rompe la activación del pago.
- **`SubscriptionsModule`**: importa `UsageLimitsModule`.
- Tests de regresión en `usage-limits.service.spec.ts` y `process-subscription-webhook.use-case.spec.ts`.

## Alcance / notas

- El path admin `UsersService.updatePlan` **no** se toca en este PR para evitar dependencia circular (`UsageLimitsService` ya inyecta `UsersService`). El bug reportado es el flujo de pago real vía webhook.
- Decisión de negocio confirmada: **Premium se mantiene en 3 tiradas/día** (no se pasa a ilimitado).

## Checklist

- [x] Tests (TDD) — 65 pasando en los specs afectados
- [x] `npm run lint` sin errores
- [x] `npm run build` exitoso
- [x] `node scripts/validate-architecture.js` OK
- [x] Sin `any` / `eslint-disable` nuevos
- [x] Texto user-facing en español

🤖 Generated with [Claude Code](https://claude.com/claude-code)