### PR TITLE
fix(cache): cerrar gaps de invalidación en mutaciones de estado de usuario

### DIFF
--- a/frontend/src/hooks/api/useDailyReading.ts
+++ b/frontend/src/hooks/api/useDailyReading.ts
@@ -106,8 +106,11 @@ export function useDailyReadingPublic() {
 
   return useMutation({
     mutationFn: createDailyReadingPublic,
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: dailyReadingQueryKeys.all });
+      // Refresh capabilities so the anonymous daily-card usage/limit updates in any
+      // widget without a manual refresh (previously relied on the component doing it).
+      await invalidateUserData(queryClient);
       // No toast for anonymous users - component handles UI feedback
     },
     onError: () => {

--- a/frontend/src/hooks/api/usePendulum.ts
+++ b/frontend/src/hooks/api/usePendulum.ts
@@ -15,7 +15,8 @@ import {
 } from '@/lib/api/pendulum-api';
 import type { PendulumQueryRequest, PendulumResponse } from '@/types/pendulum.types';
 import type { PendulumFeatureLimit } from '@/types/capabilities.types';
-import { useUserCapabilities, capabilitiesQueryKeys } from './useUserCapabilities';
+import { useUserCapabilities } from './useUserCapabilities';
+import { invalidateUserData } from '@/lib/utils/invalidate-user-data';
 
 // ============================================================================
 // Query Keys (for consistency and type safety)
@@ -47,7 +48,9 @@ export function usePendulumQuery() {
     mutationFn: (request: PendulumQueryRequest) => queryPendulum(request),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: pendulumKeys.all });
-      queryClient.invalidateQueries({ queryKey: capabilitiesQueryKeys.capabilities });
+      // invalidateUserData refetches capabilities + profile even when inactive
+      // (refetchType:'all'), so a pendulum-limit widget mounted elsewhere refreshes.
+      void invalidateUserData(queryClient);
     },
   });
 }

--- a/frontend/src/hooks/api/useSubscription.ts
+++ b/frontend/src/hooks/api/useSubscription.ts
@@ -14,7 +14,7 @@ import {
   getSubscriptionStatus,
   cancelSubscription,
 } from '@/lib/api/subscription-mp-api';
-import { capabilitiesQueryKeys } from './useUserCapabilities';
+import { invalidateUserData } from '@/lib/utils/invalidate-user-data';
 import type { MpSubscriptionStatus } from '@/types';
 
 // ============================================================================
@@ -87,8 +87,9 @@ export function useCancelSubscription() {
   return useMutation({
     mutationFn: cancelSubscription,
     onSuccess: () => {
-      // Invalidate capabilities to reflect updated plan state
-      queryClient.invalidateQueries({ queryKey: capabilitiesQueryKeys.capabilities });
+      // Refresh capabilities + profile (refetchType:'all' covers inactive queries)
+      // so every plan-gated surface reflects the cancelled state.
+      void invalidateUserData(queryClient);
       // Invalidate subscription status to reflect cancelled state
       queryClient.invalidateQueries({ queryKey: subscriptionMpQueryKeys.status });
     },

--- a/frontend/src/hooks/api/useUser.test.ts
+++ b/frontend/src/hooks/api/useUser.test.ts
@@ -22,9 +22,12 @@ vi.mock('@/hooks/utils/useToast', () => ({
 
 // Mock auth store
 const mockLogout = vi.fn();
+const mockCheckAuth = vi.fn().mockResolvedValue(undefined);
 vi.mock('@/stores/authStore', () => ({
-  useAuthStore: () => ({
-    logout: mockLogout,
+  // useUpdateProfile calls useAuthStore.getState().checkAuth() to refresh the
+  // store after a profile edit, so the mock exposes getState too.
+  useAuthStore: Object.assign(() => ({ logout: mockLogout }), {
+    getState: () => ({ checkAuth: mockCheckAuth }),
   }),
 }));
 
@@ -162,6 +165,19 @@ describe('useUser hooks', () => {
 
       expect(userApi.updateProfile).toHaveBeenCalledWith(updateData);
       expect(result.current.data).toEqual(mockUpdatedProfile);
+    });
+
+    it('should refresh the auth store (checkAuth) on success so authStore name/plan stay fresh', async () => {
+      vi.mocked(userApi.updateProfile).mockResolvedValue(mockUpdatedProfile);
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useUpdateProfile(), { wrapper });
+
+      result.current.mutate({ name: 'Updated User' });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(mockCheckAuth).toHaveBeenCalled();
     });
 
     it('should invalidate profile query on success', async () => {

--- a/frontend/src/hooks/api/useUser.ts
+++ b/frontend/src/hooks/api/useUser.ts
@@ -55,6 +55,9 @@ export function useUpdateProfile() {
       // Invalidar numerología ya que depende de birthDate y name del usuario
       queryClient.invalidateQueries({ queryKey: numerologyQueryKeys.myProfile() });
       queryClient.invalidateQueries({ queryKey: numerologyQueryKeys.myInterpretation() });
+      // Refrescar el authStore (nombre/fecha de nacimiento) para que superficies que
+      // leen del store (p.ej. la inicial del avatar en UserMenu) no queden stale.
+      void useAuthStore.getState().checkAuth();
       toast.success('Perfil actualizado exitosamente');
     },
     onError: (error: Error) => {


### PR DESCRIPTION
## Contexto

Parte del análisis de cache/tiempo real. Varias mutaciones invalidaban capabilities con `refetchType` **default** (solo queries activas) o no refrescaban el authStore, dejando widgets/superficies stale hasta un F5.

## Cambios (PR D)

- **`usePendulumQuery`**: usa `invalidateUserData` (capabilities + profile, `refetchType:'all'`) en vez de invalidar solo capabilities activas → un widget de límite de péndulo montado en otra ruta se refresca.
- **`useCancelSubscription`**: idem, para que plan/uso reflejen la baja aunque el widget esté inactivo (además del status).
- **`useUpdateProfile`**: refresca el authStore vía `checkAuth()` en `onSuccess`, así la inicial del avatar (`UserMenu`) y demás lecturas del store no quedan stale tras editar el perfil.
- **`useDailyReadingPublic`** (anónimo): invalida capabilities en el **hook** (antes dependía de que lo hiciera el componente, frágil).

## Fuera de alcance (verificado)

**`useDeleteReading` no se toca**: el backend **no libera cuota** al borrar una lectura (revisado `delete-reading.use-case.ts` — no toca `usage_limit`), así que no hay stale de uso.

## Tests

- `checkAuth` tras update de perfil; mock de `getState` en el authStore.
- **Suite completa: 5337 tests pasando.**

## Checklist

- [x] Tests (TDD) · `type-check` · `lint` (0 errores) · `build` · arquitectura OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)