### PR TITLE
fix(capabilities): auto-refrescar límites al cruzar el reset diario

### DIFF
--- a/frontend/src/hooks/api/useUserCapabilities.test.ts
+++ b/frontend/src/hooks/api/useUserCapabilities.test.ts
@@ -4,8 +4,8 @@
  * Test suite for the user capabilities hook that fetches and manages
  * user capabilities from the backend capabilities endpoint.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useUserCapabilities, useInvalidateCapabilities } from './useUserCapabilities';
 import { apiClient } from '@/lib/api/axios-config';
@@ -272,6 +272,103 @@ describe('useUserCapabilities', () => {
 
       // Data should be immediately stale (staleTime: 0)
       expect(result.current.isStale).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Auto-refresh on daily reset (fixes stale "límite alcanzado" on a new day)
+  // ==========================================================================
+  describe('daily reset auto-refresh', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const limitReachedWithResetAt = (resetAt: string): UserCapabilities => ({
+      dailyCard: { used: 1, limit: 1, canUse: false, resetAt },
+      tarotReadings: { used: 1, limit: 1, canUse: false, resetAt },
+      pendulum: {
+        used: 0,
+        limit: 3,
+        canUse: true,
+        resetAt: null,
+        period: 'monthly',
+      },
+      canCreateDailyReading: false,
+      canCreateTarotReading: false,
+      canUseAI: false,
+      canUseCustomQuestions: false,
+      canUseAdvancedSpreads: false,
+      canUseFullDeck: false,
+      plan: 'free',
+      isAuthenticated: true,
+    });
+
+    it('should not schedule an extra refetch when resetAt is already in the past', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const pastReset = new Date(Date.now() - 60_000).toISOString();
+      vi.mocked(apiClient.get).mockResolvedValue({
+        data: limitReachedWithResetAt(pastReset),
+      });
+
+      const { result } = renderHook(() => useUserCapabilities(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      // A past resetAt must not trigger an immediate/looping invalidation:
+      // refetchOnMount/refetchOnWindowFocus already handle stale-on-mount.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+
+      expect(apiClient.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refetch when the scheduled reset time is reached', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const futureReset = new Date(Date.now() + 60_000).toISOString();
+      vi.mocked(apiClient.get).mockResolvedValue({
+        data: limitReachedWithResetAt(futureReset),
+      });
+
+      const { result } = renderHook(() => useUserCapabilities(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(apiClient.get).toHaveBeenCalledTimes(1);
+
+      // Cross the reset boundary → the scheduled timer invalidates and refetches.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(61_000);
+      });
+
+      await waitFor(() => expect(apiClient.get).toHaveBeenCalledTimes(2));
+    });
+
+    it('should NOT refetch before the reset time is reached', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const futureReset = new Date(Date.now() + 60 * 60_000).toISOString();
+      vi.mocked(apiClient.get).mockResolvedValue({
+        data: limitReachedWithResetAt(futureReset),
+      });
+
+      const { result } = renderHook(() => useUserCapabilities(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      // Advance only 5 minutes: still well before the 1-hour reset.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5 * 60_000);
+      });
+
+      expect(apiClient.get).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/src/hooks/api/useUserCapabilities.test.ts
+++ b/frontend/src/hooks/api/useUserCapabilities.test.ts
@@ -341,12 +341,38 @@ describe('useUserCapabilities', () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(apiClient.get).toHaveBeenCalledTimes(1);
 
-      // Cross the reset boundary → the scheduled timer invalidates and refetches.
+      // Cross the reset boundary (+5s safety margin) → timer invalidates and refetches.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(61_000);
+        await vi.advanceTimersByTimeAsync(66_000);
       });
 
       await waitFor(() => expect(apiClient.get).toHaveBeenCalledTimes(2));
+    });
+
+    it('should clear the scheduled timer on unmount (no refetch after unmount)', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const futureReset = new Date(Date.now() + 60_000).toISOString();
+      vi.mocked(apiClient.get).mockResolvedValue({
+        data: limitReachedWithResetAt(futureReset),
+      });
+
+      const { result, unmount } = renderHook(() => useUserCapabilities(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(apiClient.get).toHaveBeenCalledTimes(1);
+
+      // Unmount before the reset fires: the cleanup must clearTimeout so no
+      // refetch happens once the boundary passes.
+      unmount();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(66_000);
+      });
+
+      expect(apiClient.get).toHaveBeenCalledTimes(1);
     });
 
     it('should NOT refetch before the reset time is reached', async () => {

--- a/frontend/src/hooks/api/useUserCapabilities.ts
+++ b/frontend/src/hooks/api/useUserCapabilities.ts
@@ -15,7 +15,7 @@
 'use client';
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { apiClient } from '@/lib/api/axios-config';
 import { API_ENDPOINTS } from '@/lib/api/endpoints';
 import { getSessionFingerprint } from '@/lib/utils/fingerprint';
@@ -43,6 +43,9 @@ export const capabilitiesQueryKeys = {
  * - staleTime: 0 (always revalidate for fresh data)
  * - refetchOnWindowFocus: true (refresh when user returns to tab)
  * - refetchOnMount: true (refresh when component mounts)
+ * - Auto-refetch when the daily limit resets (crossing midnight UTC), so a
+ *   stale "límite alcanzado" state does not persist into the new day without a
+ *   manual page refresh.
  *
  * @returns React Query result with UserCapabilities data
  *
@@ -62,7 +65,9 @@ export const capabilitiesQueryKeys = {
  * ```
  */
 export function useUserCapabilities(options?: { enabled?: boolean }) {
-  return useQuery<UserCapabilities>({
+  const queryClient = useQueryClient();
+
+  const query = useQuery<UserCapabilities>({
     queryKey: capabilitiesQueryKeys.capabilities,
     queryFn: async () => {
       // Get fingerprint for anonymous users to track usage
@@ -78,6 +83,33 @@ export function useUserCapabilities(options?: { enabled?: boolean }) {
     refetchOnWindowFocus: true, // Refresh when user returns to tab
     refetchOnMount: true, // Refresh when component mounts
   });
+
+  // Schedule a refetch for the exact moment the daily limit resets (midnight UTC).
+  // staleTime:0 alone is not enough: it marks data stale but only refetches on an
+  // event (mount/focus/reconnect). If the tab stays open across midnight on the
+  // "límite alcanzado" screen, the query never revalidates and shows yesterday's
+  // stale state until a manual refresh. This timer closes that gap.
+  const resetAt = query.data?.tarotReadings?.resetAt;
+  useEffect(() => {
+    if (!resetAt) return;
+
+    const msUntilReset = new Date(resetAt).getTime() - Date.now();
+
+    // Only schedule for a reset that is still ahead. A reset already in the past
+    // is handled by refetchOnMount/refetchOnWindowFocus (a fresh fetch always
+    // returns the next midnight UTC), so no immediate invalidation is needed.
+    if (msUntilReset <= 0) return;
+
+    const timer = setTimeout(() => {
+      void queryClient.invalidateQueries({
+        queryKey: capabilitiesQueryKeys.capabilities,
+      });
+    }, msUntilReset + 1000); // +1s margin so the backend has crossed midnight UTC
+
+    return () => clearTimeout(timer);
+  }, [resetAt, queryClient]);
+
+  return query;
 }
 
 // ============================================================================

--- a/frontend/src/hooks/api/useUserCapabilities.ts
+++ b/frontend/src/hooks/api/useUserCapabilities.ts
@@ -89,6 +89,12 @@ export function useUserCapabilities(options?: { enabled?: boolean }) {
   // event (mount/focus/reconnect). If the tab stays open across midnight on the
   // "límite alcanzado" screen, the query never revalidates and shows yesterday's
   // stale state until a manual refresh. This timer closes that gap.
+  //
+  // We key off tarotReadings.resetAt as the daily clock: dailyCard shares the same
+  // midnight-UTC boundary, and invalidating refetches the whole response, so a
+  // single timer refreshes every daily feature. Using the daily reset (max ~24h)
+  // also stays well under the setTimeout overflow limit (~24.8 days), unlike the
+  // pendulum reset which can be monthly/lifetime.
   const resetAt = query.data?.tarotReadings?.resetAt;
   useEffect(() => {
     if (!resetAt) return;
@@ -100,11 +106,14 @@ export function useUserCapabilities(options?: { enabled?: boolean }) {
     // returns the next midnight UTC), so no immediate invalidation is needed.
     if (msUntilReset <= 0) return;
 
+    // +5s margin so the backend has safely crossed midnight UTC before we refetch,
+    // tolerating small client/server clock skew (firing early would refetch the
+    // same resetAt and, since the dependency wouldn't change, skip rescheduling).
     const timer = setTimeout(() => {
       void queryClient.invalidateQueries({
         queryKey: capabilitiesQueryKeys.capabilities,
       });
-    }, msUntilReset + 1000); // +1s margin so the backend has crossed midnight UTC
+    }, msUntilReset + 5000);
 
     return () => clearTimeout(timer);
   }, [resetAt, queryClient]);


### PR DESCRIPTION
## Contexto

Bug reportado en producción: **en un nuevo día, al intentar una tirada aparece el cartel de 'límite alcanzado'; al refrescar la página, deja hacer la tirada.**

## Causa raíz

Es un problema de **cache stale en el frontend** (el backend cuenta fresco en cada request). La pantalla de límite se renderiza desde la query cacheada `['user','capabilities']`. Esa query tiene `staleTime:0`, `refetchOnMount` y `refetchOnWindowFocus`, pero **`staleTime:0` solo marca el dato como stale, no dispara un fetch por sí solo** — hace falta un evento (mount/focus/reconnect). Con la pestaña/PWA abierta cruzando la medianoche, la query nunca revalida y sigue sirviendo el `canCreateTarotReading: false` del día anterior hasta un F5 (que destruye el QueryClient singleton).

## Cambios

- **`useUserCapabilities`**: programa un `setTimeout` hasta `tarotReadings.resetAt` (medianoche UTC) que invalida la query, refrescando los límites al cambiar el día sin depender de focus/mount. Se reprograma solo con cada dato nuevo.
- Solo agenda resets **futuros**; un reset ya pasado lo cubren `refetchOnMount`/`refetchOnWindowFocus` (un fetch fresco siempre devuelve la próxima medianoche UTC), evitando bucles de refetch.

## Tests

- Refetch al disparar el timer del reset (fake timers).
- No refetch antes de alcanzar el reset.
- No refetch extra cuando `resetAt` ya pasó.

## Checklist

- [x] Tests (TDD) — 12 pasando en `useUserCapabilities.test.ts`
- [x] `npm run lint` sin errores
- [x] `npm run type-check` OK
- [x] `npm run build` exitoso
- [x] `node scripts/validate-architecture.js` OK
- [x] Sin `any` / `eslint-disable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)