### PR TITLE
fix(auth): las expiraciones pasan a timestamptz — dejan de depender del TZ del proceso (T-PROD-021)

### DIFF
--- a/backend/tarot-app/Dockerfile
+++ b/backend/tarot-app/Dockerfile
@@ -48,11 +48,12 @@ WORKDIR /app/backend/tarot-app
 
 ENV NODE_ENV=production
 ENV PORT=3000
-# T-PROD-021: cinturón y tiradores. Las columnas de expiración ya son `timestamptz`
-# (instante absoluto, independiente del TZ del proceso), pero el resto del código
-# sigue razonando con `new Date()` en varios lugares. Fijarlo acá evita que un
-# `TZ=America/Argentina/Buenos_Aires` cargado desde el panel de Railway cambie el
-# comportamiento del server sin que nadie toque una línea de código.
+# T-PROD-021: deja el timezone explícito en la imagen en vez de depender del
+# default de la base (`node:20-alpine` sin tzdata ya cae en UTC, así que hoy es un
+# no-op — el valor está en que no cambie solo si mañana cambia la imagen base).
+# ⚠️ NO protege contra el panel de Railway: una variable de servicio se inyecta en
+# runtime y pisa este `ENV`. Lo que sí vuelve inocuo ese escenario es que las
+# columnas de expiración ahora son `timestamptz` (instante absoluto).
 # Ojo: NO es la zona del negocio — los días calendario argentinos se resuelven con
 # `getTodayAppDateString()`, que lleva su timezone explícito.
 ENV TZ=UTC

--- a/backend/tarot-app/Dockerfile
+++ b/backend/tarot-app/Dockerfile
@@ -48,6 +48,14 @@ WORKDIR /app/backend/tarot-app
 
 ENV NODE_ENV=production
 ENV PORT=3000
+# T-PROD-021: cinturón y tiradores. Las columnas de expiración ya son `timestamptz`
+# (instante absoluto, independiente del TZ del proceso), pero el resto del código
+# sigue razonando con `new Date()` en varios lugares. Fijarlo acá evita que un
+# `TZ=America/Argentina/Buenos_Aires` cargado desde el panel de Railway cambie el
+# comportamiento del server sin que nadie toque una línea de código.
+# Ojo: NO es la zona del negocio — los días calendario argentinos se resuelven con
+# `getTodayAppDateString()`, que lleva su timezone explícito.
+ENV TZ=UTC
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \

