### PR TITLE
fix(readings): bloquear selección de cartas con el límite diario alcanzado

### DIFF
--- a/frontend/src/components/features/readings/ReadingExperience.limit-gate.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.limit-gate.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReadingExperience } from './ReadingExperience';
+import type { Spread, PredefinedQuestion } from '@/types/reading.types';
+
+// Mock Next.js router
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+vi.mock('next/image', () => ({
+  default: function MockImage({ src, alt }: { src: string; alt: string }) {
+    return <img src={src} alt={alt} data-testid="next-image" />;
+  },
+}));
+
+vi.mock('react-markdown', () => ({
+  default: function MockReactMarkdown({ children }: { children: string }) {
+    return <div data-testid="markdown-content">{children}</div>;
+  },
+}));
+
+vi.mock('./FreeReadingUpgradeBanner', () => ({
+  default: function MockFreeReadingUpgradeBanner() {
+    return <div data-testid="free-reading-upgrade-banner" />;
+  },
+}));
+
+vi.mock('./UpgradeModal', () => ({
+  default: function MockUpgradeModal() {
+    return null;
+  },
+}));
+
+vi.mock('./DailyLimitReachedModal', () => ({
+  default: function MockDailyLimitReachedModal() {
+    return null;
+  },
+}));
+
+const mockSpreads: Spread[] = [
+  {
+    id: 2,
+    name: 'Tres Cartas',
+    description: 'Pasado, presente, futuro',
+    cardCount: 3,
+    positions: [
+      { position: 1, name: 'Pasado', description: 'Lo que dejaste atrás' },
+      { position: 2, name: 'Presente', description: 'Tu situación actual' },
+      { position: 3, name: 'Futuro', description: 'Lo que vendrá' },
+    ],
+    difficulty: 'beginner',
+    requiredPlan: 'free',
+  },
+];
+
+const mockPredefinedQuestions: PredefinedQuestion[] = [
+  {
+    id: 33,
+    questionText: '¿Qué debo saber sobre mi situación actual?',
+    categoryId: 1,
+    order: 1,
+    isActive: true,
+    usageCount: 100,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    deletedAt: null,
+  },
+];
+
+vi.mock('@/hooks/api/useReadings', () => ({
+  useMyAvailableSpreads: () => ({ data: mockSpreads, isLoading: false }),
+  usePredefinedQuestions: () => ({ data: mockPredefinedQuestions, isLoading: false }),
+  useCreateReading: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+  useRegenerateInterpretation: () => ({ mutate: vi.fn(), isPending: false }),
+  useCategories: () => ({ data: [{ id: 1, name: 'Amor', slug: 'amor' }], isLoading: false }),
+}));
+
+vi.mock('@/hooks/utils/useToast', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+// The key mock: the daily tarot reading limit is REACHED.
+vi.mock('@/hooks/api/useUserCapabilities', () => ({
+  useUserCapabilities: () => ({
+    data: {
+      dailyCard: { used: 1, limit: 1, canUse: false, resetAt: '2026-07-24T00:00:00Z' },
+      tarotReadings: { used: 1, limit: 1, canUse: false, resetAt: '2026-07-24T00:00:00Z' },
+      pendulum: {
+        used: 0,
+        limit: 3,
+        canUse: true,
+        resetAt: null,
+        period: 'monthly',
+      },
+      canCreateDailyReading: false,
+      canCreateTarotReading: false,
+      canUseAI: false,
+      canUseCustomQuestions: false,
+      canUseAdvancedSpreads: false,
+      canUseFullDeck: false,
+      plan: 'free',
+      isAuthenticated: true,
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => ({
+    user: { id: 1, email: 'test@example.com', plan: 'free' },
+    isAuthenticated: true,
+  }),
+}));
+
+vi.mock('@/hooks/utils/useUserPlanFeatures', () => ({
+  useUserPlanFeatures: () => ({
+    canUseAI: false,
+    canUseCategories: true,
+    canUseCustomQuestions: false,
+    isPremium: false,
+    isFree: true,
+    isAnonymous: false,
+    dailyReadingsLimit: 1,
+  }),
+}));
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+describe('ReadingExperience - gate de límite en la selección de cartas', () => {
+  it('NO muestra la grilla de cartas cuando el límite diario está alcanzado', () => {
+    renderWithProviders(<ReadingExperience spreadId={2} questionId={33} customQuestion={null} />);
+
+    // El bug: al volver "atrás" con el límite agotado, se re-mostraba la grilla.
+    expect(screen.queryByTestId('card-selection-grid')).not.toBeInTheDocument();
+    expect(screen.queryAllByTestId('selectable-card')).toHaveLength(0);
+  });
+
+  it('muestra el aviso de límite alcanzado en su lugar', () => {
+    renderWithProviders(<ReadingExperience spreadId={2} questionId={33} customQuestion={null} />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Límite de tiradas alcanzado')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/readings/ReadingExperience.limit-gate.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.limit-gate.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReadingExperience } from './ReadingExperience';
@@ -89,32 +89,30 @@ vi.mock('@/hooks/utils/useToast', () => ({
   toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
-// The key mock: the daily tarot reading limit is REACHED.
+// Mutable capabilities mock so each test can set limit-reached / loading state.
+const limitReachedCapabilities = {
+  dailyCard: { used: 1, limit: 1, canUse: false, resetAt: '2026-07-24T00:00:00Z' },
+  tarotReadings: { used: 1, limit: 1, canUse: false, resetAt: '2026-07-24T00:00:00Z' },
+  pendulum: {
+    used: 0,
+    limit: 3,
+    canUse: true,
+    resetAt: null,
+    period: 'monthly' as const,
+  },
+  canCreateDailyReading: false,
+  canCreateTarotReading: false,
+  canUseAI: false,
+  canUseCustomQuestions: false,
+  canUseAdvancedSpreads: false,
+  canUseFullDeck: false,
+  plan: 'free' as const,
+  isAuthenticated: true,
+};
+
+const mockUseUserCapabilities = vi.fn();
 vi.mock('@/hooks/api/useUserCapabilities', () => ({
-  useUserCapabilities: () => ({
-    data: {
-      dailyCard: { used: 1, limit: 1, canUse: false, resetAt: '2026-07-24T00:00:00Z' },
-      tarotReadings: { used: 1, limit: 1, canUse: false, resetAt: '2026-07-24T00:00:00Z' },
-      pendulum: {
-        used: 0,
-        limit: 3,
-        canUse: true,
-        resetAt: null,
-        period: 'monthly',
-      },
-      canCreateDailyReading: false,
-      canCreateTarotReading: false,
-      canUseAI: false,
-      canUseCustomQuestions: false,
-      canUseAdvancedSpreads: false,
-      canUseFullDeck: false,
-      plan: 'free',
-      isAuthenticated: true,
-    },
-    isLoading: false,
-    isError: false,
-    error: null,
-  }),
+  useUserCapabilities: () => mockUseUserCapabilities(),
 }));
 
 vi.mock('@/stores/authStore', () => ({
@@ -144,6 +142,16 @@ const renderWithProviders = (ui: React.ReactElement) => {
 };
 
 describe('ReadingExperience - gate de límite en la selección de cartas', () => {
+  beforeEach(() => {
+    // Default: limit reached, capabilities already loaded.
+    mockUseUserCapabilities.mockReturnValue({
+      data: limitReachedCapabilities,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+  });
+
   it('NO muestra la grilla de cartas cuando el límite diario está alcanzado', () => {
     renderWithProviders(<ReadingExperience spreadId={2} questionId={33} customQuestion={null} />);
 
@@ -157,5 +165,23 @@ describe('ReadingExperience - gate de límite en la selección de cartas', () =>
 
     expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(screen.getByText('Límite de tiradas alcanzado')).toBeInTheDocument();
+  });
+
+  it('muestra spinner (no la grilla) mientras capabilities está cargando, para evitar el flash', () => {
+    // Ingreso por URL directa: hasta que capabilities resuelve, no se debe
+    // mostrar la grilla (que se vería y desaparecería al aplicar el gate).
+    mockUseUserCapabilities.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    });
+
+    renderWithProviders(<ReadingExperience spreadId={2} questionId={33} customQuestion={null} />);
+
+    expect(screen.getByText('Cargando...')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-selection-grid')).not.toBeInTheDocument();
+    // Tampoco el gate todavía: aún no sabemos si el límite está alcanzado.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/features/readings/ReadingExperience.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.tsx
@@ -28,6 +28,7 @@ import { Spinner } from '@/components/ui/spinner';
 import FreeReadingUpgradeBanner from './FreeReadingUpgradeBanner';
 import UpgradeModal from './UpgradeModal';
 import DailyLimitReachedModal from './DailyLimitReachedModal';
+import { ReadingLimitReached } from './ReadingLimitReached';
 import { cn } from '@/lib/utils';
 import type {
   ReadingDetail,
@@ -522,6 +523,19 @@ export function ReadingExperience({
             onRetry={() => router.push(ROUTES.TAROT)}
           />
         </div>
+      </div>
+    );
+  }
+
+  // Gate: si el límite diario está alcanzado, no permitir (re)elegir cartas.
+  // Cubre la navegación "atrás/adelante" del navegador y el ingreso por URL directa
+  // a la pantalla de lectura con el límite agotado (el backend también rechaza al
+  // crear, pero el wizard no debe siquiera mostrar la grilla de cartas). Solo aplica
+  // al estado 'selecting': la vista del informe ('result') nunca se bloquea.
+  if (state === 'selecting' && capabilities && !capabilities.canCreateTarotReading) {
+    return (
+      <div className="bg-bg-main flex min-h-screen items-center justify-center p-4 md:p-8">
+        <ReadingLimitReached />
       </div>
     );
   }

--- a/frontend/src/components/features/readings/ReadingExperience.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.tsx
@@ -295,7 +295,7 @@ export function ReadingExperience({
   const { data: spreads, isLoading: isSpreadsLoading } = useMyAvailableSpreads();
   const { data: predefinedQuestions, isLoading: isQuestionsLoading } = usePredefinedQuestions();
   const { data: categories } = useCategories();
-  const { data: capabilities } = useUserCapabilities();
+  const { data: capabilities, isLoading: isCapabilitiesLoading } = useUserCapabilities();
   const { cardIndices } = useTarotDeck();
   const { mutateAsync: createReading } = useCreateReading();
   const { mutate: regenerateInterpretation, isPending: isRegenerating } =
@@ -505,8 +505,11 @@ export function ReadingExperience({
     return capabilities?.canCreateTarotReading ?? false;
   }, [user, capabilities]);
 
-  // Render loading/missing spread state
-  if (isSpreadsLoading || isQuestionsLoading) {
+  // Render loading/missing spread state.
+  // Wait for capabilities too: without it, a direct-URL entry with the limit
+  // exhausted would briefly flash the card grid (capabilities undefined → gate
+  // skipped) before ReadingLimitReached takes over once capabilities resolve.
+  if (isSpreadsLoading || isQuestionsLoading || isCapabilitiesLoading) {
     return (
       <div className="bg-bg-main flex min-h-screen items-center justify-center p-8">
         <Spinner size="lg" text="Cargando..." />

--- a/frontend/src/components/features/readings/ReadingExperience.useAI.test.tsx
+++ b/frontend/src/components/features/readings/ReadingExperience.useAI.test.tsx
@@ -201,6 +201,28 @@ vi.mock('@/hooks/api/useReadings', () => ({
   }),
 }));
 
+// Capabilities: allow creating a reading (gate must not block) and be loaded.
+vi.mock('@/hooks/api/useUserCapabilities', () => ({
+  useUserCapabilities: () => ({
+    data: {
+      dailyCard: { used: 0, limit: 1, canUse: true, resetAt: '2026-07-24T00:00:00Z' },
+      tarotReadings: { used: 0, limit: 3, canUse: true, resetAt: '2026-07-24T00:00:00Z' },
+      pendulum: { used: 0, limit: 3, canUse: true, resetAt: null, period: 'monthly' },
+      canCreateDailyReading: true,
+      canCreateTarotReading: true,
+      canUseAI: false,
+      canUseCustomQuestions: false,
+      canUseAdvancedSpreads: false,
+      canUseFullDeck: false,
+      plan: 'free',
+      isAuthenticated: true,
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
 vi.mock('@/stores/authStore', () => ({
   useAuthStore: () => ({
     user: {

--- a/frontend/src/lib/utils/invalidate-user-data.test.ts
+++ b/frontend/src/lib/utils/invalidate-user-data.test.ts
@@ -18,19 +18,24 @@ describe('invalidateUserData', () => {
     } as unknown as QueryClient;
   });
 
-  it('should invalidate user capabilities query', async () => {
+  it('should invalidate user capabilities query and refetch inactive queries', async () => {
     await invalidateUserData(queryClient);
 
+    // refetchType: 'all' ensures the capabilities query refetches even when its
+    // owner component (e.g. SpreadSelector) is unmounted, so navigating back does
+    // not show stale "can create reading" data.
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: capabilitiesQueryKeys.capabilities,
+      refetchType: 'all',
     });
   });
 
-  it('should invalidate user profile query', async () => {
+  it('should invalidate user profile query and refetch inactive queries', async () => {
     await invalidateUserData(queryClient);
 
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: userQueryKeys.profile,
+      refetchType: 'all',
     });
   });
 

--- a/frontend/src/lib/utils/invalidate-user-data.ts
+++ b/frontend/src/lib/utils/invalidate-user-data.ts
@@ -30,7 +30,14 @@ import { userQueryKeys } from '@/hooks/api/useUser';
  */
 export async function invalidateUserData(queryClient: QueryClient): Promise<void> {
   await Promise.all([
-    queryClient.invalidateQueries({ queryKey: capabilitiesQueryKeys.capabilities }),
-    queryClient.invalidateQueries({ queryKey: userQueryKeys.profile }),
+    // refetchType: 'all' also refetches INACTIVE queries. After creating a reading,
+    // the SpreadSelector that owns the capabilities query is unmounted, so a plain
+    // invalidate marks it stale but never refetches it — leaving stale data that let
+    // the user re-select cards after navigating back. 'all' forces the refresh.
+    queryClient.invalidateQueries({
+      queryKey: capabilitiesQueryKeys.capabilities,
+      refetchType: 'all',
+    }),
+    queryClient.invalidateQueries({ queryKey: userQueryKeys.profile, refetchType: 'all' }),
   ]);
 }


### PR DESCRIPTION
## Contexto

Bug reportado en producción: **tras ver el informe de una lectura, al hacer 'atrás' y teniendo el límite alcanzado, la app permitía volver a elegir las cartas** con la misma categoría, pregunta y tipo de tirada.

## Causa raíz

El wizard guarda todo su estado en la **URL** (categoría/pregunta/tirada), y la transición `selecting → result` es estado local que no crea entrada de historial. Dos huecos combinados:

1. **La pantalla de elegir cartas no validaba el límite**: el estado `selecting` de `ReadingExperience` renderiza la grilla de 78 cartas sin chequear `capabilities`; solo se validaba al pulsar 'Revelar'.
2. **La puerta de `SpreadSelector` servía capabilities obsoletas al volver**: `invalidateUserData` usaba `invalidateQueries`, que no refetchea queries inactivas (SpreadSelector desmontado al crear la lectura).

## Cambios

- **`ReadingExperience`**: gate que, en estado `selecting` con `!capabilities.canCreateTarotReading`, renderiza `<ReadingLimitReached />` en lugar de la grilla. **Solo afecta `selecting`** — la vista del informe (`result`) nunca se bloquea. Cubre back/forward del navegador y URL directa.
- **`invalidate-user-data`**: `refetchType: 'all'` para que la query de capabilities se refresque aunque su componente dueño esté desmontado.

## Nota importante

El backend **ya rechaza la creación** (`DailyLimitError` 403), así que **no se creaban lecturas de más**. Este fix cierra el agujero de **UX/estado del wizard**.

> Mejora opcional no incluida (menor): un handler `pageshow`/BFCache para revalidar al restaurar desde el back-forward cache. El gate ya cierra el agujero funcional sin ella.

## Tests

- `ReadingExperience.limit-gate.test.tsx` (nuevo): con el límite alcanzado no se muestra la grilla y sí el aviso de límite.
- `invalidate-user-data.test.ts`: ajustado a `refetchType: 'all'`.
- Suite completa de `ReadingExperience`: 57 pasando.

## Checklist

- [x] Tests (TDD)
- [x] `npm run lint` sin errores / `type-check` OK
- [x] `npm run build` exitoso / arquitectura OK
- [x] Sin `any` / `eslint-disable`, texto en español, `'use client'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)