### PR TITLE
feat(seeds): script parametrizable para crear/promover un admin

### DIFF
--- a/backend/tarot-app/package.json
+++ b/backend/tarot-app/package.json
@@ -38,6 +38,7 @@
     "db:seed:all": "ts-node -r tsconfig-paths/register scripts/db-seed-all.ts",
     "db:seed:cards": "ts-node -r tsconfig-paths/register scripts/db-seed-cards.ts",
     "db:seed:users": "ts-node -r tsconfig-paths/register scripts/db-seed-users.ts",
+    "db:seed:admin": "ts-node -r tsconfig-paths/register scripts/db-seed-admin.ts",
     "generate:reading": "ts-node -r tsconfig-paths/register scripts/generate-reading.ts",
     "test:e2e:local": "npm run db:e2e:reset && npm run test:e2e && npm run db:e2e:clean",
     "logs:openai": "ts-node -r tsconfig-paths/register scripts/logs-openai.ts",

--- a/backend/tarot-app/scripts/db-seed-admin.ts
+++ b/backend/tarot-app/scripts/db-seed-admin.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env ts-node
+/**
+ * Script para crear/promover un usuario ADMIN de forma parametrizable.
+ *
+ * A diferencia de db:seed:users (credenciales hardcodeadas de test), este script
+ * toma las credenciales desde variables de entorno, para poder crear el primer
+ * admin en producción sin exponer secretos en el repo.
+ *
+ * Conecta a la base definida por las variables POSTGRES_* del entorno actual, así
+ * que para apuntar a producción hay que exportar las env de la DB de producción.
+ *
+ * Uso:
+ *   ADMIN_EMAIL=florzenavilla@gmail.com \
+ *   ADMIN_PASSWORD='TuPasswordTemporal' \
+ *   ADMIN_NAME='Flor' \
+ *   npm run db:seed:admin
+ *
+ * ADMIN_NAME es opcional (default: 'Admin'). ADMIN_EMAIL y ADMIN_PASSWORD son
+ * obligatorios. Es idempotente: si el email ya existe, lo promueve a admin.
+ */
+
+import { NestFactory } from '@nestjs/core';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AppModule } from '../src/app.module';
+import { User } from '../src/modules/users/entities/user.entity';
+import { seedAdminUser } from '../src/database/seeds/admin-user.seeder';
+
+async function bootstrap(): Promise<void> {
+  const email = process.env.ADMIN_EMAIL;
+  const password = process.env.ADMIN_PASSWORD;
+  const name = process.env.ADMIN_NAME ?? 'Admin';
+
+  if (!email || !password) {
+    console.error(
+      '❌ Faltan variables de entorno obligatorias: ADMIN_EMAIL y ADMIN_PASSWORD.',
+    );
+    console.error(
+      "   Ejemplo: ADMIN_EMAIL=admin@dominio.com ADMIN_PASSWORD='...' npm run db:seed:admin",
+    );
+    process.exit(1);
+  }
+
+  const app = await NestFactory.createApplicationContext(AppModule);
+  const userRepository = app.get<Repository<User>>(getRepositoryToken(User));
+
+  try {
+    console.log(`👤 Seeding admin (${email})...`);
+    const result = await seedAdminUser(userRepository, {
+      email,
+      password,
+      name,
+    });
+    console.log(
+      `✨ Listo: acción=${result.action}, userId=${result.userId}. ` +
+        'Cambiá la password desde la app apenas ingreses.',
+    );
+  } catch (error) {
+    console.error('❌ Error creando el admin:', error);
+    process.exit(1);
+  } finally {
+    await app.close();
+  }
+}
+
+void bootstrap();

--- a/backend/tarot-app/scripts/db-seed-admin.ts
+++ b/backend/tarot-app/scripts/db-seed-admin.ts
@@ -6,25 +6,70 @@
  * toma las credenciales desde variables de entorno, para poder crear el primer
  * admin en producción sin exponer secretos en el repo.
  *
- * Conecta a la base definida por las variables POSTGRES_* del entorno actual, así
- * que para apuntar a producción hay que exportar las env de la DB de producción.
+ * IMPORTANTE: usa un DataSource AISLADO (NO bootea el AppModule), con
+ * `migrationsRun: false` y `synchronize: false`. Así, correrlo contra producción
+ * solo inserta/actualiza el usuario admin y NUNCA dispara migraciones ni DDL.
  *
