### PR TITLE
feat(usage-limits): resetear límites diarios a medianoche de Argentina

### DIFF
--- a/backend/tarot-app/src/common/utils/date.utils.spec.ts
+++ b/backend/tarot-app/src/common/utils/date.utils.spec.ts
@@ -4,6 +4,10 @@ import {
   getStartOfTodayUTC,
   getStartOfTomorrowUTC,
   getDateDaysAgoUTCString,
+  getTodayAppDateString,
+  getStartOfTodayApp,
+  getNextAppMidnight,
+  getDateDaysAgoAppString,
 } from './date.utils';
 
 describe('Date Utils', () => {
@@ -120,6 +124,60 @@ describe('Date Utils', () => {
       // This test verifies the function works across year boundaries
       const result = getDateDaysAgoUTCString(400);
       expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  // ==========================================================================
+  // App business day (Argentina, UTC-3) — daily limit boundary
+  // ==========================================================================
+  describe('getTodayAppDateString', () => {
+    it('returns the Argentina calendar day, which differs from UTC late at night', () => {
+      // 2026-07-25 01:00 UTC = 2026-07-24 22:00 in Argentina (UTC-3)
+      expect(getTodayAppDateString(new Date('2026-07-25T01:00:00Z'))).toBe(
+        '2026-07-24',
+      );
+      // 2026-07-25 05:00 UTC = 2026-07-25 02:00 in Argentina
+      expect(getTodayAppDateString(new Date('2026-07-25T05:00:00Z'))).toBe(
+        '2026-07-25',
+      );
+    });
+
+    it('crosses the app day exactly at 03:00 UTC (00:00 Argentina)', () => {
+      expect(getTodayAppDateString(new Date('2026-07-25T02:59:59Z'))).toBe(
+        '2026-07-24',
+      );
+      expect(getTodayAppDateString(new Date('2026-07-25T03:00:00Z'))).toBe(
+        '2026-07-25',
+      );
+    });
+  });
+
+  describe('getStartOfTodayApp', () => {
+    it('returns the UTC instant of the current Argentina midnight (03:00 UTC)', () => {
+      // AR 02:00 on the 25th → start of AR day 25 = 2026-07-25T03:00:00Z
+      expect(
+        getStartOfTodayApp(new Date('2026-07-25T05:00:00Z')).toISOString(),
+      ).toBe('2026-07-25T03:00:00.000Z');
+      // AR 23:00 on the 24th → start of AR day 24 = 2026-07-24T03:00:00Z
+      expect(
+        getStartOfTodayApp(new Date('2026-07-25T02:00:00Z')).toISOString(),
+      ).toBe('2026-07-24T03:00:00.000Z');
+    });
+  });
+
+  describe('getNextAppMidnight', () => {
+    it('returns the next Argentina midnight as a UTC instant', () => {
+      expect(
+        getNextAppMidnight(new Date('2026-07-25T05:00:00Z')).toISOString(),
+      ).toBe('2026-07-26T03:00:00.000Z');
+    });
+  });
+
+  describe('getDateDaysAgoAppString', () => {
+    it('returns the Argentina date N days ago', () => {
+      expect(getDateDaysAgoAppString(7, new Date('2026-07-25T05:00:00Z'))).toBe(
+        '2026-07-18',
+      );
     });
   });
 });

--- a/backend/tarot-app/src/common/utils/date.utils.ts
+++ b/backend/tarot-app/src/common/utils/date.utils.ts
@@ -110,3 +110,73 @@ export function getStartOfMonthUTC(): Date {
   now.setUTCHours(0, 0, 0, 0);
   return now;
 }
+
+// ============================================================================
+// App business day (Argentina) — daily usage/limit boundary
+// ============================================================================
+
+/**
+ * App business timezone. The DAILY usage/limit "day" resets at local midnight
+ * in this timezone, NOT at UTC midnight, because the audience is in Argentina
+ * and a UTC boundary meant limits reset at 21:00 local.
+ *
+ * Argentina currently has NO DST (fixed UTC-3). If that ever changes, replace
+ * APP_UTC_OFFSET with an Intl-based offset computed per instant.
+ */
+export const APP_TIMEZONE = 'America/Argentina/Buenos_Aires';
+const APP_UTC_OFFSET = '-03:00';
+
+/**
+ * Returns the current calendar day in the app timezone as 'YYYY-MM-DD'.
+ * This is the key used for daily usage records and daily limit comparisons.
+ *
+ * @param now - Instant to evaluate (defaults to now)
+ * @example
+ * // At 2026-07-25T01:00:00Z (2026-07-24 22:00 in Argentina) → '2026-07-24'
+ */
+export function getTodayAppDateString(now: Date = new Date()): string {
+  // 'en-CA' formats dates as 'YYYY-MM-DD'.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: APP_TIMEZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now);
+}
+
+/**
+ * Returns the UTC instant of the most recent app-timezone midnight (start of the
+ * current app day). Use for TIMESTAMP comparisons like `createdAt >= start`.
+ *
+ * @param now - Instant to evaluate (defaults to now)
+ */
+export function getStartOfTodayApp(now: Date = new Date()): Date {
+  return new Date(`${getTodayAppDateString(now)}T00:00:00${APP_UTC_OFFSET}`);
+}
+
+/**
+ * Returns the UTC instant of the next app-timezone midnight (when the daily
+ * limits reset). Used for `resetAt` in capabilities.
+ *
+ * @param now - Instant to evaluate (defaults to now)
+ */
+export function getNextAppMidnight(now: Date = new Date()): Date {
+  // Fixed -3 offset ⇒ start-of-app-day + 24h is the next app midnight.
+  return new Date(getStartOfTodayApp(now).getTime() + 24 * 60 * 60 * 1000);
+}
+
+/**
+ * Returns the app-timezone date N days ago as 'YYYY-MM-DD'. Used for retention
+ * cleanup so the cutoff matches the app-day keys stored on usage records.
+ *
+ * @param days - Number of days to subtract
+ * @param now - Instant to evaluate (defaults to now)
+ */
+export function getDateDaysAgoAppString(
+  days: number,
+  now: Date = new Date(),
+): string {
+  return getTodayAppDateString(
+    new Date(now.getTime() - days * 24 * 60 * 60 * 1000),
+  );
+}

--- a/backend/tarot-app/src/modules/tarot/daily-reading/daily-reading.service.ts
+++ b/backend/tarot-app/src/modules/tarot/daily-reading/daily-reading.service.ts
@@ -20,7 +20,7 @@ import {
   DailyReadingHistoryDto,
   DailyReadingHistoryItemDto,
 } from './dto/daily-reading-history.dto';
-import { getTodayUTCDateString } from '../../../common/utils/date.utils';
+import { getTodayAppDateString } from '../../../common/utils/date.utils';
 
 @Injectable()
 export class DailyReadingService {
@@ -53,7 +53,7 @@ export class DailyReadingService {
     tarotistaId: number,
     user?: Partial<User>,
   ): Promise<DailyReading> {
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
 
     // NUEVO: Verificar límite de carta del día ANTES de verificar existencia
     // Si el usuario alcanzó su límite diario de cartas, lanzar error 403
@@ -167,7 +167,7 @@ export class DailyReadingService {
    * Obtiene la carta del día de hoy si existe
    */
   async getTodayCard(userId: number): Promise<DailyReading | null> {
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
 
     return this.dailyReadingRepository
       .createQueryBuilder('daily_reading')
@@ -202,7 +202,7 @@ export class DailyReadingService {
    * No incluye interpretación IA (solo info de DB)
    */
   async getTodayCardPublic(): Promise<DailyReading | null> {
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
 
     return this.dailyReadingRepository
       .createQueryBuilder('daily_reading')
@@ -222,7 +222,7 @@ export class DailyReadingService {
     fingerprint: string,
     tarotistaId: number,
   ): Promise<DailyReading> {
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
 
     // Verificar que NO existe carta del día para este fingerprint hoy
     const existingReading = await this.dailyReadingRepository
@@ -293,7 +293,7 @@ export class DailyReadingService {
     userId: number,
     tarotistaId: number,
   ): Promise<DailyReading> {
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
 
     // Buscar carta del día existente
     const existingReading = await this.dailyReadingRepository

--- a/backend/tarot-app/src/modules/usage-limits/guards/check-usage-limit.guard.spec.ts
+++ b/backend/tarot-app/src/modules/usage-limits/guards/check-usage-limit.guard.spec.ts
@@ -549,8 +549,8 @@ describe('CheckUsageLimitGuard', () => {
         const userId = 1;
         const today = '2025-01-15';
 
-        // Mock getTodayUTCDateString to return "today"
-        jest.spyOn(dateUtils, 'getTodayUTCDateString').mockReturnValue(today);
+        // Mock getTodayAppDateString to return "today"
+        jest.spyOn(dateUtils, 'getTodayAppDateString').mockReturnValue(today);
 
         // Recreate module with dailyReadingRepository mock
         const mockDailyQueryBuilder = {
@@ -634,7 +634,7 @@ describe('CheckUsageLimitGuard', () => {
         const userId = 1;
         const today = '2025-01-15';
 
-        jest.spyOn(dateUtils, 'getTodayUTCDateString').mockReturnValue(today);
+        jest.spyOn(dateUtils, 'getTodayAppDateString').mockReturnValue(today);
 
         const mockDailyQueryBuilder = {
           where: jest.fn().mockReturnThis(),
@@ -713,9 +713,9 @@ describe('CheckUsageLimitGuard', () => {
         const userId = 1;
         const today = '2025-01-15';
 
-        jest.spyOn(dateUtils, 'getTodayUTCDateString').mockReturnValue(today);
+        jest.spyOn(dateUtils, 'getTodayAppDateString').mockReturnValue(today);
         jest
-          .spyOn(dateUtils, 'getStartOfTodayUTC')
+          .spyOn(dateUtils, 'getStartOfTodayApp')
           .mockReturnValue(new Date('2025-01-15T00:00:00.000Z'));
 
         const mockTarotQueryBuilder = {
@@ -795,9 +795,9 @@ describe('CheckUsageLimitGuard', () => {
         const userId = 1;
         const today = '2025-01-15';
 
-        jest.spyOn(dateUtils, 'getTodayUTCDateString').mockReturnValue(today);
+        jest.spyOn(dateUtils, 'getTodayAppDateString').mockReturnValue(today);
         jest
-          .spyOn(dateUtils, 'getStartOfTodayUTC')
+          .spyOn(dateUtils, 'getStartOfTodayApp')
           .mockReturnValue(new Date('2025-01-15T00:00:00.000Z'));
 
         const mockTarotQueryBuilder = {
@@ -869,16 +869,16 @@ describe('CheckUsageLimitGuard', () => {
         jest.restoreAllMocks();
       });
 
-      it('should use consistent UTC date for both DAILY_CARD and TAROT_READING', async () => {
+      it('should use a consistent app-timezone date for both DAILY_CARD and TAROT_READING', async () => {
         // Verify both features use the same date utility functions
         const today = '2025-01-15';
         const startOfToday = new Date('2025-01-15T00:00:00.000Z');
 
         const getTodaySpy = jest
-          .spyOn(dateUtils, 'getTodayUTCDateString')
+          .spyOn(dateUtils, 'getTodayAppDateString')
           .mockReturnValue(today);
         const getStartSpy = jest
-          .spyOn(dateUtils, 'getStartOfTodayUTC')
+          .spyOn(dateUtils, 'getStartOfTodayApp')
           .mockReturnValue(startOfToday);
 
         // Test DAILY_CARD

--- a/backend/tarot-app/src/modules/usage-limits/guards/check-usage-limit.guard.ts
+++ b/backend/tarot-app/src/modules/usage-limits/guards/check-usage-limit.guard.ts
@@ -21,8 +21,8 @@ import { UserPlan } from '../../users/entities/user.entity';
 import { USAGE_LIMIT_FEATURE_KEY } from '../decorators/check-usage-limit.decorator';
 import { ALLOW_ANONYMOUS_KEY } from '../decorators/allow-anonymous.decorator';
 import {
-  getTodayUTCDateString,
-  getStartOfTodayUTC,
+  getTodayAppDateString,
+  getStartOfTodayApp,
 } from '../../../common/utils/date.utils';
 
 /** Standard error message for daily limit reached */
@@ -127,7 +127,7 @@ export class CheckUsageLimitGuard implements CanActivate {
    * to ensure consistent behavior across timezones.
    */
   private async checkDailyCardLimit(userId: number): Promise<boolean> {
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
     this.logger.debug(
       `Checking DAILY_CARD for userId=${userId}, date=${todayStr}`,
     );
@@ -180,8 +180,8 @@ export class CheckUsageLimitGuard implements CanActivate {
     }
 
     // Count today's readings using start of day UTC
-    const startOfToday = getStartOfTodayUTC();
-    const todayStr = getTodayUTCDateString();
+    const startOfToday = getStartOfTodayApp();
+    const todayStr = getTodayAppDateString();
 
     const readingsCount = await this.tarotReadingRepository
       .createQueryBuilder('tarot_reading')

--- a/backend/tarot-app/src/modules/usage-limits/services/anonymous-tracking.service.ts
+++ b/backend/tarot-app/src/modules/usage-limits/services/anonymous-tracking.service.ts
@@ -5,7 +5,7 @@ import { createHash } from 'crypto';
 import { AnonymousUsage } from '../entities/anonymous-usage.entity';
 import { UsageFeature } from '../entities/usage-limit.entity';
 import { Request } from 'express';
-import { getTodayUTCDateString } from '../../../common/utils/date.utils';
+import { getTodayAppDateString } from '../../../common/utils/date.utils';
 
 @Injectable()
 export class AnonymousTrackingService {
@@ -53,7 +53,7 @@ export class AnonymousTrackingService {
     feature: UsageFeature,
   ): Promise<boolean> {
     const fingerprint = this.generateFingerprint(ip, userAgent);
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
 
     // Check if fingerprint already accessed today for this feature
     const existingUsage = await this.anonymousUsageRepository.findOne({
@@ -80,7 +80,7 @@ export class AnonymousTrackingService {
     feature: UsageFeature,
   ): Promise<number> {
     const fingerprint = this.generateFingerprint(ip, userAgent);
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
 
     // Count usage for this fingerprint today
     const count = await this.anonymousUsageRepository.count({
@@ -103,7 +103,7 @@ export class AnonymousTrackingService {
     const ip = req.ip || '';
     const userAgent = req.headers['user-agent'] || '';
     const fingerprint = this.generateFingerprint(ip, userAgent);
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
 
     const anonymousUsage = this.anonymousUsageRepository.create({
       fingerprint,

--- a/backend/tarot-app/src/modules/usage-limits/services/usage-limits-reset.service.ts
+++ b/backend/tarot-app/src/modules/usage-limits/services/usage-limits-reset.service.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, LessThan } from 'typeorm';
 import { UsageLimit } from '../entities/usage-limit.entity';
 import { USAGE_RETENTION_DAYS } from '../usage-limits.constants';
-import { getDateDaysAgoUTCString } from '../../../common/utils/date.utils';
+import { getDateDaysAgoAppString } from '../../../common/utils/date.utils';
 
 /**
  * Service responsible for daily reset of usage limits.
@@ -37,7 +37,7 @@ export class UsageLimitsResetService {
     this.logger.log('Daily usage limits reset job started');
 
     try {
-      const cutoffDateStr = getDateDaysAgoUTCString(USAGE_RETENTION_DAYS);
+      const cutoffDateStr = getDateDaysAgoAppString(USAGE_RETENTION_DAYS);
 
       const deleteResult = await this.usageLimitRepository.delete({
         date: LessThan(cutoffDateStr),
@@ -66,7 +66,7 @@ export class UsageLimitsResetService {
     recordsToDelete: number;
     retentionDays: number;
   }> {
-    const cutoffDateStr = getDateDaysAgoUTCString(USAGE_RETENTION_DAYS);
+    const cutoffDateStr = getDateDaysAgoAppString(USAGE_RETENTION_DAYS);
 
     const count = await this.usageLimitRepository.count({
       where: {

--- a/backend/tarot-app/src/modules/usage-limits/usage-limits.service.spec.ts
+++ b/backend/tarot-app/src/modules/usage-limits/usage-limits.service.spec.ts
@@ -10,6 +10,7 @@ import {
   UserPlan,
   SubscriptionStatus,
 } from '../users/entities/user.entity';
+import { getTodayAppDateString } from '../../common/utils/date.utils';
 
 describe('UsageLimitsService', () => {
   let service: UsageLimitsService;
@@ -349,14 +350,12 @@ describe('UsageLimitsService', () => {
       expect(result).toBe(3);
     });
 
-    it('should query for today UTC date', async () => {
+    it('should query for today (app timezone / Argentina) date', async () => {
       mockUsageLimitRepository.findOne.mockResolvedValue(null);
 
       await service.getUsage(1, UsageFeature.DAILY_CARD);
 
-      const today = new Date();
-      today.setUTCHours(0, 0, 0, 0);
-      const expectedDate = today.toISOString().split('T')[0];
+      const expectedDate = getTodayAppDateString();
 
       expect(mockUsageLimitRepository.findOne).toHaveBeenCalledWith({
         where: {
@@ -520,10 +519,8 @@ describe('UsageLimitsService', () => {
         const dateArg = callArgs.where.date;
         expect(dateArg).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 
-        // Verify it's today's date
-        const today = new Date();
-        today.setUTCHours(0, 0, 0, 0);
-        const expectedDateString = today.toISOString().split('T')[0];
+        // Verify it's today's date (app timezone / Argentina)
+        const expectedDateString = getTodayAppDateString();
         expect(dateArg).toBe(expectedDateString);
       });
 
@@ -654,8 +651,8 @@ describe('UsageLimitsService', () => {
       });
     });
 
-    describe('UTC date handling', () => {
-      it('should use UTC timezone for date calculations', async () => {
+    describe('app-timezone date handling', () => {
+      it('should use the app timezone (Argentina) for date calculations', async () => {
         const freeUser: Partial<User> = {
           id: 1,
           plan: UserPlan.FREE,
@@ -675,14 +672,12 @@ describe('UsageLimitsService', () => {
         expect(typeof dateArg).toBe('string');
         expect(dateArg).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 
-        // Should match today's date in UTC
-        const today = new Date();
-        today.setUTCHours(0, 0, 0, 0);
-        const expectedDateString = today.toISOString().split('T')[0];
+        // Should match today's date in the app timezone (Argentina)
+        const expectedDateString = getTodayAppDateString();
         expect(dateArg).toBe(expectedDateString);
       });
 
-      it("should increment usage for today's date in UTC", async () => {
+      it("should increment usage for today's date (app timezone)", async () => {
         const mockInsertQueryBuilder = {
           insert: jest.fn().mockReturnThis(),
           into: jest.fn().mockReturnThis(),
@@ -703,9 +698,7 @@ describe('UsageLimitsService', () => {
           .mockReturnValueOnce(mockInsertQueryBuilder)
           .mockReturnValueOnce(mockUpdateQueryBuilder);
 
-        const todayMock = new Date();
-        todayMock.setUTCHours(0, 0, 0, 0);
-        const todayDateString = todayMock.toISOString().split('T')[0];
+        const todayDateString = getTodayAppDateString();
 
         mockUsageLimitRepository.findOne.mockResolvedValue({
           id: 1,
@@ -723,10 +716,8 @@ describe('UsageLimitsService', () => {
         expect(typeof insertValues.date).toBe('string');
         expect(insertValues.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 
-        // Verify it's today's date in UTC
-        const today = new Date();
-        today.setUTCHours(0, 0, 0, 0);
-        const expectedDateString = today.toISOString().split('T')[0];
+        // Verify it's today's date in the app timezone (Argentina)
+        const expectedDateString = getTodayAppDateString();
         expect(insertValues.date).toBe(expectedDateString);
       });
     });

--- a/backend/tarot-app/src/modules/usage-limits/usage-limits.service.ts
+++ b/backend/tarot-app/src/modules/usage-limits/usage-limits.service.ts
@@ -10,8 +10,8 @@ import { UsersService } from '../users/users.service';
 import { PlanConfigService } from '../plan-config/plan-config.service';
 import { USAGE_RETENTION_DAYS, USAGE_LIMITS } from './usage-limits.constants';
 import {
-  getTodayUTCDateString,
-  getDateDaysAgoUTCString,
+  getTodayAppDateString,
+  getDateDaysAgoAppString,
 } from '../../common/utils/date.utils';
 
 @Injectable()
@@ -64,7 +64,7 @@ export class UsageLimitsService {
     userId: number,
     feature: UsageFeature,
   ): Promise<UsageLimit | null> {
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
     return this.usageLimitRepository.findOne({
       where: {
         userId,
@@ -134,7 +134,7 @@ export class UsageLimitsService {
     userId: number,
     feature: UsageFeature,
   ): Promise<UsageLimit> {
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
 
     // First, try to create a new record (if it doesn't exist)
     // This leverages the unique constraint on (userId, feature, date)
@@ -203,7 +203,7 @@ export class UsageLimitsService {
    * @returns Cantidad de registros eliminados.
    */
   async resetTodayUsage(userId: number): Promise<number> {
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
 
     const result = await this.usageLimitRepository
       .createQueryBuilder()
@@ -216,7 +216,7 @@ export class UsageLimitsService {
   }
 
   async cleanOldRecords(): Promise<number> {
-    const cutoffDateStr = getDateDaysAgoUTCString(USAGE_RETENTION_DAYS);
+    const cutoffDateStr = getDateDaysAgoAppString(USAGE_RETENTION_DAYS);
 
     const result = await this.usageLimitRepository
       .createQueryBuilder()

--- a/backend/tarot-app/src/modules/users/application/services/user-capabilities.service.spec.ts
+++ b/backend/tarot-app/src/modules/users/application/services/user-capabilities.service.spec.ts
@@ -12,6 +12,7 @@ import { UserPlanType } from '../dto/user-capabilities.dto';
 import { User, UserPlan, SubscriptionStatus } from '../../entities/user.entity';
 import { Plan } from '../../../plan-config/entities/plan.entity';
 import { UserRole } from '../../../../common/enums/user-role.enum';
+import { getNextAppMidnight } from '../../../../common/utils';
 
 describe('UserCapabilitiesService', () => {
   let service: UserCapabilitiesService;
@@ -696,7 +697,7 @@ describe('UserCapabilitiesService', () => {
     });
 
     describe('resetAt calculation', () => {
-      it('should return next midnight UTC', async () => {
+      it('should return the next Argentina (app timezone) midnight', async () => {
         // No fingerprint provided, so no query is made
         const result = await service.getCapabilities(null, null);
         const resetDate = new Date(result.dailyCard.resetAt);
@@ -704,13 +705,17 @@ describe('UserCapabilitiesService', () => {
         // Should be a valid date
         expect(resetDate.toString()).not.toBe('Invalid Date');
 
-        // Should be midnight UTC
-        expect(resetDate.getUTCHours()).toBe(0);
+        // Should be the next app (Argentina) midnight. Argentina is UTC-3, so
+        // local midnight lands at 03:00 UTC.
+        expect(result.dailyCard.resetAt).toBe(
+          getNextAppMidnight().toISOString(),
+        );
+        expect(resetDate.getUTCHours()).toBe(3);
         expect(resetDate.getUTCMinutes()).toBe(0);
         expect(resetDate.getUTCSeconds()).toBe(0);
         expect(resetDate.getUTCMilliseconds()).toBe(0);
 
-        // Should be in the future (tomorrow)
+        // Should be in the future (next local midnight)
         const now = new Date();
         expect(resetDate.getTime()).toBeGreaterThan(now.getTime());
       });

--- a/backend/tarot-app/src/modules/users/application/services/user-capabilities.service.ts
+++ b/backend/tarot-app/src/modules/users/application/services/user-capabilities.service.ts
@@ -13,8 +13,9 @@ import {
 } from '../dto/user-capabilities.dto';
 import { UserPlan } from '../../entities/user.entity';
 import {
-  getTodayUTCDateString,
-  getStartOfTodayUTC,
+  getTodayAppDateString,
+  getStartOfTodayApp,
+  getNextAppMidnight,
   mapSubscriptionStatus,
 } from '../../../../common/utils';
 import { UsageFeature } from '../../../usage-limits/entities/usage-limit.entity';
@@ -60,7 +61,7 @@ export class UserCapabilitiesService {
     // Esto garantiza consistencia con la tabla real de lecturas
     // BUG-CAP-001 FIX: Use string comparison for DATE column (not MoreThanOrEqual with Date object)
     // The readingDate column is type DATE (YYYY-MM-DD), so we must use string equality
-    const todayStr = getTodayUTCDateString();
+    const todayStr = getTodayAppDateString();
 
     const existingDailyReading = await this.dailyReadingRepository
       .createQueryBuilder('daily_reading')
@@ -73,7 +74,7 @@ export class UserCapabilitiesService {
     // Obtener uso de tiradas de tarot consultando directamente la tabla tarot_reading
     // Esto garantiza consistencia con la tabla real de lecturas
     // For TIMESTAMP columns, MoreThanOrEqual with Date object works correctly
-    const startOfToday = getStartOfTodayUTC();
+    const startOfToday = getStartOfTodayApp();
     const tarotReadingsCount = await this.tarotReadingRepository.count({
       where: {
         user: { id: userId },
@@ -92,7 +93,7 @@ export class UserCapabilitiesService {
         ? 999999
         : planConfig.tarotReadingsLimit;
 
-    const resetAt = this.getNextMidnightUTC();
+    const resetAt = this.getNextResetAt();
 
     // Obtener límites del péndulo según el plan del usuario
     const pendulumConfig = await this.planConfigService.getPendulumLimit(
@@ -108,7 +109,7 @@ export class UserCapabilitiesService {
     // Calcular resetAt del péndulo según el período
     let pendulumResetAt: string | null = null;
     if (pendulumConfig.period === 'daily') {
-      pendulumResetAt = resetAt; // Usa el mismo resetAt (próxima medianoche UTC)
+      pendulumResetAt = resetAt; // Usa el mismo resetAt (próxima medianoche AR)
     } else if (pendulumConfig.period === 'monthly') {
       // Calcular primer día del próximo mes (00:00:00.000 UTC) de forma segura
       // Usar Date.UTC() evita bugs de normalización en fechas de fin de mes
@@ -170,7 +171,7 @@ export class UserCapabilitiesService {
   private async getAnonymousCapabilities(
     fingerprint: string | null,
   ): Promise<UserCapabilitiesDto> {
-    const resetAt = this.getNextMidnightUTC();
+    const resetAt = this.getNextResetAt();
 
     // Check actual usage for anonymous user via fingerprint
     let dailyCardUsed = 0;
@@ -182,7 +183,7 @@ export class UserCapabilitiesService {
     if (fingerprint && fingerprint.length > 0) {
       // Query the daily_reading table directly for today's reading
       // BUG-CAP-001 FIX: Use string comparison for DATE column
-      const todayStr = getTodayUTCDateString();
+      const todayStr = getTodayAppDateString();
 
       const existingReading = await this.dailyReadingRepository
         .createQueryBuilder('daily_reading')
@@ -243,14 +244,12 @@ export class UserCapabilitiesService {
   }
 
   /**
-   * Calcula la próxima medianoche UTC
-   * @returns Fecha ISO 8601 de la próxima medianoche UTC
+   * Calcula la próxima medianoche en la zona horaria de la app (Argentina),
+   * que es cuando resetean los límites diarios.
+   * @returns Fecha ISO 8601 (instante UTC) de la próxima medianoche local AR
    */
-  private getNextMidnightUTC(): string {
-    const tomorrow = new Date();
-    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
-    tomorrow.setUTCHours(0, 0, 0, 0);
-    return tomorrow.toISOString();
+  private getNextResetAt(): string {
+    return getNextAppMidnight().toISOString();
   }
 
   /**


### PR DESCRIPTION
## Contexto

Los límites de uso (tiradas de tarot, carta del día, péndulo diario) reseteaban a **medianoche UTC = 21:00 ART**, así que a un usuario argentino se le reseteaban a las 21hs. Este PR hace que el "día" de los límites sea el **día calendario de Argentina** → resetean a las **00:00 hora local AR**.

## Enfoque (Opción A — zona horaria fija de la app)

A diferencia del horóscopo (display-only), los límites se **enforcean en el backend**, así que el cambio es server-side. Usamos una zona horaria fija de la app (Argentina), sin abuso ni plumbing de TZ por request.

## Cambios

- **`date.utils`**: nuevas funciones de "día de la app" — `getTodayAppDateString`, `getStartOfTodayApp`, `getNextAppMidnight`, `getDateDaysAgoAppString`. `APP_TIMEZONE = America/Argentina/Buenos_Aires`. (Argentina no tiene DST; si volviera, cambiar `APP_UTC_OFFSET` por un offset calculado con `Intl`.)
- **Migrados todos los consumidores del boundary diario**: `usage-limits.service` (conteo/chequeo/incremento/reset/retención), `check-usage-limit.guard`, `anonymous-tracking.service`, `daily-reading.service`, `user-capabilities.service` (conteo + `resetAt` = próxima medianoche AR), `usage-limits-reset.service` (retención).
- Se **conservan** las utils UTC como primitivas genéricas (para mes/otros usos).

## Frontend: sin cambios

El timer de reset que ya construimos consume `capabilities.resetAt`. Ahora ese campo devuelve la **próxima medianoche AR** (03:00 UTC), así que el auto-refresco sin F5 ya funciona.

## Tests

- Nuevas utils app con caso de borde **03:00 UTC = 00:00 AR** (cruce de día).
- Specs de límites/guard/capabilities actualizados de "UTC" a "día app (Argentina)": `resetAt` ahora se espera a las 03:00 UTC y se valida contra `getNextAppMidnight()`.
- **Suite backend completa: 4591 tests en verde.**

## Nota

El `date` de `usage_limit` pasa a guardar la fecha AR. Registros existentes (UTC) conviven sin problema; solo cambia la clave a futuro.

## Checklist

- [x] Tests (TDD) · `lint` · `build` · `validate-architecture` OK
- [x] Sin `any` / `eslint-disable`, texto en español

🤖 Generated with [Claude Code](https://claude.com/claude-code)