### PR TITLE
fix(frontend): desbloquear build de Railway (ERESOLVE de @hookform/resolvers)

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,11 @@
+# @hookform/resolvers v5 declara peer deps OPCIONALES contradictorias sobre
+# valibot: la propia lib pide valibot ^1.0.0 mientras su cadena @typeschema
+# arrastra valibot 0.39. Este proyecto usa zod (no valibot), así que ese peer
+# opcional es irrelevante. legacy-peer-deps permite que `npm install` resuelva
+# sin abortar por ese conflicto de peers opcionales.
+#
+# Necesario para el build de Railway: su Dockerfile copia solo package.json y
+# corre `npm install` (resolución fresca, sin lockfile), donde el conflicto
+# aparece. Los workflows de GitHub usan `npm ci` contra el lockfile raíz y no
+# se ven afectados.
+legacy-peer-deps=true

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,8 +4,9 @@ FROM node:20-alpine AS deps
 
 WORKDIR /app
 
-# Copy package files
-COPY package.json ./
+# Copy package files (.npmrc sets legacy-peer-deps so npm install resolves the
+# @hookform/resolvers v5 optional-peer conflict on valibot — see frontend/.npmrc)
+COPY package.json .npmrc ./
 RUN npm install
 
 # ── Stage 2: Build ──────────────────────────────────────────────


### PR DESCRIPTION
## Problema

El deploy de Railway falla en `npm install` (build daemon):

```
npm error code ERESOLVE
npm error peerOptional valibot@"^1.0.0 ..." from @hookform/resolvers@5.5.1
npm error Found: valibot@0.39.0 (via @typeschema/valibot@0.14.0)
```

## Causa

`@hookform/resolvers@5.5.1` declara peers **opcionales contradictorios** sobre `valibot`: la propia lib pide `valibot@^1.0.0`, mientras su cadena `@typeschema/*` arrastra `valibot@0.39`. El proyecto usa **zod**, no valibot → ese peer opcional es irrelevante.

El `frontend/Dockerfile` de Railway copia **solo `package.json`** y corre `npm install` (resolución fresca, **sin lockfile**), que es donde el conflicto explota. Los workflows de GitHub usan `npm ci` contra el lockfile raíz (que resolvió sin valibot) y **no** se ven afectados — por eso el problema es solo del deploy, no del CI de tests.

**No lo causaron los cambios de esta tanda de PRs** (ninguno tocó dependencias); es un conflicto que solo aparece en un install limpio sin lockfile.

## Fix (el que sugiere el propio Railway: `--legacy-peer-deps`)

- `frontend/.npmrc` con `legacy-peer-deps=true`.
- `frontend/Dockerfile`: copia el `.npmrc` antes de `npm install`.

Seguro: valibot es un peer **opcional no usado**; `legacy-peer-deps` solo evita que npm aborte por ese conflicto de peers opcionales.

## Validación

Repliqué la etapa `deps` del Docker en un dir limpio (solo `package.json` [+ `.npmrc`]):
- **Sin `.npmrc`** → `npm error code ERESOLVE` (repro exacto).
- **Con `.npmrc`** → `added 708 packages`, sin error.

## Nota de release

El deploy roto está en **main** (de merges previos). Este fix va a `develop`; al promover `develop → main` el build de Railway pasará.

🤖 Generated with [Claude Code](https://claude.com/claude-code)