- * Uso:
- *   ADMIN_EMAIL=florzenavilla@gmail.com \
- *   ADMIN_PASSWORD='TuPasswordTemporal' \
- *   ADMIN_NAME='Flor' \
+ * Conexión (en este orden de prioridad):
+ *   1. DATABASE_URL (o DB_URL): string de conexión completo. Útil para apuntar a
+ *      producción vía el proxy público de Railway (DATABASE_PUBLIC_URL).
+ *   2. Variables POSTGRES_* individuales (host/port/user/password/db).
+ * Opcional: DB_SSL=true para habilitar SSL (rejectUnauthorized: false).
+ *
+ * Uso (local, con POSTGRES_* del .env):
+ *   ADMIN_EMAIL=admin@dominio.com ADMIN_PASSWORD='...' npm run db:seed:admin
+ *
+ * Uso (producción, vía proxy público de Railway):
+ *   DATABASE_URL='postgresql://user:pass@junction.proxy.rlwy.net:PORT/railway' \
+ *   ADMIN_EMAIL=admin@dominio.com ADMIN_PASSWORD='...' ADMIN_NAME='...' \
  *   npm run db:seed:admin
  *
  * ADMIN_NAME es opcional (default: 'Admin'). ADMIN_EMAIL y ADMIN_PASSWORD son
  * obligatorios. Es idempotente: si el email ya existe, lo promueve a admin.
  */
 
-import { NestFactory } from '@nestjs/core';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { AppModule } from '../src/app.module';
+import 'reflect-metadata';
+import * as path from 'path';
+import { DataSource } from 'typeorm';
 import { User } from '../src/modules/users/entities/user.entity';
 import { seedAdminUser } from '../src/database/seeds/admin-user.seeder';
