### PR TITLE
fix(email): corregir contenido erróneo del email de cambio de plan

### DIFF
--- a/backend/tarot-app/src/modules/email/email-templates.spec.ts
+++ b/backend/tarot-app/src/modules/email/email-templates.spec.ts
@@ -254,7 +254,9 @@ describe('Email templates (render)', () => {
 
       // Premium NO es ilimitado (1 carta/día + 3 tiradas/día) ni ofrece estas
       // features inexistentes: eran texto genérico erróneo.
-      expect(mail.html).not.toContain('Lecturas ilimitadas');
+      // El núcleo del bug era prometer algo "ilimitado": lo bloqueamos por raíz
+      // para atajar futuras reintroducciones ("tiradas ilimitadas", etc.).
+      expect(mail.html).not.toMatch(/ilimitad/i);
       expect(mail.html).not.toContain('Soporte prioritario');
       expect(mail.html).not.toContain('Sin publicidad');
       expect(mail.html).not.toContain('Historial completo');
@@ -268,9 +270,11 @@ describe('Email templates (render)', () => {
         changeDate: '22 de julio de 2026',
       });
 
+      expect(mail.html).toContain('1 carta del día');
       expect(mail.html).toContain('3 tiradas de tarot diarias');
       expect(mail.html).toContain('Preguntas personalizadas');
       expect(mail.html).toContain('Tiradas avanzadas');
+      expect(mail.html).toContain('Comparte tus lecturas');
     });
   });
 });

--- a/backend/tarot-app/src/modules/email/email-templates.spec.ts
+++ b/backend/tarot-app/src/modules/email/email-templates.spec.ts
@@ -230,4 +230,47 @@ describe('Email templates (render)', () => {
       },
     );
   });
+
+  describe('plan-change: contenido veraz del email de cambio de plan', () => {
+    it('usa la marca "Auguria", nunca "Tarot App"', async () => {
+      const mail = await render('plan-change', {
+        userName: 'Flavia',
+        oldPlan: 'Gratuito',
+        newPlan: 'Premium',
+        changeDate: '22 de julio de 2026',
+      });
+
+      expect(mail.html).toContain('Auguria');
+      expect(mail.html).not.toContain('Tarot App');
+    });
+
+    it('no promete beneficios que el plan Premium no ofrece', async () => {
+      const mail = await render('plan-change', {
+        userName: 'Flavia',
+        oldPlan: 'Gratuito',
+        newPlan: 'Premium',
+        changeDate: '22 de julio de 2026',
+      });
+
+      // Premium NO es ilimitado (1 carta/día + 3 tiradas/día) ni ofrece estas
+      // features inexistentes: eran texto genérico erróneo.
+      expect(mail.html).not.toContain('Lecturas ilimitadas');
+      expect(mail.html).not.toContain('Soporte prioritario');
+      expect(mail.html).not.toContain('Sin publicidad');
+      expect(mail.html).not.toContain('Historial completo');
+    });
+
+    it('lista los beneficios reales del plan Premium', async () => {
+      const mail = await render('plan-change', {
+        userName: 'Flavia',
+        oldPlan: 'Gratuito',
+        newPlan: 'Premium',
+        changeDate: '22 de julio de 2026',
+      });
+
+      expect(mail.html).toContain('3 tiradas de tarot diarias');
+      expect(mail.html).toContain('Preguntas personalizadas');
+      expect(mail.html).toContain('Tiradas avanzadas');
+    });
+  });
 });

--- a/backend/tarot-app/src/modules/email/templates/plan-change.hbs
+++ b/backend/tarot-app/src/modules/email/templates/plan-change.hbs
@@ -142,7 +142,7 @@
       <div class='content'>
         <p>Hola <strong>{{userName}}</strong>,</p>
         <p>Tu cambio de plan se ha procesado exitosamente. ¡Gracias por confiar
-          en Tarot App!</p>
+          en Auguria!</p>
       </div>
 
       <div class='plan-change-box'>
