### PR TITLE
fix(premium): cerrar gaps de tiempo real en el retorno de MercadoPago

### DIFF
--- a/frontend/src/components/features/premium/ActivationPage.test.tsx
+++ b/frontend/src/components/features/premium/ActivationPage.test.tsx
@@ -53,10 +53,10 @@ vi.mock('@/hooks/api/useSubscription', () => ({
     mockUseSubscriptionStatus(options),
 }));
 
-// Mock capabilities invalidation
-const mockInvalidateCapabilities = vi.fn();
-vi.mock('@/hooks/api/useUserCapabilities', () => ({
-  useInvalidateCapabilities: () => mockInvalidateCapabilities,
+// Mock user-data invalidation (capabilities + profile, refetchType:'all')
+const mockInvalidateUserData = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/utils/invalidate-user-data', () => ({
+  invalidateUserData: (...args: unknown[]) => mockInvalidateUserData(...args),
 }));
 
 // Mock auth store
@@ -301,7 +301,7 @@ describe('ActivationPage', () => {
       renderWithProviders(<ActivationPage />);
 
       await waitFor(() => {
-        expect(mockInvalidateCapabilities).toHaveBeenCalled();
+        expect(mockInvalidateUserData).toHaveBeenCalled();
       });
     });
 
@@ -363,7 +363,7 @@ describe('ActivationPage', () => {
       });
     });
 