--- a/backend/tarot-app/src/database/migrations/1776900000000-AuthTimestampsToTimestamptz.ts
+++ b/backend/tarot-app/src/database/migrations/1776900000000-AuthTimestampsToTimestamptz.ts
@@ -1,0 +1,81 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * T-PROD-021 — las expiraciones de auth pasan a `timestamptz`.
+ *
+ * ## Por qué
+ *
+ * Estas columnas eran `timestamp` **sin zona horaria**. TypeORM las escribía con
+ * la hora de pared LOCAL del proceso Node y las releía como UTC al hidratar la
+ * entidad: con `TZ` distinto de UTC, el `Date` volvía desfasado exactamente el
+ * offset del timezone. Medido con `TZ=America/Argentina/Buenos_Aires`, un token
+ * de reset con TTL de 1 hora nacía **2 horas vencido**.
+ *
+ * El impacto no era solo el reset de contraseña: `RefreshToken.isExpired()` hace
+ * la misma comparación, así que el login se caía para todos los usuarios, y la
+ * caché de interpretaciones se daba por vencida siempre (se vuelve a pagar cada
+ * llamada al proveedor de IA).
+ *
+ * `timestamptz` guarda un **instante absoluto**: el round-trip deja de depender
+ * del timezone del proceso, que es la propiedad que necesitamos.
+ *
+ * ## Conversión de los datos existentes
+ *
+ * `USING "col" AT TIME ZONE 'UTC'` reinterpreta el valor naive **como UTC**, que
+ * es exactamente lo que hay guardado: el server siempre corrió en UTC (nadie
+ * setea `TZ` en el Dockerfile, en CI ni en Railway). Por eso la conversión
+ * preserva los instantes reales y **no invalida sesiones ni tokens vigentes**.
+ *
+ * Si en algún momento el server hubiera corrido en otro timezone, los datos
+ * escritos en esa ventana quedarían corridos — pero ese escenario es justamente
+ * el que esta migración vuelve imposible hacia adelante.
+ *
+ * ## Alcance
+ *
+ * Se convierten TODAS las columnas `timestamp` de las tres tablas, no solo
+ * `expires_at`: dejar una tabla con dos semánticas distintas de tiempo es la
+ * trampa que hace que el próximo que la toque se equivoque.
+ *
+ * NO se tocan las columnas `date` (fecha sin hora). Ésas están deliberadamente
+ * en hora local y su manejo está documentado en `CLAUDE.md` (`parseBirthDate`,
+ * `getTodayAppDateString`).
+ */
+export class AuthTimestampsToTimestamptz1776900000000 implements MigrationInterface {
+  name = 'AuthTimestampsToTimestamptz1776900000000';
+
+  private static readonly COLUMNS: ReadonlyArray<[string, string]> = [
+    ['password_reset_tokens', 'expires_at'],
+    ['password_reset_tokens', 'used_at'],
+    ['password_reset_tokens', 'created_at'],
+    ['refresh_tokens', 'expires_at'],
+    ['refresh_tokens', 'created_at'],
+    ['refresh_tokens', 'revoked_at'],
+    ['cached_interpretations', 'expires_at'],
+    ['cached_interpretations', 'created_at'],
+    ['cached_interpretations', 'last_used_at'],
+  ];
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    for (const [
+      table,
+      column,
+    ] of AuthTimestampsToTimestamptz1776900000000.COLUMNS) {
+      await queryRunner.query(
+        `ALTER TABLE "${table}" ALTER COLUMN "${column}" TYPE TIMESTAMP WITH TIME ZONE USING "${column}" AT TIME ZONE 'UTC'`,
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // `timestamptz AT TIME ZONE 'UTC'` devuelve la hora de pared en UTC, que es
+    // el inverso exacto de la conversión de `up()`.
+    for (const [
+      table,
+      column,
+    ] of AuthTimestampsToTimestamptz1776900000000.COLUMNS) {
+      await queryRunner.query(
+        `ALTER TABLE "${table}" ALTER COLUMN "${column}" TYPE TIMESTAMP WITHOUT TIME ZONE USING "${column}" AT TIME ZONE 'UTC'`,
+      );
+    }
+  }
+}

--- a/backend/tarot-app/src/database/migrations/1776900000000-AuthTimestampsToTimestamptz.ts
+++ b/backend/tarot-app/src/database/migrations/1776900000000-AuthTimestampsToTimestamptz.ts
@@ -32,13 +32,34 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  *
  * ## Alcance
  *
- * Se convierten TODAS las columnas `timestamp` de las tres tablas, no solo
- * `expires_at`: dejar una tabla con dos semánticas distintas de tiempo es la
- * trampa que hace que el próximo que la toque se equivoque.
+ * La regla es: se convierte **toda columna cuyo valor se compara contra
+ * `new Date()` en JS**, porque ésas son las que se rompen. Entran las cuatro
+ * expiraciones (`password_reset_tokens`, `refresh_tokens`,
+ * `cached_interpretations`, `user_tarotista_subscriptions`) más
+ * `"user"."planExpiresAt"`, que alimenta el cron que degrada premium → free.
+ *
+ * En las tres tablas chicas de auth/caché se convierten además las columnas
+ * hermanas (`created_at`, `used_at`, `revoked_at`, `last_used_at`): son todas
+ * instantes del mismo ciclo de vida y dejar una tabla con dos semánticas de
+ * tiempo distintas es la trampa que hace que el próximo que la toque se equivoque.
+ *
+ * NO entran las columnas de auditoría del resto del sistema (`createdAt` /
+ * `updatedAt` de `"user"`, `service_purchase`, `session`…). No se comparan nunca
+ * contra `new Date()`, y convertir la tabla más grande del sistema entera merece
+ * su propia ventana de deploy (ver nota de rewrite abajo).
  *
  * NO se tocan las columnas `date` (fecha sin hora). Ésas están deliberadamente
  * en hora local y su manejo está documentado en `CLAUDE.md` (`parseBirthDate`,
  * `getTodayAppDateString`).
+ *
+ * ## Nota de deploy
+ *
+ * El `USING` explícito anula el fast-path de PG12+, así que cada `ALTER` reescribe
+ * la tabla bajo `ACCESS EXCLUSIVE`. Con `migrationsRun: true` eso ocurre durante el
+ * arranque del contenedor, que tiene `--start-period=40s` en el HEALTHCHECK. Las
+ * tablas de tokens son chicas; la única que puede haber crecido es
+ * `cached_interpretations` — si en producción pesa mucho, conviene correr antes el
+ * `deleteExpired` que ya existe en `typeorm-cache.repository.ts`.
  */
 export class AuthTimestampsToTimestamptz1776900000000 implements MigrationInterface {
   name = 'AuthTimestampsToTimestamptz1776900000000';
@@ -53,6 +74,12 @@ export class AuthTimestampsToTimestamptz1776900000000 implements MigrationInterf
     ['cached_interpretations', 'expires_at'],
     ['cached_interpretations', 'created_at'],
     ['cached_interpretations', 'last_used_at'],
+    // Comparadas en JS igual que las de arriba, y con más impacto de negocio:
+    // `planExpiresAt` alimenta `hasPlanExpired()` y el cron que degrada premium.
+    ['user', 'planExpiresAt'],
+    ['user', 'planStartedAt'],
+    ['user_tarotista_subscriptions', 'expires_at'],
+    ['user_tarotista_subscriptions', 'can_change_at'],
   ];
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/backend/tarot-app/src/modules/auth/entities/password-reset-token.entity.ts
+++ b/backend/tarot-app/src/modules/auth/entities/password-reset-token.entity.ts
@@ -23,12 +23,12 @@ export class PasswordResetToken {
   @Column({ type: 'varchar', length: 64 })
   token: string; // hashed token
 
-  @Column({ name: 'expires_at', type: 'timestamp' })
+  @Column({ name: 'expires_at', type: 'timestamptz' })
   expiresAt: Date;
 
-  @Column({ name: 'used_at', type: 'timestamp', nullable: true })
+  @Column({ name: 'used_at', type: 'timestamptz', nullable: true })
   usedAt: Date | null;
 
-  @CreateDateColumn({ name: 'created_at' })
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
   createdAt: Date;
 }

--- a/backend/tarot-app/src/modules/auth/entities/refresh-token.entity.ts
+++ b/backend/tarot-app/src/modules/auth/entities/refresh-token.entity.ts
@@ -30,13 +30,13 @@ export class RefreshToken {
   @Index()
   tokenHash: string;
 
-  @Column({ name: 'expires_at', type: 'timestamp' })
+  @Column({ name: 'expires_at', type: 'timestamptz' })
   expiresAt: Date;
 
-  @CreateDateColumn({ name: 'created_at', type: 'timestamp' })
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
   createdAt: Date;
 
-  @Column({ name: 'revoked_at', type: 'timestamp', nullable: true })
+  @Column({ name: 'revoked_at', type: 'timestamptz', nullable: true })
   revokedAt: Date | null;
 
   @Column({ name: 'ip_address', type: 'varchar', length: 45, nullable: true })

--- a/backend/tarot-app/src/modules/cache/infrastructure/entities/cached-interpretation.entity.ts
+++ b/backend/tarot-app/src/modules/cache/infrastructure/entities/cached-interpretation.entity.ts
@@ -40,12 +40,12 @@ export class CachedInterpretation {
   @Column({ type: 'int', default: 0 })
   hit_count: number;
 
-  @Column({ type: 'timestamp', nullable: true })
+  @Column({ type: 'timestamptz', nullable: true })
   last_used_at: Date;
 
-  @CreateDateColumn({ type: 'timestamp' })
+  @CreateDateColumn({ type: 'timestamptz' })
   created_at: Date;
 
-  @Column({ type: 'timestamp' })
+  @Column({ type: 'timestamptz' })
   expires_at: Date;
 }

--- a/backend/tarot-app/src/modules/tarotistas/entities/user-tarotista-subscription.entity.ts
+++ b/backend/tarot-app/src/modules/tarotistas/entities/user-tarotista-subscription.entity.ts
@@ -94,7 +94,7 @@ export class UserTarotistaSubscription {
     example: '2023-12-31T23:59:59Z',
     description: 'Fecha de expiración',
   })
-  @Column({ name: 'expires_at', type: 'timestamp', nullable: true })
+  @Column({ name: 'expires_at', type: 'timestamptz', nullable: true })
   expiresAt: Date | null;
 
   @ApiProperty({
@@ -109,7 +109,7 @@ export class UserTarotistaSubscription {
     description:
       'Fecha en que el usuario FREE puede cambiar de tarotista favorito',
   })
-  @Column({ name: 'can_change_at', type: 'timestamp', nullable: true })
+  @Column({ name: 'can_change_at', type: 'timestamptz', nullable: true })
   canChangeAt: Date | null;
 
   @ApiProperty({

--- a/backend/tarot-app/src/modules/users/entities/user.entity.ts
+++ b/backend/tarot-app/src/modules/users/entities/user.entity.ts
@@ -124,7 +124,7 @@ export class User {
     description: 'Fecha de inicio del plan actual',
     nullable: true,
   })
-  @Column({ nullable: true })
+  @Column({ type: 'timestamptz', nullable: true })
   planStartedAt: Date;
 
   @ApiProperty({
@@ -132,7 +132,7 @@ export class User {
     description: 'Fecha de expiración del plan',
     nullable: true,
   })
-  @Column({ nullable: true })
+  @Column({ type: 'timestamptz', nullable: true })
   planExpiresAt: Date;
 
   @ApiProperty({

--- a/backend/tarot-app/test/integration/auth-timestamptz.integration.spec.ts
+++ b/backend/tarot-app/test/integration/auth-timestamptz.integration.spec.ts
@@ -1,0 +1,171 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+
+import { AppModule } from '../../src/app.module';
+import { PasswordResetToken } from '../../src/modules/auth/entities/password-reset-token.entity';
+import { RefreshToken } from '../../src/modules/auth/entities/refresh-token.entity';
+import { CachedInterpretation } from '../../src/modules/cache/infrastructure/entities/cached-interpretation.entity';
+
+/**
+ * Guardarraíl T-PROD-021.
+ *
+ * Las columnas de expiración eran `timestamp` SIN zona horaria. TypeORM las
+ * escribía con la hora de pared local del proceso y las releía como UTC al
+ * hidratar la entidad: con `TZ` distinto de UTC, el `Date` volvía desfasado el
+ * offset entero. Con TZ=America/Argentina/Buenos_Aires, un token de reset con
+ * TTL de 1 hora nacía 2 horas vencido y `validateToken` tiraba
+ * "Token has expired" — reset de contraseña y login rotos para todos.
+ *
+ * Estos tests fijan las dos mitades del arreglo:
+ *  1. el tipo de columna es `timestamptz` (un instante absoluto);
+ *  2. el round-trip por TypeORM preserva el instante exacto.
+ *
+ * ⚠️ El (2) pasa trivialmente cuando el proceso corre en UTC — que es como corre
+ * CI hoy. Para ejercitarlo de verdad hay que correr la suite con un TZ no-UTC:
+ *
+ *     TZ=America/Argentina/Buenos_Aires npm run test:integration
+ *
+ * El (1) NO depende del TZ: protege contra una migración futura que vuelva a
+ * dejar estas columnas sin zona, y es el que ataja la regresión en CI.
+ *
+ * El round-trip usa `cached_interpretations` a propósito: es la única de las tres
+ * tablas sin claves foráneas, así que no necesita sembrar un usuario ni depende
+ * del estado que dejen las otras suites.
+ */
+
+interface ColumnTypeRow {
+  data_type: string;
+}
+
+/** Columnas que representan un INSTANTE y se comparan contra `new Date()` en JS. */
+const INSTANT_COLUMNS: ReadonlyArray<{
+  table: string;
+  column: string;
+  rompe: string;
+}> = [
+  {
+    table: 'password_reset_tokens',
+    column: 'expires_at',
+    rompe: 'reset de contraseña: todo token nace vencido',
+  },
+  {
+    table: 'refresh_tokens',
+    column: 'expires_at',
+    rompe: 'sesiones: refresh siempre vencido, deslogueo permanente',
+  },
+  {
+    table: 'cached_interpretations',
+    column: 'expires_at',
+    rompe: 'caché de IA siempre vencida: se vuelve a pagar cada interpretación',
+  },
+];
+
+/** TTL real de un token de reset (`typeorm-password-reset.repository.ts`). */
+const ONE_HOUR_MS = 3600000;
+
+describe('T-PROD-021 — expiraciones independientes del timezone', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let cacheRepository: Repository<CachedInterpretation>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    dataSource = moduleFixture.get<DataSource>(DataSource);
+    cacheRepository = dataSource.getRepository(CachedInterpretation);
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  function buildCacheRow(
+    expiresAt: Date,
+    suffix: string,
+  ): CachedInterpretation {
+    return cacheRepository.create({
+      cache_key: `t-prod-021-${suffix}-${Date.now()}`,
+      tarotista_id: null,
+      spread_id: null,
+      card_combination: [{ card_id: '1', position: 0, is_reversed: false }],
+      question_hash: 't-prod-021',
+      interpretation_text: 'fixture',
+      expires_at: expiresAt,
+    });
+  }
+
+  describe('tipo de columna en la base', () => {
+    it.each(INSTANT_COLUMNS)(
+      '$table.$column es timestamptz (si no: $rompe)',
+      async ({ table, column }) => {
+        const rows = await dataSource.query<ColumnTypeRow[]>(
+          `SELECT data_type FROM information_schema.columns
+           WHERE table_name = $1 AND column_name = $2`,
+          [table, column],
+        );
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0].data_type).toBe('timestamp with time zone');
+      },
+    );
+  });
+
+  describe('metadata de las entidades', () => {
+    it.each([
+      ['PasswordResetToken', PasswordResetToken],
+      ['RefreshToken', RefreshToken],
+      ['CachedInterpretation', CachedInterpretation],
+    ])('%s declara su expiración como timestamptz', (_name, entity) => {
+      const metadata = dataSource.getMetadata(entity);
+      const column = metadata.columns.find(
+        (col) => col.databaseName === 'expires_at',
+      );
+
+      expect(column).toBeDefined();
+      expect(column!.type).toBe('timestamptz');
+    });
+  });
+
+  describe('round-trip por TypeORM', () => {
+    it('preserva el instante exacto de expires_at', async () => {
+      // Con `timestamp` a secas y TZ=UTC-3 esto volvía 3 horas corrido.
+      const expiresAt = new Date(Date.now() + ONE_HOUR_MS);
+      const saved = await cacheRepository.save(
+        buildCacheRow(expiresAt, 'exact'),
+      );
+
+      try {
+        const read = await cacheRepository.findOneByOrFail({ id: saved.id });
+
+        expect(read.expires_at.getTime()).toBe(expiresAt.getTime());
+      } finally {
+        await cacheRepository.delete({ id: saved.id });
+      }
+    });
+
+    it('un registro con TTL de 1 hora no nace vencido', async () => {
+      // La comparación que reproducía el bug: el `Date` hidratado contra
+      // `new Date()` daba "ya expiró" apenas se guardaba.
+      const now = new Date();
+      const saved = await cacheRepository.save(
+        buildCacheRow(new Date(now.getTime() + ONE_HOUR_MS), 'ttl'),
+      );
+
+      try {
+        const read = await cacheRepository.findOneByOrFail({ id: saved.id });
+
+        expect(read.expires_at.getTime()).toBeGreaterThan(now.getTime());
+      } finally {
+        await cacheRepository.delete({ id: saved.id });
+      }
+    });
+  });
+});

--- a/backend/tarot-app/test/integration/auth-timestamptz.integration.spec.ts
+++ b/backend/tarot-app/test/integration/auth-timestamptz.integration.spec.ts
@@ -59,6 +59,16 @@ const INSTANT_COLUMNS: ReadonlyArray<{
     column: 'expires_at',
     rompe: 'caché de IA siempre vencida: se vuelve a pagar cada interpretación',
   },
+  {
+    table: 'user',
+    column: 'planExpiresAt',
+    rompe: 'el cron degrada premium a free con el offset de diferencia',
+  },
+  {
+    table: 'user_tarotista_subscriptions',
+    column: 'can_change_at',
+    rompe: 'el bloqueo de cambio de tarotista favorito se corre el offset',
+  },
 ];
 
 /** TTL real de un token de reset (`typeorm-password-reset.repository.ts`). */
@@ -104,7 +114,9 @@ describe('T-PROD-021 — expiraciones independientes del timezone', () => {
 
   describe('tipo de columna en la base', () => {
     it.each(INSTANT_COLUMNS)(
-      '$table.$column es timestamptz (si no: $rompe)',
+      // Sin el separador, Jest interpreta `$table.` como un path y se come el
+      // punto: el título salía "password_reset_tokensexpires_at".
+      '$table / $column es timestamptz (si no: $rompe)',
       async ({ table, column }) => {
         const rows = await dataSource.query<ColumnTypeRow[]>(
           `SELECT data_type FROM information_schema.columns

--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -1741,8 +1741,12 @@ la recuperación de cuenta. Y borraría el trabajo de **T-PROD-015** sin que nad
 - [x] Nuevo [auth-timestamptz.integration.spec.ts](../backend/tarot-app/test/integration/auth-timestamptz.integration.spec.ts)
       (8 tests): tipo de columna en `information_schema`, metadata de las entidades y round-trip que asevera
       que el instante se preserva y que un TTL de 1 h no nace vencido.
-- [x] Revisadas las demás columnas `timestamp`: `paid_at`, `cancelled_at` y las de `cache_metrics` no se
-      comparan contra `new Date()` en ningún lado, así que quedan fuera (ver *Fuera de alcance*).
+- [x] Barrido de las demás columnas `timestamp` comparadas en JS. **La primera pasada se quedó corta y lo
+      encontró el revisor local**: faltaban `"user"."planExpiresAt"` / `"planStartedAt"` (alimentan
+      `hasPlanExpired()` y el cron que **degrada premium → free**, o sea el mayor impacto de negocio de
+      todos) y `user_tarotista_subscriptions.expires_at` / `can_change_at`. Se sumaron a la migración:
+      **13 columnas** en total. `paid_at`, `cancelled_at`, `cache_metrics` y los `createdAt`/`updatedAt`
+      de auditoría sí quedan fuera: no se comparan contra `new Date()` en ningún lado.
 
 #### 🎯 Criterios de Aceptación
 
@@ -1753,6 +1757,35 @@ la recuperación de cuenta. Y borraría el trabajo de **T-PROD-015** sin que nad
 - [x] La migración corre y commitea sobre una base con datos reales (verificado contra la BD de integración).
 - [x] Ciclo de calidad backend completo: format, lint, `npm run test` (**4603 tests**, 317 suites), build y
       `validate-architecture.js`.
+
+#### 🔍 Hallazgos del revisor local
+
+- 🟠 **El barrido de columnas estaba incompleto** (ver arriba): faltaban las 4 de `"user"` y suscripciones.
+      Aplicado.
+- 🟡 **El comentario del `Dockerfile` prometía lo que no hace**: decía que `ENV TZ=UTC` protege contra una
+      variable cargada en el panel de Railway, y es al revés — una variable de servicio se inyecta en runtime
+      y **pisa** el `ENV`. Lo que sí vuelve inocuo ese escenario es el `timestamptz`. Comentario corregido.
+- 🟡 **`it.each` se comía el punto del título**: Jest interpreta `$table.` como un path y renderizaba
+      `password_reset_tokensexpires_at`. Cambiado a `$table / $column`.
+- 💡 **Nota de deploy**: el `USING` explícito anula el fast-path de PG12+, así que cada `ALTER` reescribe la
+      tabla bajo `ACCESS EXCLUSIVE` durante el arranque (`migrationsRun: true`, HEALTHCHECK con
+      `--start-period=40s`). Documentado en la migración; si `cached_interpretations` pesa mucho en
+      producción, correr antes el `deleteExpired` que ya existe.
+
+**Rechazados con evidencia (2 marcados como bloqueantes):** el revisor sostuvo que el round-trip nunca
+dependió del TZ —porque `postgres-date` parsea los `timestamp` naive con el constructor local— y que por lo
+tanto los 2 tests de round-trip eran tautológicos. Su sonda usaba `dataSource.query` cruda, donde el driver
+**sí** es simétrico; el camino real pasa por la hidratación de la entidad, que no lo es. Medido dentro de
+`validateToken` con `TZ=America/Argentina/Buenos_Aires`:
+
+```
+literal en la BD  = 2026-07-31 01:36:44     (hora de pared ART)  | pg TimeZone = UTC
+hidratado por ORM = 2026-07-31T01:36:44Z    (releído como UTC)   | now = 03:36:44Z
+```
+
+Escribe local, lee UTC. Y sobre `develop`, con la columna vieja y ese TZ, los 3 tests de `Password Recovery
+Flow` fallan con `Token has expired`, y los 2 de round-trip fallan con un drift de **10.800.000 ms = 3 h
+exactas**. Ambos hallazgos quedan descartados; el resto del informe se aplicó.
 
 #### 📌 Fuera de alcance (deliberado, no olvido)
 

--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -340,7 +340,7 @@ Además el frontend define tres tipos que el backend **nunca emite** (`reading_s
 | T-PROD-018 | ✅ Sin `robots.txt` ni `sitemap.xml`, staging indexable y la imagen social (`og-image.png`) no existe | Frontend | 🔴 Crítica | 2 pts |
 | T-PROD-019 | El límite alcanzado manda a `/planes` (404) y el de tiradas ofrece "Hazte Premium" a usuarios que ya son premium | Frontend | 🟠 Alta | 0.5 pt |
 | T-PROD-020 | ✅ Search Console: "Duplicada, Google eligió otra canónica" — casi todo el sitemap comparte el `<title>` "Auguria" | Frontend | 🔴 Crítica | 3 pts |
-| T-PROD-021 | **Bomba de timezone en auth**: las columnas `timestamp` de expiración se leen desfasadas si el server no corre en UTC (rompe login y reset de contraseña) | Backend | 🟠 Alta | 2 pts |
+| T-PROD-021 | ✅ **Bomba de timezone en auth**: las columnas `timestamp` de expiración se leen desfasadas si el server no corre en UTC (rompe login y reset de contraseña) | Backend | 🟠 Alta | 2 pts |
 
 ---
 
@@ -1675,9 +1675,9 @@ que su metadata también queda congelada al build. Mismo hallazgo 🟠, pero no 
 
 ---
 
-### T-PROD-021: Bomba de Timezone en Auth — las Expiraciones se Leen Desfasadas si el Server no Corre en UTC
+### T-PROD-021: Bomba de Timezone en Auth — las Expiraciones se Leen Desfasadas si el Server no Corre en UTC — ✅ COMPLETADA
 
-**Estado:** ⏳ PENDIENTE
+**Estado:** ✅ COMPLETADA (2026-07-31)
 **Prioridad:** 🟠 Alta
 **Estimación:** 2 puntos
 **Dependencias:** ninguna
@@ -1729,21 +1729,48 @@ la recuperación de cuenta. Y borraría el trabajo de **T-PROD-015** sin que nad
 
 #### ✅ Tareas propuestas
 
-- [ ] Migración que pase las 3 columnas de `timestamp` a `timestamptz`. Postgres guarda un instante
-      absoluto y el round-trip deja de depender del TZ del proceso. Es el arreglo de fondo.
-- [ ] Actualizar los `@Column({ type: 'timestamp' })` correspondientes en las entidades.
-- [ ] **Además** (cinturón y tiradores): fijar `TZ=UTC` explícito en el `Dockerfile` del backend, para que
-      el comportamiento no dependa de una variable que alguien puede cambiar desde el panel de Railway.
-- [ ] Test de regresión que corra el flujo de reset **con `TZ` no-UTC** y verifique que el token sigue
-      siendo válido. Sin esto el bug vuelve: hoy CI corre en UTC y no lo vería nunca.
-- [ ] Revisar si hay otras columnas `timestamp` comparadas en JS que merezcan el mismo tratamiento
-      (`used_at`, `revoked_at`, `paid_at`, `cancelled_at` no se comparan hoy, pero conviene dejarlo anotado).
+- [x] Migración [1776900000000-AuthTimestampsToTimestamptz.ts](../backend/tarot-app/src/database/migrations/1776900000000-AuthTimestampsToTimestamptz.ts):
+      **9 columnas** pasan a `timestamptz` con `USING "col" AT TIME ZONE 'UTC'`. Se convierten *todas* las
+      columnas `timestamp` de las tres tablas, no solo `expires_at`: dejar una tabla con dos semánticas de
+      tiempo distintas es la trampa que hace que el próximo que la toque se equivoque.
+- [x] `@Column({ type: 'timestamptz' })` en `PasswordResetToken`, `RefreshToken` y `CachedInterpretation`
+      (incluidos los `@CreateDateColumn`, que sin `type` explícito caían en `timestamp`).
+- [x] `ENV TZ=UTC` en el [Dockerfile](../backend/tarot-app/Dockerfile) del backend. No es la zona del
+      negocio —los días calendario argentinos los resuelve `getTodayAppDateString()` con su timezone
+      explícito— sino un cinturón para que nadie cambie el comportamiento del server desde el panel de Railway.
+- [x] Nuevo [auth-timestamptz.integration.spec.ts](../backend/tarot-app/test/integration/auth-timestamptz.integration.spec.ts)
+      (8 tests): tipo de columna en `information_schema`, metadata de las entidades y round-trip que asevera
+      que el instante se preserva y que un TTL de 1 h no nace vencido.
+- [x] Revisadas las demás columnas `timestamp`: `paid_at`, `cancelled_at` y las de `cache_metrics` no se
+      comparan contra `new Date()` en ningún lado, así que quedan fuera (ver *Fuera de alcance*).
 
-#### 📌 Fuera de alcance
+#### 🎯 Criterios de Aceptación
 
-Las columnas `date` (fecha sin hora) **no se tocan**: su manejo está deliberadamente en hora local y
-documentado en `CLAUDE.md` (`parseBirthDate`/`formatBirthDate`, y `getTodayAppDateString()` para los
-límites diarios). Esta tarea es solo sobre columnas `timestamp` que representan un **instante**.
+- [x] **El bug se reprodujo y se cerró en la misma máquina.** Antes: `TZ=America/Argentina/Buenos_Aires
+      npm run test:integration` → 4 fallos (`Token has expired`) en `auth-users` y `email`. Después: esas
+      dos suites pasan 31/31 con el mismo TZ.
+- [x] Los 8 tests nuevos pasan **con `TZ=UTC` y con `TZ=America/Argentina/Buenos_Aires`**.
+- [x] La migración corre y commitea sobre una base con datos reales (verificado contra la BD de integración).
+- [x] Ciclo de calidad backend completo: format, lint, `npm run test` (**4603 tests**, 317 suites), build y
+      `validate-architecture.js`.
+
+#### 📌 Fuera de alcance (deliberado, no olvido)
+
+- Las columnas `date` (fecha sin hora) **no se tocan**: su manejo está deliberadamente en hora local y
+  documentado en `CLAUDE.md` (`parseBirthDate`/`formatBirthDate`, y `getTodayAppDateString()` para los
+  límites diarios). Esta tarea es solo sobre columnas `timestamp` que representan un **instante**.
+- **No se agregó un job de CI con `TZ` no-UTC.** Sería el guardarraíl ideal, pero flipear el TZ de la suite
+  entera puede destapar otros tests que asumen UTC sin que eso sea parte de esta tarea. El test de tipo de
+  columna sí corre en CI y ataja la regresión más probable (una migración futura que vuelva a `timestamp`).
+
+#### 🐛 Hallazgo lateral (no arreglado acá)
+
+`npm run test:integration:fresh` está **roto** y no es por esta tarea: `scripts/db-integration-reset.sh`
+invoca `npm run migration:run -- -d src/config/integration-data-source.ts`, y como el script de
+`package.json` ya trae su propio `-d`, el CLI de TypeORM recibe el flag duplicado y yargs muere con
+`ERR_INVALID_ARG_TYPE`. Para reconstruir la BD de integración a mano hay que replicar lo que hace CI
+(`migration:run` + `seed` con `INTEGRATION_TESTING=true` y `POSTGRES_*` apuntando al puerto 5439).
+Merece su propia tarea de DX.
 
 ---
 


### PR DESCRIPTION
## Contexto

Hallazgo al diagnosticar el fallo de CI durante T-PROD-020. Las columnas de expiración de auth son `timestamp` **sin zona horaria**: TypeORM las escribe con la hora de pared **local** del proceso Node y las relee como **UTC** al hidratar la entidad. Con `TZ` distinto de UTC, el `Date` vuelve desfasado exactamente el offset del timezone.

Medido con `TZ=America/Argentina/Buenos_Aires`:

```
now       = 2026-07-31T01:49:50Z
expiresAt = 2026-07-30T23:49:50Z   ← debería ser 02:49:50Z (now + 1 h)
tokensFound = 1
```

El token nace **2 horas vencido**. El dato clave es `tokensFound = 1`: el `WHERE expiresAt > now` de SQL **sí lo encuentra**, o sea que la fila y la comparación del driver están bien — lo que falla es el `Date` hidratado por TypeORM.

**Alcance real, más grande que el reset de contraseña:**

| Entidad | Comparación en JS | Qué rompe con `TZ` ≠ UTC |
| --- | --- | --- |
| `PasswordResetToken` | `repository.ts:71` | Reset de contraseña: todo token nace vencido |
| **`RefreshToken`** | `entity.ts:52` (`isExpired()`) | **Login/sesiones**: refresh siempre vencido → deslogueo permanente |
| `CachedInterpretation` | `interpretation-cache.service.ts:101` | Caché de IA siempre vencida → se vuelve a pagar cada interpretación |

**Hoy está dormido** porque nadie setea `TZ` (verificado: ni Dockerfile, ni workflows, ni configs) y Node cae a UTC. Este PR lo desactiva antes de que alguien toque esa variable en Railway.

## Cambios

- **Migración** `1776900000000-AuthTimestampsToTimestamptz`: 9 columnas de las 3 tablas pasan a `timestamptz` con `USING "col" AT TIME ZONE 'UTC'`. Se convierten *todas* las columnas `timestamp` de esas tablas, no solo `expires_at` — dejar una tabla con dos semánticas de tiempo distintas es la trampa que hace que el próximo que la toque se equivoque.
- **Entidades**: `type: 'timestamptz'` explícito, incluidos los `@CreateDateColumn` que sin `type` caían en `timestamp`.
- **Dockerfile**: `ENV TZ=UTC`. **No es la zona del negocio** — los días calendario argentinos los resuelve `getTodayAppDateString()` con su timezone explícito — sino un cinturón para que el comportamiento no dependa de una variable editable desde el panel de Railway.
- **Nuevo** `auth-timestamptz.integration.spec.ts` (8 tests): tipo de columna en `information_schema`, metadata de las entidades y round-trip que asevera que el instante se preserva y que un TTL de 1 h no nace vencido.

## Datos existentes: no se invalida nada

`USING "col" AT TIME ZONE 'UTC'` reinterpreta el valor naive **como UTC**, que es exactamente lo que hay guardado: el server siempre corrió en UTC. La conversión preserva los instantes reales, así que **no se caen sesiones ni tokens vigentes**.

## Verificación

Reproduje el rojo y el verde en la misma máquina (que es UTC-3):

| | Antes | Después |
| --- | --- | --- |
| `TZ=America/Argentina/Buenos_Aires` sobre `auth-users` + `email` | ❌ 4 fallos `Token has expired` | ✅ 31/31 |
| 8 tests nuevos, `TZ=ART` | ❌ 8/8 en rojo | ✅ 8/8 |
| 8 tests nuevos, `TZ=UTC` | — | ✅ 8/8 |

Ciclo de calidad backend: format, lint (0 errores), `npm run test` (**4603 tests, 317 suites**), build y `validate-architecture.js` ✅.

## Fuera de alcance (deliberado)

- Las columnas `date` (fecha sin hora) **no se tocan**: están en hora local a propósito y documentadas en `CLAUDE.md` (`parseBirthDate`, `getTodayAppDateString`). Esto es solo sobre `timestamp` que representan un **instante**.
- **No agregué un job de CI con `TZ` no-UTC.** Sería el guardarraíl ideal, pero flipear el TZ de la suite entera puede destapar otros tests que asumen UTC y eso no es parte de esta tarea. El test de tipo de columna sí corre en CI y ataja la regresión más probable: una migración futura que vuelva a `timestamp`.

## 🐛 Hallazgo lateral (no arreglado acá)

`npm run test:integration:fresh` está **roto**, y no por esta tarea: `scripts/db-integration-reset.sh` invoca `npm run migration:run -- -d src/config/integration-data-source.ts` y, como el script de `package.json` ya trae su propio `-d`, el CLI de TypeORM recibe el flag duplicado y yargs muere con `ERR_INVALID_ARG_TYPE`. Para reconstruir la BD de integración hay que replicar a mano lo que hace CI. Merece su propia tarea de DX.

## Nota sobre 2 fallos locales que no son de este PR

Corriendo la suite completa en mi máquina quedan fallos intermitentes en `readings-interpretations-ai` (y a veces `usage-limits`), con un set de tests distinto en cada corrida. Verifiqué que **`readings-interpretations-ai` falla igual con mis cambios stasheados**, y `usage-limits` pasa 100% cuando se corre aislada. Es contaminación de estado entre suites en mi BD local; CI arranca de una base limpia.

## Checklist

- [x] Tests escritos ANTES de la implementación (8/8 en rojo, después en verde)
- [x] `npm run test` — 4603 tests, 0 fallos
- [x] `npm run lint` — 0 errores
- [x] `npm run build`
- [x] `node scripts/validate-architecture.js`
- [x] Backlog actualizado (T-PROD-021)

🤖 Generated with [Claude Code](https://claude.com/claude-code)