### PR TITLE
fix(horoscope): backfill de horóscopos faltantes al arrancar la app

### DIFF
--- a/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.spec.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { HoroscopeCronService } from './horoscope-cron.service';
 import { HoroscopeGenerationService } from './horoscope-generation.service';
 import { ZodiacSign } from '../../../../common/utils/zodiac.utils';
@@ -7,6 +8,7 @@ import { DailyHoroscope } from '../../entities/daily-horoscope.entity';
 
 describe('HoroscopeCronService', () => {
   let service: HoroscopeCronService;
+  let mockConfigGet: jest.Mock;
 
   // Mock completo de DailyHoroscope
   const createMockHoroscope = (sign: ZodiacSign): DailyHoroscope => ({
@@ -38,12 +40,20 @@ describe('HoroscopeCronService', () => {
   };
 
   beforeEach(async () => {
+    // Por defecto los tests corren fuera de producción, así el hook de bootstrap
+    // no dispara generación salvo en los tests que lo fuerzan explícitamente.
+    mockConfigGet = jest.fn().mockReturnValue('test');
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         HoroscopeCronService,
         {
           provide: HoroscopeGenerationService,
           useValue: mockHoroscopeGenerationService,
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: mockConfigGet },
         },
       ],
     }).compile();
@@ -68,6 +78,52 @@ describe('HoroscopeCronService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('onApplicationBootstrap', () => {
+    // Deja correr la tarea fire-and-forget disparada por el hook.
+    const flushMicrotasks = () =>
+      new Promise((resolve) => setImmediate(resolve));
+
+    it('rellena los horóscopos faltantes de hoy al arrancar en producción', async () => {
+      mockConfigGet.mockReturnValue('production');
+      mockHoroscopeGenerationService.findMissingSignsForDate.mockResolvedValue(
+        [],
+      );
+
+      service.onApplicationBootstrap();
+      await flushMicrotasks();
+
+      expect(mockConfigGet).toHaveBeenCalledWith('NODE_ENV');
+      expect(
+        mockHoroscopeGenerationService.findMissingSignsForDate,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('NO dispara generación fuera de producción (dev/test)', async () => {
+      mockConfigGet.mockReturnValue('development');
+
+      service.onApplicationBootstrap();
+      await flushMicrotasks();
+
+      expect(
+        mockHoroscopeGenerationService.findMissingSignsForDate,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('no propaga errores del backfill (no tumba el arranque)', async () => {
+      mockConfigGet.mockReturnValue('production');
+      mockHoroscopeGenerationService.findMissingSignsForDate.mockRejectedValue(
+        new Error('DB caída'),
+      );
+
+      expect(() => service.onApplicationBootstrap()).not.toThrow();
+      await flushMicrotasks();
+
+      expect(
+        mockHoroscopeGenerationService.findMissingSignsForDate,
+      ).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('generateDailyHoroscopes', () => {

--- a/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.spec.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.spec.ts
@@ -98,6 +98,14 @@ describe('HoroscopeCronService', () => {
       expect(
         mockHoroscopeGenerationService.findMissingSignsForDate,
       ).toHaveBeenCalledTimes(1);
+
+      // Se rellena la fecha de HOY (blinda contra regresiones en el argumento).
+      const dateArg =
+        mockHoroscopeGenerationService.findMissingSignsForDate.mock.calls[0][0];
+      expect(dateArg).toBeInstanceOf(Date);
+      expect((dateArg as Date).toISOString().split('T')[0]).toBe(
+        new Date().toISOString().split('T')[0],
+      );
     });
 
     it('NO dispara generación fuera de producción (dev/test)', async () => {

--- a/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.ts
@@ -33,6 +33,7 @@ interface GenerationResult {
  *
  * Responsabilidades:
  * - Generar horóscopos diarios a las 01:00 UTC de forma SECUENCIAL
+ * - Rellenar los faltantes de hoy al arrancar la app (backfill de bootstrap)
  * - Respetar límites de rate de la API de IA (15 RPM para Gemini)
  * - Limpiar horóscopos antiguos semanalmente
  * - Proveer método manual para testing

--- a/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.ts
+++ b/backend/tarot-app/src/modules/horoscope/application/services/horoscope-cron.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Cron } from '@nestjs/schedule';
 import { HoroscopeGenerationService } from './horoscope-generation.service';
 import {
@@ -41,9 +42,12 @@ interface GenerationResult {
  * - Delay de 6 segundos entre signos para no superar 15 RPM
  * - Total: ~72 segundos para 12 signos
  * - Si un signo falla, continúa con el siguiente
+ * - Al arrancar la app (OnApplicationBootstrap) rellena los horóscopos faltantes
+ *   de hoy, para recuperarse de corridas de cron perdidas por deploys/reinicios
+ *   (los @Cron de NestJS no ejecutan tareas perdidas).
  */
 @Injectable()
-export class HoroscopeCronService {
+export class HoroscopeCronService implements OnApplicationBootstrap {
   private readonly logger = new Logger(HoroscopeCronService.name);
 
   /**
@@ -71,7 +75,63 @@ export class HoroscopeCronService {
     ZodiacSign.PISCES,
   ];
 
-  constructor(private readonly horoscopeService: HoroscopeGenerationService) {}
+  constructor(
+    private readonly horoscopeService: HoroscopeGenerationService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * Hook de arranque: al levantar la app, rellena los horóscopos faltantes de hoy.
+   *
+   * Motivo: los @Cron de NestJS NO ejecutan tareas perdidas. Si el proceso estaba
+   * caído o redesplegando durante la ventana de generación (01:00 UTC) y de
+   * verificación (02:00 UTC), el día quedaría sin generar hasta el día siguiente.
+   * Este hook hace que cada deploy/reinicio se auto-cure el día en curso.
+   *
+   * - Solo corre en producción: en dev (watch mode) y test evita disparar la IA
+   *   en cada reinicio.
+   * - Fire-and-forget: no bloquea el arranque de la app (la generación puede
+   *   tardar ~72s). Los errores se loguean, no se propagan.
+   * - Idempotente: `generateMissingHoroscopes` solo genera los signos que faltan.
+   */
+  onApplicationBootstrap(): void {
+    const nodeEnv = this.configService.get<string>('NODE_ENV');
+
+    if (nodeEnv !== 'production') {
+      this.logger.log(
+        `Bootstrap backfill de horóscopos omitido (NODE_ENV=${nodeEnv ?? 'undefined'})`,
+      );
+      return;
+    }
+
+    // Fire-and-forget: no await para no bloquear el arranque.
+    void this.runBootstrapBackfill();
+  }
+
+  /**
+   * Ejecuta el relleno de faltantes del día en curso, capturando cualquier error
+   * para que un fallo del backfill nunca tumbe el arranque de la app.
+   */
+  private async runBootstrapBackfill(): Promise<void> {
+    try {
+      this.logger.log(
+        '=== BOOTSTRAP: verificando completitud de horóscopos de hoy ===',
+      );
+      const result = await this.generateMissingHoroscopes(new Date());
+      this.logger.log(
+        `Bootstrap backfill: ${result.missing} faltantes, ` +
+          `${result.successful} generados, ${result.failed} fallidos`,
+      );
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const errorStack = error instanceof Error ? (error.stack ?? '') : '';
+      this.logger.error(
+        `Error en bootstrap backfill de horóscopos: ${errorMessage}`,
+        errorStack,
+      );
+    }
+  }
 
   /**
    * Genera horóscopos diarios para todos los signos - 01:00 UTC (22:00 ART)


### PR DESCRIPTION
## Problema

Los `@Cron` de NestJS **no ejecutan tareas perdidas**. Si el proceso está caído o redesplegando durante la ventana de generación (01:00 UTC) y de verificación (02:00 UTC), el día queda **sin generar hasta el día siguiente**, y los usuarios ven el horóscopo de ayer (fallback) todo el día.

Verificado en producción: el 26/07, tras un deploy que cayó en la ventana de los crons, quedó con **0/12 horóscopos** a las 13:38 ART, mientras el 24 y 25 estaban completos. Esta es la causa raíz del recurrente "no se generan los horóscopos".

## Solución

Hook `OnApplicationBootstrap` en `HoroscopeCronService`: al levantar la app, rellena los horóscopos faltantes de hoy reutilizando `generateMissingHoroscopes(today)`. **Cada deploy/reinicio se auto-cura el día en curso.**

- **Solo en producción** (`NODE_ENV=production`): evita disparar la IA en cada reinicio de dev (watch mode) y en tests.
- **Fire-and-forget**: no bloquea el arranque (la generación puede tardar ~72s).
- **Idempotente**: solo genera los signos que faltan; los errores se loguean y **no se propagan** (un fallo del backfill nunca tumba el arranque).

## Cambios

- `horoscope-cron.service.ts`: implementa `OnApplicationBootstrap`, inyecta `ConfigService`, agrega `onApplicationBootstrap()` + `runBootstrapBackfill()`.
- `horoscope-cron.service.spec.ts`: 3 tests nuevos (corre backfill en prod; NO dispara fuera de prod; no propaga errores).

## Validaciones

- [x] `npm run format`
- [x] `npm run lint`
- [x] Tests: 44/44 ✅ (3 suites)
- [x] `npm run build` ✅
- [x] `node scripts/validate-architecture.js` ✅

## Relación con otros PRs

Complementa el **PR #614** (mueve los crons a 01:00/02:00 UTC para que el día esté listo antes de la medianoche argentina). Este PR ataca el otro flanco: que la app **no haya corrido el cron** por estar caída/redesplegando.

## Limitación conocida

Si la plataforma **duerme** el servicio (scale-to-zero) y no hay tráfico a las 01:00 UTC, el cron igual no dispara y el backfill solo actúa cuando algo despierta la app. Para garantía total haría falta un scheduler externo (cron de la plataforma o pinger). Fuera de alcance de este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)