### PR TITLE
fix(capabilities): scope cache por identidad (arregla widget 0/0 stale)

### DIFF
--- a/frontend/src/components/features/dashboard/StatsSection.test.tsx
+++ b/frontend/src/components/features/dashboard/StatsSection.test.tsx
@@ -112,6 +112,33 @@ describe('StatsSection', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('should return null (not render 0/0) when capabilities are an anonymous payload', () => {
+    // Stale pre-auth response leaking into a premium session: plan 'anonymous'
+    // with used:0/limit:0 would render a bogus "0 / 0 - límite alcanzado".
+    mockUseUserCapabilities.mockReturnValue({
+      data: {
+        tarotReadings: { used: 0, limit: 0, canUse: false, resetAt: '2026-01-09T00:00:00Z' },
+        dailyCard: { used: 0, limit: 1, canUse: true, resetAt: '2026-01-09T00:00:00Z' },
+        canCreateDailyReading: true,
+        canCreateTarotReading: false,
+        canUseAI: false,
+        canUseCustomQuestions: false,
+        canUseAdvancedSpreads: false,
+        plan: 'anonymous',
+        isAuthenticated: false,
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<StatsSection />);
+
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText('0 / 0')).not.toBeInTheDocument();
+    expect(screen.queryByText('Has alcanzado tu límite diario')).not.toBeInTheDocument();
+  });
+
   it('should display remaining readings', () => {
     mockUseUserCapabilities.mockReturnValue({
       data: {

--- a/frontend/src/components/features/dashboard/StatsSection.tsx
+++ b/frontend/src/components/features/dashboard/StatsSection.tsx
@@ -83,7 +83,11 @@ export function StatsSection({ index = 0 }: StatsSectionProps) {
         />
       </WidgetCard>
     );
-  } else if (!capabilities) {
+  } else if (!capabilities || capabilities.plan === 'anonymous') {
+    // Defensive: never render an anonymous capabilities payload here. This widget
+    // is only shown to authenticated (premium) users; an 'anonymous' plan means a
+    // stale pre-auth response (used:0/limit:0) — treat it as "still loading" so we
+    // don't flash a bogus "0/0 - límite alcanzado" until the authenticated fetch lands.
     return null;
   } else {
     const dailyReadingsCount = capabilities.tarotReadings.used;

--- a/frontend/src/hooks/api/useUserCapabilities.test.ts
+++ b/frontend/src/hooks/api/useUserCapabilities.test.ts
@@ -170,6 +170,20 @@ describe('useUserCapabilities', () => {
       expect(apiClient.get).toHaveBeenCalledTimes(1);
     });
 
+    it('forwards the AbortSignal to axios so an in-flight request can be cancelled', async () => {
+      vi.mocked(apiClient.get).mockResolvedValue({ data: mockAnonymousCapabilities });
+
+      const { result } = renderHook(() => useUserCapabilities(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      const config = vi.mocked(apiClient.get).mock.calls[0][1];
+      expect(config).toHaveProperty('signal');
+      expect(config?.signal).toBeInstanceOf(AbortSignal);
+    });
+
     it('should fetch free user capabilities', async () => {
       vi.mocked(apiClient.get).mockResolvedValue({ data: mockFreeCapabilities });
 

--- a/frontend/src/hooks/api/useUserCapabilities.ts
+++ b/frontend/src/hooks/api/useUserCapabilities.ts
@@ -19,6 +19,7 @@ import { useCallback, useEffect } from 'react';
 import { apiClient } from '@/lib/api/axios-config';
 import { API_ENDPOINTS } from '@/lib/api/endpoints';
 import { getSessionFingerprint } from '@/lib/utils/fingerprint';
+import { useAuthStore } from '@/stores/authStore';
 import type { UserCapabilities } from '@/types';
 
 // ============================================================================
@@ -26,7 +27,20 @@ import type { UserCapabilities } from '@/types';
 // ============================================================================
 
 export const capabilitiesQueryKeys = {
+  /**
+   * Invalidation prefix — matches every per-identity capabilities cache entry.
+   * Use this for `invalidateQueries` so both the anonymous and authenticated
+   * caches are refreshed regardless of who is logged in.
+   */
   capabilities: ['user', 'capabilities'] as const,
+  /**
+   * Actual query key, scoped by identity. The capabilities endpoint returns a
+   * DIFFERENT payload for an anonymous request (no token → `plan:'anonymous'`,
+   * `0/0`) vs an authenticated one. Sharing a single key let a stale anonymous
+   * response leak into a logged-in premium session (the "0/0" dashboard widget).
+   * Scoping by identity keeps those responses in separate cache entries.
+   */
+  byIdentity: (identity: string | number) => ['user', 'capabilities', identity] as const,
 } as const;
 
 // ============================================================================
@@ -67,13 +81,21 @@ export const capabilitiesQueryKeys = {
 export function useUserCapabilities(options?: { enabled?: boolean }) {
   const queryClient = useQueryClient();
 
+  // Scope the cache by identity so an anonymous response never leaks into an
+  // authenticated session (and vice versa). Falls back to 'anon' pre-login.
+  const userId = useAuthStore((state) => state.user?.id);
+  const identity = userId ?? 'anon';
+
   const query = useQuery<UserCapabilities>({
-    queryKey: capabilitiesQueryKeys.capabilities,
-    queryFn: async () => {
+    queryKey: capabilitiesQueryKeys.byIdentity(identity),
+    queryFn: async ({ signal }) => {
       // Get fingerprint for anonymous users to track usage
       const fingerprint = await getSessionFingerprint();
 
       const response = await apiClient.get<UserCapabilities>(API_ENDPOINTS.USERS.CAPABILITIES, {
+        // Forward React Query's AbortSignal so a logout/login `queryClient.clear()`
+        // cancels an in-flight request instead of letting it repopulate the cache.
+        signal,
         params: { fingerprint },
       });
       return response.data;

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -146,6 +146,18 @@ export const useAuthStore = create<AuthStore>()(
 
           const response = await apiClient.get<AuthUser>('/users/profile');
           get().setUser(response.data);
+
+          // Force a fresh, identity-scoped capabilities fetch on session restore.
+          // The capabilities cache is keyed by identity (see useUserCapabilities),
+          // so an anonymous `0/0` response persisted before auth must not gate the
+          // authenticated session. Literal key avoids an import cycle with the hook.
+          if (typeof window !== 'undefined') {
+            const queryClient = getGlobalQueryClient();
+            void queryClient.invalidateQueries({
+              queryKey: ['user', 'capabilities'],
+              refetchType: 'all',
+            });
+          }
         } catch {
           // Clear invalid tokens (SSR safety check)
           if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Contexto

Bug reportado: tras hacer las 3 tiradas premium, el widget del dashboard 'Lecturas de Hoy' mostraba **'0 / 0 (Has alcanzado tu límite diario)'** y había que refrescar para ver '3 / 3'.

## Causa raíz

`0/0` con `plan:'anonymous'` es exactamente la respuesta que el backend devuelve a una request de `/capabilities` **sin token**. La query key `['user','capabilities']` era **estática y compartida entre identidades**: una respuesta anónima (pre-auth / request en vuelo durante login) quedaba cacheada, y como el dashboard decide mostrar el widget con `isPremium` del authStore (que sí dice premium) pero lee los números de `capabilities`, mostraba el `0/0` anónimo stale. El F5 lo arreglaba porque al primer fetch el token ya estaba en localStorage.

## Cambios (PR A del análisis de cache/tiempo real)

- **Query key por identidad** ([useUserCapabilities.ts](frontend/src/hooks/api/useUserCapabilities.ts)): `['user','capabilities', userId ?? 'anon']`. La respuesta anónima y la autenticada quedan en entradas separadas de cache. `capabilitiesQueryKeys.capabilities` se mantiene como **prefijo de invalidación** (matchea todas las identidades por prefijo, así todos los invalidadores existentes siguen funcionando).
- **Reenvío del `AbortSignal`** en el `queryFn`: un `queryClient.clear()` en login/logout cancela la request en vuelo en vez de dejar que repueble la cache.
- **`authStore.checkAuth`** fuerza un refetch de capabilities (`refetchType:'all'`) al restaurar sesión (literal inline para evitar ciclo de imports con el hook).
- **`StatsSection`**: guard defensivo — no renderiza un payload `plan:'anonymous'` (evita el flash de `0/0` hasta que llega la respuesta autenticada).

## Tests

- `StatsSection`: payload anónimo → renderiza `null` (no `0/0`).
- `useUserCapabilities`: reenvía el `AbortSignal` a axios.
- Suites de dashboard/stores/hooks: 194 pasando.

## Checklist

- [x] Tests (TDD) · `type-check` · `lint` (0 errores) · `build` · arquitectura OK
- [x] Sin `any` / `eslint-disable`, `'use client'`, español

🤖 Generated with [Claude Code](https://claude.com/claude-code)