-    it('should show timeout message after 30 seconds without premium activation', async () => {
+    it('should show timeout message after the polling window without premium activation', async () => {
       // Plan never becomes premium
       mockUseSubscriptionStatus.mockReturnValue({
         data: {
@@ -380,7 +380,7 @@ describe('ActivationPage', () => {
       expect(screen.getByTestId('activation-loading')).toBeInTheDocument();
 
       act(() => {
-        vi.advanceTimersByTime(30000);
+        vi.advanceTimersByTime(90000);
       });
 
       await waitFor(() => {
@@ -388,6 +388,32 @@ describe('ActivationPage', () => {
       });
 
       expect(screen.getByText(/estamos procesando tu pago/i)).toBeInTheDocument();
+    });
+
+    it('should invalidate user data when falling back to the timeout state', async () => {
+      mockUseSubscriptionStatus.mockReturnValue({
+        data: {
+          plan: 'free',
+          subscriptionStatus: null,
+          planExpiresAt: null,
+          mpPreapprovalId: null,
+        },
+        isLoading: false,
+      });
+
+      renderWithProviders(<ActivationPage />);
+
+      act(() => {
+        vi.advanceTimersByTime(90000);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('activation-timeout')).toBeInTheDocument();
+      });
+
+      // If the webhook landed just after the last poll, the timeout invalidation
+      // ensures a later navigation/focus already reflects premium.
+      expect(mockInvalidateUserData).toHaveBeenCalled();
     });
 
     it('should show "Ir al inicio" button on timeout', async () => {
@@ -404,7 +430,7 @@ describe('ActivationPage', () => {
       renderWithProviders(<ActivationPage />);
 
       act(() => {
-        vi.advanceTimersByTime(30000);
+        vi.advanceTimersByTime(90000);
       });
 
       await waitFor(() => {

--- a/frontend/src/components/features/premium/ActivationPage.tsx
+++ b/frontend/src/components/features/premium/ActivationPage.tsx
@@ -9,9 +9,10 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Reveal } from '@/components/common/Reveal';
 import { PremiumHero } from './PremiumHero';
+import { useQueryClient } from '@tanstack/react-query';
 import { useSubscriptionStatus } from '@/hooks/api/useSubscription';
-import { useInvalidateCapabilities } from '@/hooks/api/useUserCapabilities';
 import { useAuthStore } from '@/stores/authStore';
+import { invalidateUserData } from '@/lib/utils/invalidate-user-data';
 import { ROUTES } from '@/lib/constants/routes';
 import type { EditorialImage } from '@/lib/data/encyclopedia-editorial.data';
 
@@ -20,7 +21,9 @@ import type { EditorialImage } from '@/lib/data/encyclopedia-editorial.data';
 // ============================================================================
 
 const POLLING_INTERVAL_MS = 2000;
-const POLLING_TIMEOUT_MS = 30000;
+// MercadoPago webhooks routinely take more than 30s in production. Give the
+// happy path a wider window before falling back to the "en procesamiento" UI.
+const POLLING_TIMEOUT_MS = 90000;
 
 /**
  * Themed image for the success band (T-PREM-004). `PremiumHero` degrades to its
@@ -197,7 +200,7 @@ type ActivationState = 'loading' | 'success' | 'timeout' | 'pending' | 'failure'
 export function ActivationPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const invalidateCapabilities = useInvalidateCapabilities();
+  const queryClient = useQueryClient();
   const { user, setUser } = useAuthStore();
 
   const status = parseCheckoutStatus(searchParams.get('status'));
@@ -214,8 +217,12 @@ export function ActivationPage() {
   // Track if we already handled the success (to avoid double-fire)
   const successHandled = useRef(false);
 
-  // Polling is active only while in 'loading' state for an 'authorized' checkout
-  const pollingActive = status === 'authorized' && activationState === 'loading';
+  // Keep polling in both 'loading' and 'timeout' states: if the MercadoPago
+  // webhook lands after the timeout fell back to the "en procesamiento" UI, the
+  // polling still detects it and recovers to the success state (invalidating the
+  // caches) instead of leaving the user with stale free capabilities.
+  const pollingActive =
+    status === 'authorized' && (activationState === 'loading' || activationState === 'timeout');
 
   // Subscription status polling — only enabled for authorized + loading flow
   const { data: subscriptionStatus } = useSubscriptionStatus({
@@ -236,6 +243,10 @@ export function ActivationPage() {
 
     const timer = setTimeout(() => {
       if (!successHandled.current) {
+        // Invalidate user data on the way into the timeout state so that, if the
+        // webhook landed between the last poll and now, any later navigation
+        // (or window focus) already reflects premium instead of stale free.
+        void invalidateUserData(queryClient);
         startTransition(() => {
           setActivationState('timeout');
         });
@@ -243,7 +254,7 @@ export function ActivationPage() {
     }, POLLING_TIMEOUT_MS);
 
     return () => clearTimeout(timer);
-  }, [status]);
+  }, [status, queryClient]);
 
   // Detect premium activation via polling
   useEffect(() => {
@@ -266,14 +277,16 @@ export function ActivationPage() {
       });
     }
 
-    // Invalidate capabilities to reflect new plan
-    invalidateCapabilities();
+    // Invalidate BOTH capabilities and profile (refetchType:'all' refetches even
+    // inactive queries) so every plan-gated surface reflects premium immediately,
+    // not just capabilities.
+    void invalidateUserData(queryClient);
 
     // Show success state immediately
     startTransition(() => {
       setActivationState('success');
     });
-  }, [subscriptionStatus?.plan, status, user, setUser, invalidateCapabilities]);
+  }, [subscriptionStatus?.plan, status, user, setUser, queryClient]);
 
   // Redirect after 3 seconds once success state is reached
   useEffect(() => {


### PR DESCRIPTION
## Contexto

Bug reportado: al hacer premium a un usuario y volver de MercadoPago, la UI seguía mostrando opciones de **free hasta refrescar**.

## Causa raíz

Cache staleness (NO JWT: el plan se re-lee de la DB en cada request). La `ActivationPage` (`/premium/activacion`) ya cubría el camino feliz (webhook <30s), pero tenía gaps:
1. El **success handler** solo invalidaba `['user','capabilities']`, no `['profile']` (staleTime 5min).
2. El **timeout de 30s** (corto para webhooks de MP en prod) caía al estado "en procesamiento" **sin invalidar nada ni seguir escuchando**; si el webhook llegaba después, la cache quedaba en free hasta un F5.

## Cambios (PR B del análisis de cache/tiempo real)

- **success**: usa `invalidateUserData` (capabilities + profile con `refetchType:'all'`) en vez de solo `invalidateCapabilities`, para que **toda** superficie gateada por plan refleje premium.
- **timeout**: 
  - Polling window 30s → **90s**.
  - Invalida user data al entrar en `timeout` (por si el webhook llegó entre el último poll y ahora).
  - **Mantiene el polling activo** en estado `timeout`: si el webhook llega tarde, recupera a `success` (con su invalidación) en vez de dejar al usuario con free stale.

## Tests

- Invalidación en success y en timeout; window ajustado a 90s. 27 pasando.

## Nota

Los gaps de fondo (authStore vs capabilities como doble fuente del plan) se abordan en el PR de unificación de gating (PR C). Este PR cubre específicamente el retorno de MP.

## Checklist

- [x] Tests (TDD) · `type-check` · `lint` (0 errores) · `build` · arquitectura OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)