@@ -164,12 +164,11 @@
       <div class='benefits-box'>
         <h2>¿Qué incluye tu nuevo plan?</h2>
         <ul class='benefits-list'>
-          <li>Lecturas ilimitadas de tarot</li>
-          <li>Acceso a tiradas premium exclusivas</li>
+          <li>1 carta del día + 3 tiradas de tarot diarias</li>
           <li>Interpretaciones más profundas y personalizadas</li>
-          <li>Historial completo de tus lecturas</li>
-          <li>Soporte prioritario</li>
-          <li>Sin publicidad</li>
+          <li>Preguntas personalizadas en tus lecturas</li>
+          <li>Tiradas avanzadas de 5 o más cartas</li>
+          <li>Comparte tus lecturas</li>
         </ul>
       </div>
 
@@ -181,7 +180,7 @@
       </div>
 
       <div class='footer'>
-        <p>✨ Tarot App - Tu guía espiritual ✨</p>
+        <p>✨ Auguria - Tu guía espiritual ✨</p>
         <p>Este email fue generado automáticamente. Por favor no respondas a
           este mensaje.</p>
       </div>

--- a/backend/tarot-app/src/modules/subscriptions/application/use-cases/process-subscription-webhook.use-case.ts
+++ b/backend/tarot-app/src/modules/subscriptions/application/use-cases/process-subscription-webhook.use-case.ts
@@ -161,6 +161,7 @@ export class ProcessSubscriptionWebhookUseCase {
         oldPlan: PLAN_LABELS[previousPlan],
         newPlan: PLAN_LABELS[UserPlan.PREMIUM],
         changeDate: new Date().toLocaleDateString('es-AR', {
+          timeZone: 'America/Argentina/Buenos_Aires',
           day: '2-digit',
           month: 'long',
           year: 'numeric',


### PR DESCRIPTION
## Contexto

Bug reportado en producción: al suscribirse a Premium, el email de confirmación llegaba con **información errónea**.

## Errores corregidos (contra la fuente de verdad `plans.seeder.ts`)

| Antes | Problema | Ahora |
|---|---|---|
| "Tarot App" (x2) | La marca real es **Auguria** (usada en todo el resto del código) | "Auguria" |
| "Lecturas ilimitadas de tarot" | **Falso**: Premium es 1 carta/día + 3 tiradas/día | "1 carta del día + 3 tiradas de tarot diarias" |
| "Historial completo" | Feature no diferenciada por plan | (removido) |
| "Soporte prioritario" | No existe en el código | (removido) |
| "Sin publicidad" | La app no tiene publicidad en ningún plan | (removido) |
| — | — | + "Preguntas personalizadas", "Tiradas avanzadas de 5+ cartas", "Comparte tus lecturas" (reales) |

## Bug secundario corregido

`changeDate` usaba `toLocaleDateString('es-AR', ...)` **sin `timeZone`** → dependía del TZ del proceso del servidor. Si producción corre en UTC, una suscripción nocturna (UTC-3) podía mostrar el día calendario equivocado. Se fija `timeZone: 'America/Argentina/Buenos_Aires'`.

## Archivos

- `modules/email/templates/plan-change.hbs`
- `modules/subscriptions/application/use-cases/process-subscription-webhook.use-case.ts` (changeDate)
- `modules/email/email-templates.spec.ts` (tests de regresión de contenido)

## Nota

Decisión de negocio confirmada: **Premium se mantiene en 3 tiradas/día** (no ilimitado), por eso el email deja de prometer "ilimitado".

## Checklist

- [x] Tests (TDD) — 49 pasando (email-templates, no-ia-user-facing, webhook)
- [x] `npm run lint` sin errores
- [x] `npm run build` exitoso
- [x] `node scripts/validate-architecture.js` OK
- [x] Texto user-facing en español, sin mención de 'IA'

🤖 Generated with [Claude Code](https://claude.com/claude-code)