+
+/**
+ * Construye un DataSource aislado (sin migraciones ni synchronize) para operar
+ * solo sobre las entidades, sin arrastrar el arranque completo del AppModule.
+ */
+function buildDataSource(): DataSource {
+  const url = process.env.DATABASE_URL ?? process.env.DB_URL;
+  const ssl =
+    process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : false;
+  const entities = [path.join(__dirname, '..', 'src', '**', '*.entity{.ts,.js}')];
+
+  if (url) {
+    return new DataSource({
+      type: 'postgres',
+      url,
+      entities,
+      synchronize: false,
+      migrationsRun: false,
+      ssl,
+      logging: ['error'],
+    });
+  }
+
+  return new DataSource({
+    type: 'postgres',
+    host: process.env.POSTGRES_HOST ?? 'localhost',
+    port: parseInt(process.env.POSTGRES_PORT ?? '5432', 10),
+    username: process.env.POSTGRES_USER ?? 'postgres',
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DB,
+    entities,
+    synchronize: false,
+    migrationsRun: false,
+    ssl,
+    logging: ['error'],
+  });
+}
 
 async function bootstrap(): Promise<void> {
   const email = process.env.ADMIN_EMAIL;
@@ -41,12 +86,13 @@ async function bootstrap(): Promise<void> {
     process.exit(1);
   }
 
-  const app = await NestFactory.createApplicationContext(AppModule);
-  const userRepository = app.get<Repository<User>>(getRepositoryToken(User));
+  const dataSource = buildDataSource();
+  await dataSource.initialize();
+  console.log('✅ Conectado a la base de datos.');
 
   try {
     console.log(`👤 Seeding admin (${email})...`);
-    const result = await seedAdminUser(userRepository, {
+    const result = await seedAdminUser(dataSource.getRepository(User), {
       email,
       password,
       name,
@@ -57,9 +103,9 @@ async function bootstrap(): Promise<void> {
     );
   } catch (error) {
     console.error('❌ Error creando el admin:', error);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
-    await app.close();
+    await dataSource.destroy();
   }
 }
 

--- a/backend/tarot-app/src/database/seeds/admin-user.seeder.spec.ts
+++ b/backend/tarot-app/src/database/seeds/admin-user.seeder.spec.ts
@@ -1,0 +1,109 @@
+import { Repository } from 'typeorm';
+import { User, UserRole } from '../../modules/users/entities/user.entity';
+import { seedAdminUser } from './admin-user.seeder';
+
+describe('seedAdminUser', () => {
+  let mockRepo: {
+    findOne: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+  };
+
+  const input = {
+    email: 'florzenavilla@gmail.com',
+    password: 'TempPass123!',
+    name: 'Flor',
+  };
+
+  beforeEach(() => {
+    mockRepo = {
+      findOne: jest.fn(),
+      create: jest.fn((data) => data as User),
+      save: jest.fn((user) => Promise.resolve({ id: 42, ...user } as User)),
+    };
+    jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('crea un admin nuevo cuando el email no existe', async () => {
+    mockRepo.findOne.mockResolvedValue(null);
+
+    const result = await seedAdminUser(
+      mockRepo as unknown as Repository<User>,
+      input,
+    );
+
+    expect(result.action).toBe('created');
+    expect(result.userId).toBe(42);
+
+    const created = mockRepo.create.mock.calls[0][0] as Partial<User>;
+    expect(created.email).toBe('florzenavilla@gmail.com');
+    expect(created.roles).toEqual([UserRole.CONSUMER, UserRole.ADMIN]);
+    expect(created.isAdmin).toBe(true);
+    // La password se guarda hasheada, nunca en texto plano.
+    expect(created.password).not.toBe(input.password);
+    expect(typeof created.password).toBe('string');
+  });
+
+  it('normaliza el email a minúsculas y sin espacios', async () => {
+    mockRepo.findOne.mockResolvedValue(null);
+
+    await seedAdminUser(mockRepo as unknown as Repository<User>, {
+      ...input,
+      email: '  Flor.Zenavilla@Gmail.com  ',
+    });
+
+    expect(mockRepo.findOne).toHaveBeenCalledWith({
+      where: { email: 'flor.zenavilla@gmail.com' },
+    });
+  });
+
+  it('promueve a admin un usuario existente que no lo es (sin tocar la password)', async () => {
+    const existing = {
+      id: 7,
+      email: input.email,
+      password: 'hash-previo',
+      roles: [UserRole.CONSUMER],
+      isAdmin: false,
+    } as User;
+    mockRepo.findOne.mockResolvedValue(existing);
+
+    const result = await seedAdminUser(
+      mockRepo as unknown as Repository<User>,
+      input,
+    );
+
+    expect(result.action).toBe('promoted');
+    expect(result.userId).toBe(7);
+
+    const saved = mockRepo.save.mock.calls[0][0] as User;
+    expect(saved.roles).toContain(UserRole.ADMIN);
+    expect(saved.roles).toContain(UserRole.CONSUMER);
+    expect(saved.isAdmin).toBe(true);
+    // No se re-hashea ni se cambia la password del usuario existente.
+    expect(saved.password).toBe('hash-previo');
+    expect(mockRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('no hace nada si el usuario ya es admin', async () => {
+    mockRepo.findOne.mockResolvedValue({
+      id: 9,
+      email: input.email,
+      roles: [UserRole.CONSUMER, UserRole.ADMIN],
+      isAdmin: true,
+    } as User);
+
+    const result = await seedAdminUser(
+      mockRepo as unknown as Repository<User>,
+      input,
+    );
+
+    expect(result.action).toBe('already-admin');
+    expect(result.userId).toBe(9);
+    expect(mockRepo.save).not.toHaveBeenCalled();
+    expect(mockRepo.create).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tarot-app/src/database/seeds/admin-user.seeder.ts
+++ b/backend/tarot-app/src/database/seeds/admin-user.seeder.ts
@@ -1,0 +1,92 @@
+import { Repository } from 'typeorm';
+import * as bcrypt from 'bcryptjs';
+import {
+  User,
+  UserRole,
+  UserPlan,
+  SubscriptionStatus,
+} from '../../modules/users/entities/user.entity';
+
+/**
+ * Datos de entrada para crear/promover un usuario admin.
+ */
+export interface AdminSeedInput {
+  email: string;
+  password: string;
+  name: string;
+}
+
+/**
+ * Resultado del seed de admin.
+ * - `created`: se creó un usuario nuevo con rol admin.
+ * - `promoted`: ya existía el email y se le agregó el rol admin.
+ * - `already-admin`: el usuario ya existía y ya era admin (no se hizo nada).
+ */
+export type AdminSeedAction = 'created' | 'promoted' | 'already-admin';
+
+export interface AdminSeedResult {
+  userId: number;
+  action: AdminSeedAction;
+}
+
+const BCRYPT_ROUNDS = 10;
+
+/**
+ * Crea (o promueve) un usuario administrador de forma idempotente.
+ *
+ * A diferencia de los seeds de Flavia / test users, las credenciales NO están
+ * hardcodeadas: se reciben por parámetro (típicamente desde variables de entorno),
+ * para poder crear el primer admin en producción sin exponer secretos en el repo.
+ *
+ * Comportamiento:
+ * - Si NO existe el email → crea el usuario con roles [CONSUMER, ADMIN].
+ * - Si existe y NO es admin → le agrega el rol ADMIN (no toca su password).
+ * - Si existe y ya es admin → no hace nada.
+ *
+ * @param userRepository - Repositorio TypeORM de User
+ * @param input - Email, password y nombre del admin
+ * @returns Id del usuario y la acción realizada
+ */
+export async function seedAdminUser(
+  userRepository: Repository<User>,
+  input: AdminSeedInput,
+): Promise<AdminSeedResult> {
+  const email = input.email.trim().toLowerCase();
+
+  const existingUser = await userRepository.findOne({ where: { email } });
+
+  if (existingUser) {
+    if (existingUser.roles?.includes(UserRole.ADMIN)) {
+      console.log(
+        `✅ El usuario ${email} ya es admin (ID: ${existingUser.id})`,
+      );
+      return { userId: existingUser.id, action: 'already-admin' };
+    }
+
+    // Promover: agregar rol admin sin sobreescribir la password existente.
+    existingUser.roles = [
+      ...new Set([...(existingUser.roles ?? []), UserRole.ADMIN]),
+    ];
+    existingUser.isAdmin = true;
+    const promoted = await userRepository.save(existingUser);
+    console.log(`⬆️  Usuario ${email} promovido a admin (ID: ${promoted.id})`);
+    return { userId: promoted.id, action: 'promoted' };
+  }
+
+  const hashedPassword = await bcrypt.hash(input.password, BCRYPT_ROUNDS);
+
+  const user = userRepository.create({
+    email,
+    name: input.name,
+    password: hashedPassword,
+    roles: [UserRole.CONSUMER, UserRole.ADMIN],
+    isAdmin: true,
+    plan: UserPlan.PREMIUM,
+    planStartedAt: new Date(),
+    subscriptionStatus: SubscriptionStatus.ACTIVE,
+  });
+
+  const savedUser = await userRepository.save(user);
+  console.log(`🌱 Admin creado: ${email} (ID: ${savedUser.id})`);
+  return { userId: savedUser.id, action: 'created' };
+}


### PR DESCRIPTION
## Motivo

El backend **no provisiona ningún admin automáticamente** al desplegar (no hay migración, ni bootstrap, ni env var que lo cree). Los únicos seeds con admin (`db:seed:all` → Flavia, `db:seed:users` → `admin@test.com`) tienen credenciales **hardcodeadas** en el repo. Falta una forma limpia y segura de crear el **primer admin en producción** sin exponer secretos.

## Solución

Nuevo comando **`npm run db:seed:admin`** que crea (o promueve) un admin tomando las credenciales desde variables de entorno.

- **`seedAdminUser()`** (idempotente):
  - Email no existe → crea con roles `[CONSUMER, ADMIN]`, `isAdmin: true`, plan PREMIUM activo, password **hasheada** (bcrypt).
  - Email existe y no es admin → lo **promueve** (agrega rol ADMIN) **sin tocar su password**.
  - Ya es admin → no hace nada. Normaliza el email a minúsculas.
- **`scripts/db-seed-admin.ts`**: usa un **DataSource AISLADO** (`migrationsRun: false`, `synchronize: false`), NO bootea el AppModule. Así, correrlo contra producción solo inserta/actualiza el admin y **nunca dispara migraciones ni DDL**.
  - Conexión por `DATABASE_URL`/`DB_URL` (ej. proxy público de Railway) o por `POSTGRES_*` individuales. `DB_SSL=true` opcional.

## Uso

Local:
```bash
ADMIN_EMAIL=admin@dominio.com ADMIN_PASSWORD='...' npm run db:seed:admin
```
Producción (proxy público de Railway):
```bash
DATABASE_URL='postgresql://user:pass@junction.proxy.rlwy.net:PORT/railway' \
ADMIN_EMAIL=admin@dominio.com ADMIN_PASSWORD='...' ADMIN_NAME='...' \
npm run db:seed:admin
```
La password se pasa por env (no queda en el repo) y se cambia desde la app apenas se ingresa.

## Validaciones

- [x] `npm run format` · `npm run lint`
- [x] Tests del seeder: 4/4 ✅ (crear, promover, ya-admin, normalización)
- [x] `npm run build` ✅ · `validate-architecture` ✅

> Nota: el enfoque de DataSource aislado ya se validó en la práctica — se usó exactamente esta forma de conexión para crear/habilitar el admin en producción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)