### PR TITLE
fix(seo): el AuthProvider ya no vacía el sitio para los buscadores (T-PROD-022)

### DIFF
--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -1878,6 +1878,32 @@ Medido descontando las 39 palabras de header + footer:
 Las de la derecha son listados y fichas que traen sus datos **por el cliente** con React Query: el crawler
 sigue recibiendo el cascarón. No es el mismo bug (ya no hay un gate global), pero sí el mismo síntoma.
 
+#### 🔍 Hallazgos del revisor local (aplicados en un segundo commit)
+
+- 🟠 **Regresión que introdujo el primer commit: mismatch de hidratación en todo el sitio.** El revisor
+      lo midió: zustand `persist` rehidrata de forma **síncrona** con `localStorage`, así que el primer
+      render del cliente ya tenía `user`, mientras que el del servidor no lo tiene nunca. React 19 lo
+      reporta como *"Hydration failed… this tree will be regenerated on the client"* y **descarta el HTML
+      del servidor en cada página** (el `Header` vive en el layout raíz). No afectaba a Googlebot ni a
+      anónimos, pero tiraba a la basura el beneficio del SSR justamente para los usuarios logueados.
+      Arreglado con `skipHydration: true` en el store + `persist.rehydrate()` desde un efecto del
+      `AuthProvider`: el primer render del cliente coincide con el del servidor y la sesión entra después.
+      Verificado que no rompe `useRequireAuth`: solo redirige con `!isAuthenticated && !isLoading`, y
+      `isLoading` arranca en `true`, así que ningún usuario logueado se va a `/login` durante la ventana.
+- 🟡 **Comentario que describía un skeleton borrado en ese mismo commit.** La sección "dónde vive ahora la
+      protección contra el FOUC" del `AuthProvider` afirmaba que `HomePageContent` mostraba un skeleton.
+      Reescrita.
+- 🟡 **Mock muerto y aserciones tautológicas** en `HomePageContent.test.tsx`: el `vi.mock` de
+      `@/components/ui/skeleton` quedó inerte y `expect(queryAllByTestId('skeleton-loader')).toHaveLength(0)`
+      no podía fallar nunca. Eliminados.
+- 🟡 **Carrera al desmontar con el import dinámico.** Si el componente se desmonta mientras viaja el chunk
+      de astrochart, el cleanup ya corrió y después se construía un `Chart` contra un contenedor
+      inexistente que nadie limpiaba. Agregado un contador de generación que se incrementa en el cleanup y
+      se verifica al volver del `await`.
+- 💡 **El guardarraíl no cubría el nivel del bug.** Los tests corrían en jsdom con un mock, pero lo que
+      rompió el sitio fue el **string del servidor**. Sumado un test con `renderToString` que asevera que el
+      HTML contiene el contenido y no contiene "Verificando sesión".
+
 #### 📌 Fuera de alcance → **candidata a T-PROD-023**
 
 Hacer SSR del contenido de esos listados/fichas, como ya se hizo con `/enciclopedia/tarot/[slug]` en

--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -341,6 +341,7 @@ Además el frontend define tres tipos que el backend **nunca emite** (`reading_s
 | T-PROD-019 | El límite alcanzado manda a `/planes` (404) y el de tiradas ofrece "Hazte Premium" a usuarios que ya son premium | Frontend | 🟠 Alta | 0.5 pt |
 | T-PROD-020 | ✅ Search Console: "Duplicada, Google eligió otra canónica" — casi todo el sitemap comparte el `<title>` "Auguria" | Frontend | 🔴 Crítica | 3 pts |
 | T-PROD-021 | ✅ **Bomba de timezone en auth**: las columnas `timestamp` de expiración se leen desfasadas si el server no corre en UTC (rompe login y reset de contraseña) | Backend | 🟠 Alta | 2 pts |
+| T-PROD-022 | ✅ **El sitio entero servía 3 palabras a Googlebot**: el `AuthProvider` devolvía "Verificando sesión..." en lugar del contenido en todo render SSR (rechazo de AdSense) | Frontend | 🔴 Crítica | 2 pts |
 
 ---
 
@@ -1804,6 +1805,93 @@ invoca `npm run migration:run -- -d src/config/integration-data-source.ts`, y co
 `ERR_INVALID_ARG_TYPE`. Para reconstruir la BD de integración a mano hay que replicar lo que hace CI
 (`migration:run` + `seed` con `INTEGRATION_TESTING=true` y `POSTGRES_*` apuntando al puerto 5439).
 Merece su propia tarea de DX.
+
+---
+
+### T-PROD-022: El Sitio Entero le Servía 3 Palabras a Googlebot — ✅ COMPLETADA
+
+**Estado:** ✅ COMPLETADA (2026-08-08)
+**Prioridad:** 🔴 Crítica
+**Estimación:** 2 puntos
+**Dependencias:** ninguna (pero deja sin efecto parte del beneficio de T-PROD-020 hasta que se deploye)
+**Origen:** AdSense rechazó `auguriatarot.com` por *"Contenido de poco valor"*
+**Tipo:** Frontend (`docs/WORKFLOW_FRONTEND.md`)
+
+#### 📋 Problema
+
+AdSense rechazó el sitio por contenido de poco valor. Al medir producción con el user-agent de
+Googlebot, el motivo resultó literal: **todas las páginas devolvían 3 palabras**.
+
+| URL | `<title>` | Palabras visibles |
+| --- | --- | --- |
+| `/` | Auguria | 3 |
+| `/enciclopedia/tarot/the-fool` | Auguria | 3 |
+| `/horoscopo/aries` | Auguria | 3 |
+| `/numerologia` | Auguria | 3 |
+
+Las tres palabras eran siempre `Auguria Verificando sesión...`.
+
+**Causa:** `auth-provider.tsx` devolvía la pantalla de carga **en lugar de** `children` mientras
+`!hasHydrated || isLoading`. Como vive en el layout raíz y en el servidor `_hasHydrated` es **siempre
+`false`** (no existe `localStorage`), **todo render SSR del sitio entero era ese splash**.
+
+⚠️ **Esto era también la mitad que faltaba de T-PROD-020.** Aquella tarea dejó los `<title>` únicos, pero
+los cuerpos seguían siendo todos idénticos, así que Google habría seguido agrupando las URLs como
+duplicadas. Verificado sobre el build con T-PROD-020 aplicado: `"Enciclopedia Mística | Auguria
+Verificando sesión..."` = 6 palabras.
+
+**Segundo foco, misma clase:** `HomePageContent` devolvía un skeleton mientras `isLoading` — y `isLoading`
+arranca en `true` en el store, así que ese skeleton **era** el render del servidor de `/`. La home, la URL
+más importante del sitio, servía 4 palabras propias.
+
+#### ✅ Tareas específicas
+
+- [x] `AuthProvider` renderiza `children` **siempre**; mantiene el `checkAuth` tras la hidratación.
+      La protección contra FOUC baja a quien la necesita: `useRequireAuth` en rutas privadas y
+      `useAdsEnabled`, que **ya** exigía `_hasHydrated` por su cuenta — o sea que el gate nunca fue lo que
+      protegía a los Premium de ver un anuncio (T-PROD-008 sigue intacto).
+- [x] `HomePageContent`: la landing es el render por defecto; el dashboard aparece en cuanto hay sesión.
+- [x] **Bug destapado por el arreglo:** `/carta-astral/resultado` rompía el build con
+      `ReferenceError: self is not defined`. `@astrodraw/astrochart` toca `self` al evaluarse y se
+      importaba en el tope de `ChartWheel.hooks.ts`; el gate lo tapaba porque la página nunca llegaba a
+      renderizarse en el servidor. Pasa a `await import()` dentro del `requestAnimationFrame`, que ya
+      corre en el browser.
+- [x] Tests de regresión en `auth-provider.test.tsx` (6) y `HomePageContent.test.tsx`. Los de TASK-017 que
+      aseveraban *"no renderizar contenido mientras carga"* se invirtieron a propósito, con el porqué escrito.
+
+#### 🎯 Criterios de Aceptación
+
+- [x] Ninguna página emite la pantalla de "Verificando sesión" en el HTML del servidor.
+- [x] La home pasa de **4 a 611 palabras propias** en el build.
+- [x] El build prerenderiza las 85 páginas sin errores.
+- [x] Ciclo de calidad frontend completo: format, lint:fix, type-check, `test:run` (**5512 tests**,
+      435 suites), build y `validate-architecture.js`.
+
+#### 📊 Estado del contenido después del arreglo (build local, sin API)
+
+Medido descontando las 39 palabras de header + footer:
+
+| Con contenido propio | Todavía casi vacías |
+| --- | --- |
+| `/` 611 · `/carta-astral` 376 · `/numerologia` 305 · `/horoscopo-chino` 258 · `/rituales` 223 · `/horoscopo` 217 · `/pendulo` 215 | `/premium` 3 · `/servicios` 5 · `/enciclopedia/guias` 13 · `/explorar` 20 · `/enciclopedia/tarot` 24 · `/horoscopo/aries` 31 |
+
+Las de la derecha son listados y fichas que traen sus datos **por el cliente** con React Query: el crawler
+sigue recibiendo el cascarón. No es el mismo bug (ya no hay un gate global), pero sí el mismo síntoma.
+
+#### 📌 Fuera de alcance → **candidata a T-PROD-023**
+
+Hacer SSR del contenido de esos listados/fichas, como ya se hizo con `/enciclopedia/tarot/[slug]` en
+T-PROD-020 (resolver en el server y pasar por `initialData` a React Query). Es lo que falta para que
+AdSense evalúe un sitio con contenido real en todas sus URLs, y conviene medirlo contra producción con la
+API arriba antes de decidir el alcance — varias de esas páginas se llenan en producción y el build local
+las subestima.
+
+#### 📌 Nota de deploy
+
+Producción corre `main`. Nada de esto —ni T-PROD-020, ni T-PROD-021, ni esto— llega al sitio hasta
+promover `develop` → `main`. Después del deploy hay que **re-verificar con el mismo `curl` como Googlebot**
+antes de apretar "Solicitar revisión" en AdSense. Pendiente aparte: `ads.txt` figura como *No se encuentra*
+en el panel (contemplado en T-PROD-009).
 
 ---
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -44,8 +44,11 @@ export default function RootLayout({
       >
         <ReactQueryProvider>
           <AuthProvider>
-            {/* Dentro del AuthProvider: necesita el plan hidratado para no cargarle
-                el loader de AdSense a un usuario Premium (T-PROD-008) */}
+            {/* El gating de AdSense NO depende de este árbol: `useAdsEnabled` exige
+                `_hasHydrated` por su cuenta, así que un Premium no ve ni un flash de
+                anuncio (T-PROD-008). El `AuthProvider` ya no bloquea el render —
+                bloquearlo dejaba el sitio entero en blanco para los buscadores
+                (T-PROD-022). */}
             <AdSenseScript />
             <div className="flex min-h-screen flex-col">
               <Header />

--- a/frontend/src/components/features/birth-chart/ChartWheel/ChartWheel.hooks.ts
+++ b/frontend/src/components/features/birth-chart/ChartWheel/ChartWheel.hooks.ts
@@ -58,6 +58,14 @@ export function useChartWheel({
   const [selectedPlanet, setSelectedPlanet] = useState<string | null>(null);
   const chartRef = useRef<AstroChart | null>(null);
   const containerIdRef = useRef<string>(generateChartContainerId());
+  /**
+   * Se incrementa en cada cleanup. Como el `import()` dinámico de astrochart
+   * puede tardar lo que tarde la descarga del chunk, al volver del `await` hay
+   * que confirmar que este render sigue vigente: sin esto, desmontar el
+   * componente mientras el chunk viaja dejaba un `Chart` construido contra un
+   * contenedor que ya no existe, y nadie lo limpiaba nunca.
+   */
+  const renderGenerationRef = useRef(0);
 
   // Renderizar gráfico
   const renderChart = useCallback(() => {
@@ -88,7 +96,13 @@ export function useChartWheel({
           // porque nunca llegaba a renderizar la página en el servidor; al quitar
           // ese bloqueo (T-PROD-022) el error salió a la luz. Acá ya estamos en el
           // browser, dentro de un `requestAnimationFrame`.
+          const generation = renderGenerationRef.current;
           const { Chart } = await import('@astrodraw/astrochart');
+
+          // El componente se desmontó (o se relanzó el render) mientras cargaba.
+          if (generation !== renderGenerationRef.current) {
+            return;
+          }
 
           // Convertir datos
           const planets = convertPlanetsToAstroChart(data.planets as PlanetPosition[]);
@@ -147,6 +161,9 @@ export function useChartWheel({
 
     // Cleanup al desmontar
     return () => {
+      // Invalida cualquier `import()` en vuelo (ver `renderGenerationRef`).
+      renderGenerationRef.current += 1;
+
       if (chartRef.current) {
         const container = document.getElementById(currentContainerId);
         if (container) {

--- a/frontend/src/components/features/birth-chart/ChartWheel/ChartWheel.hooks.ts
+++ b/frontend/src/components/features/birth-chart/ChartWheel/ChartWheel.hooks.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Chart } from '@astrodraw/astrochart';
 import type {
   PlanetPosition,
   HouseCusp,
@@ -81,8 +80,16 @@ export function useChartWheel({
       }
 
       // Esperar siguiente frame para asegurar que el DOM esté listo
-      requestAnimationFrame(() => {
+      requestAnimationFrame(async () => {
         try {
+          // `@astrodraw/astrochart` toca `self` al evaluarse, así que importarla
+          // arriba del módulo rompía el prerender de `/carta-astral/resultado`
+          // ("ReferenceError: self is not defined"). El `AuthProvider` lo tapaba
+          // porque nunca llegaba a renderizar la página en el servidor; al quitar
+          // ese bloqueo (T-PROD-022) el error salió a la luz. Acá ya estamos en el
+          // browser, dentro de un `requestAnimationFrame`.
+          const { Chart } = await import('@astrodraw/astrochart');
+
           // Convertir datos
           const planets = convertPlanetsToAstroChart(data.planets as PlanetPosition[]);
           const cusps = convertHousesToAstroChart(data.houses as HouseCusp[]);

--- a/frontend/src/components/features/home/HomePageContent.test.tsx
+++ b/frontend/src/components/features/home/HomePageContent.test.tsx
@@ -42,7 +42,10 @@ describe('HomePageContent (Root Page)', () => {
   });
 
   describe('Loading State', () => {
-    it('should show loading skeleton while validating auth', () => {
+    it('⚠️ T-PROD-022: muestra la landing mientras se valida la sesión, no un skeleton', () => {
+      // `isLoading` arranca en `true` en el store, así que el skeleton que había
+      // acá ERA el render del servidor: la home le servía a Googlebot una pantalla
+      // de carga. La landing es el default, también en SSR.
       mockUseAuthStore.mockReturnValue({
         user: null,
         isAuthenticated: false,
@@ -51,10 +54,21 @@ describe('HomePageContent (Root Page)', () => {
 
       render(<HomePageContent />);
 
-      const skeletons = screen.getAllByTestId('skeleton-loader');
-      expect(skeletons.length).toBeGreaterThan(0);
-      expect(screen.queryByTestId('landing-page')).not.toBeInTheDocument();
+      expect(screen.getByTestId('landing-page')).toBeInTheDocument();
+      expect(screen.queryAllByTestId('skeleton-loader')).toHaveLength(0);
       expect(screen.queryByTestId('user-dashboard')).not.toBeInTheDocument();
+    });
+
+    it('⚠️ T-PROD-022: muestra el dashboard en cuanto hay sesión, aunque siga cargando', () => {
+      mockUseAuthStore.mockReturnValue({
+        user: { id: 1, name: 'Test User', plan: 'free' },
+        isAuthenticated: true,
+        isLoading: true,
+      });
+
+      render(<HomePageContent />);
+
+      expect(screen.getByTestId('user-dashboard')).toBeInTheDocument();
     });
   });
 
@@ -123,8 +137,8 @@ describe('HomePageContent (Root Page)', () => {
       });
 
       const { rerender } = render(<HomePageContent />);
-      const skeletons = screen.getAllByTestId('skeleton-loader');
-      expect(skeletons.length).toBeGreaterThan(0);
+      // Antes de resolver la sesión ya se ve la landing (T-PROD-022).
+      expect(screen.getByTestId('landing-page')).toBeInTheDocument();
 
       // Simulate auth check complete - no user
       mockUseAuthStore.mockReturnValue({
@@ -146,8 +160,8 @@ describe('HomePageContent (Root Page)', () => {
       });
 
       const { rerender } = render(<HomePageContent />);
-      const skeletons = screen.getAllByTestId('skeleton-loader');
-      expect(skeletons.length).toBeGreaterThan(0);
+      // Antes de resolver la sesión ya se ve la landing (T-PROD-022).
+      expect(screen.getByTestId('landing-page')).toBeInTheDocument();
 
       // Simulate auth check complete - user logged in
       mockUseAuthStore.mockReturnValue({
@@ -162,8 +176,14 @@ describe('HomePageContent (Root Page)', () => {
     });
   });
 
-  describe('FOUC Prevention', () => {
-    it('should not render content while loading to prevent FOUC', () => {
+  describe('Contenido indexable (T-PROD-022)', () => {
+    it('⚠️ nunca deja la home sin contenido: el render por defecto es la landing', () => {
+      // TASK-017 aseveraba lo contrario ("no renderizar contenido mientras carga,
+      // para evitar el FOUC"). Se invirtió a propósito: como `isLoading` arranca en
+      // `true`, ese comportamiento hacía que el HTML servido por el servidor —lo
+      // que ve Googlebot y lo que evaluó AdSense— fuera una pantalla de carga.
+      // El precio es un parpadeo de la landing antes del dashboard para un usuario
+      // logueado; el beneficio es tener una home indexable.
       mockUseAuthStore.mockReturnValue({
         user: null,
         isAuthenticated: false,
@@ -172,11 +192,8 @@ describe('HomePageContent (Root Page)', () => {
 
       render(<HomePageContent />);
 
-      // Should only show loading, no actual content
-      const skeletons = screen.getAllByTestId('skeleton-loader');
-      expect(skeletons.length).toBeGreaterThan(0);
-      expect(screen.queryByTestId('landing-page')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('user-dashboard')).not.toBeInTheDocument();
+      expect(screen.getByTestId('landing-page')).toBeInTheDocument();
+      expect(screen.queryAllByTestId('skeleton-loader')).toHaveLength(0);
     });
   });
 });

--- a/frontend/src/components/features/home/HomePageContent.test.tsx
+++ b/frontend/src/components/features/home/HomePageContent.test.tsx
@@ -11,15 +11,6 @@ vi.mock('@/components/features/dashboard', () => ({
   UserDashboard: () => <div data-testid="user-dashboard">UserDashboard Component</div>,
 }));
 
-// Mock Skeleton component
-vi.mock('@/components/ui/skeleton', () => ({
-  Skeleton: ({ className }: { className?: string }) => (
-    <div data-testid="skeleton-loader" className={className}>
-      Loading...
-    </div>
-  ),
-}));
-
 // Mock authStore
 const mockUseAuthStore = vi.fn();
 vi.mock('@/stores/authStore', () => ({
@@ -55,7 +46,6 @@ describe('HomePageContent (Root Page)', () => {
       render(<HomePageContent />);
 
       expect(screen.getByTestId('landing-page')).toBeInTheDocument();
-      expect(screen.queryAllByTestId('skeleton-loader')).toHaveLength(0);
       expect(screen.queryByTestId('user-dashboard')).not.toBeInTheDocument();
     });
 
@@ -149,7 +139,6 @@ describe('HomePageContent (Root Page)', () => {
 
       rerender(<HomePageContent />);
       expect(screen.getByTestId('landing-page')).toBeInTheDocument();
-      expect(screen.queryAllByTestId('skeleton-loader').length).toBe(0);
     });
 
     it('should handle transition from loading to authenticated', () => {
@@ -172,7 +161,6 @@ describe('HomePageContent (Root Page)', () => {
 
       rerender(<HomePageContent />);
       expect(screen.getByTestId('user-dashboard')).toBeInTheDocument();
-      expect(screen.queryAllByTestId('skeleton-loader').length).toBe(0);
     });
   });
 
@@ -193,7 +181,6 @@ describe('HomePageContent (Root Page)', () => {
       render(<HomePageContent />);
 
       expect(screen.getByTestId('landing-page')).toBeInTheDocument();
-      expect(screen.queryAllByTestId('skeleton-loader')).toHaveLength(0);
     });
   });
 });

--- a/frontend/src/components/features/home/HomePageContent.tsx
+++ b/frontend/src/components/features/home/HomePageContent.tsx
@@ -1,25 +1,8 @@
 'use client';
 
 import { UserDashboard } from '@/components/features/dashboard';
-import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthStore } from '@/stores/authStore';
 import { LandingPage } from './LandingPage';
-
-/**
- * Loading Skeleton for auth validation
- * Prevents FOUC (Flash Of Unauthed Content)
- */
-function LoadingSkeleton() {
-  return (
-    <div className="bg-bg-main flex min-h-screen items-center justify-center">
-      <div className="w-full max-w-4xl space-y-8 px-4">
-        <Skeleton className="mx-auto h-24 w-3/4" />
-        <Skeleton className="mx-auto h-16 w-full" />
-        <Skeleton className="mx-auto h-64 w-full" />
-      </div>
-    </div>
-  );
-}
 
 /**
  * Home Page with Dual Logic
@@ -30,23 +13,31 @@ function LoadingSkeleton() {
  * servía el `<title>` genérico "Auguria" — el mismo que el resto del sitio.
  *
  * Behavior:
- * - Shows loading skeleton while checking auth (prevents FOUC)
- * - Shows LandingPage for unauthenticated users
- * - Shows UserDashboard for authenticated users (all plans)
+ * - LandingPage por defecto (incluido el render del servidor)
+ * - UserDashboard en cuanto hay sesión validada
+ *
+ * ## Por qué ya no hay skeleton de carga (T-PROD-022)
+ *
+ * TASK-017 devolvía un skeleton mientras `isLoading`. Pero `isLoading` arranca en
+ * `true` en el store, así que ese skeleton **era el render del servidor**: `/` le
+ * servía a Googlebot 4 palabras de contenido propio. La home es la URL más
+ * importante del sitio y era una pantalla de carga.
+ *
+ * El costo asumido es un parpadeo de la landing antes del dashboard para un
+ * usuario ya logueado. Es preferible a no tener home indexable: el skeleton
+ * ahorraba ese flash a costa de vaciar la página para todos los buscadores.
  */
 export function HomePageContent() {
-  const { user, isAuthenticated, isLoading } = useAuthStore();
-
-  // Show loading skeleton while validating auth (prevent FOUC)
-  if (isLoading) {
-    return <LoadingSkeleton />;
-  }
-
-  // Show LandingPage for unauthenticated users
-  if (!isAuthenticated || !user) {
-    return <LandingPage />;
-  }
+  const { user, isAuthenticated } = useAuthStore();
 
   // Show UserDashboard for authenticated users (all plans)
-  return <UserDashboard />;
+  if (isAuthenticated && user) {
+    return <UserDashboard />;
+  }
+
+  // La landing es el default, incluido el render del servidor. Antes se devolvía
+  // un skeleton mientras `isLoading` —que arranca en `true`—, así que `/` le
+  // servía a Googlebot 4 palabras de contenido propio: la home, la URL más
+  // importante del sitio, era una pantalla de carga (T-PROD-022).
+  return <LandingPage />;
 }

--- a/frontend/src/lib/providers/auth-provider.test.tsx
+++ b/frontend/src/lib/providers/auth-provider.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { renderToString } from 'react-dom/server';
 
 import { AuthProvider } from './auth-provider';
 
@@ -29,6 +30,7 @@ import { AuthProvider } from './auth-provider';
  */
 
 const mockCheckAuth = vi.fn();
+const mockRehydrate = vi.fn();
 
 interface MockAuthState {
   checkAuth: () => void;
@@ -38,9 +40,13 @@ interface MockAuthState {
 
 let mockState: MockAuthState;
 
-vi.mock('@/stores/authStore', () => ({
-  useAuthStore: (selector: (state: MockAuthState) => unknown) => selector(mockState),
-}));
+vi.mock('@/stores/authStore', () => {
+  const useAuthStore = (selector: (state: MockAuthState) => unknown) => selector(mockState);
+  // El store real usa `skipHydration`, así que el provider dispara la
+  // rehidratación a mano desde un efecto.
+  useAuthStore.persist = { rehydrate: () => mockRehydrate() };
+  return { useAuthStore };
+});
 
 function renderWithState(state: Partial<MockAuthState>) {
   mockState = {
@@ -99,5 +105,36 @@ describe('AuthProvider', () => {
     renderWithState({ _hasHydrated: false, isLoading: true });
 
     expect(mockCheckAuth).not.toHaveBeenCalled();
+  });
+
+  it('dispara la rehidratación del store, que ahora usa skipHydration', () => {
+    // Sin esto la sesión no se recupera nunca: `skipHydration` desactiva la
+    // rehidratación automática para que el primer render del cliente coincida
+    // con el del servidor.
+    renderWithState({ _hasHydrated: false, isLoading: true });
+
+    expect(mockRehydrate).toHaveBeenCalledOnce();
+  });
+
+  describe('render del servidor', () => {
+    it('⚠️ T-PROD-022: el HTML del servidor trae el contenido, no el splash', () => {
+      // Éste es el nivel donde ocurrió el bug: en jsdom se simula con un mock,
+      // pero lo que rompió el sitio fue el string que emite el servidor.
+      mockState = {
+        checkAuth: mockCheckAuth,
+        // En el servidor no existe `localStorage`: este es el estado real.
+        isLoading: true,
+        _hasHydrated: false,
+      };
+
+      const html = renderToString(
+        <AuthProvider>
+          <main>Significado de El Loco en el tarot</main>
+        </AuthProvider>
+      );
+
+      expect(html).toContain('Significado de El Loco en el tarot');
+      expect(html).not.toContain('Verificando sesión');
+    });
   });
 });

--- a/frontend/src/lib/providers/auth-provider.test.tsx
+++ b/frontend/src/lib/providers/auth-provider.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { AuthProvider } from './auth-provider';
+
+/**
+ * Guardarraíl T-PROD-022.
+ *
+ * `AuthProvider` devolvía una pantalla de "Verificando sesión..." **en lugar de**
+ * `children` mientras la sesión no estuviera resuelta. Como vive en el layout
+ * raíz y en el servidor `_hasHydrated` es SIEMPRE `false` (no existe
+ * `localStorage`), **todo render SSR del sitio entero era ese splash**.
+ *
+ * Medido en producción con el user-agent de Googlebot, antes del arreglo:
+ *
+ *     /                              → "Auguria Verificando sesión..."  (3 palabras)
+ *     /enciclopedia/tarot/the-fool   → "Auguria Verificando sesión..."  (3 palabras)
+ *     /horoscopo/aries               → "Auguria Verificando sesión..."  (3 palabras)
+ *
+ * Eso le costó al sitio el rechazo de AdSense por "contenido de poco valor" y es
+ * la mitad que faltaba del "Duplicada: Google eligió otra canónica" de T-PROD-020:
+ * los títulos quedaron únicos, pero los cuerpos seguían siendo todos idénticos.
+ *
+ * La regla que fija este test: **el contenido de la página se renderiza siempre**.
+ * Cada componente que necesite ocultar algo hasta tener sesión se protege solo
+ * (`HomePageContent` con su skeleton, `useRequireAuth` en rutas privadas, y
+ * `useAdsEnabled`, que ya exige `_hasHydrated` para no mostrarle un anuncio a un
+ * Premium).
+ */
+
+const mockCheckAuth = vi.fn();
+
+interface MockAuthState {
+  checkAuth: () => void;
+  isLoading: boolean;
+  _hasHydrated: boolean;
+}
+
+let mockState: MockAuthState;
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: (selector: (state: MockAuthState) => unknown) => selector(mockState),
+}));
+
+function renderWithState(state: Partial<MockAuthState>) {
+  mockState = {
+    checkAuth: mockCheckAuth,
+    isLoading: false,
+    _hasHydrated: true,
+    ...state,
+  };
+
+  return render(
+    <AuthProvider>
+      <main data-testid="contenido">Significado de El Loco en el tarot</main>
+    </AuthProvider>
+  );
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('⚠️ T-PROD-022: renderiza el contenido aunque el store todavía no hidrató', () => {
+    // Éste es el caso del servidor: `_hasHydrated` nunca llega a true en SSR, así
+    // que es exactamente lo que recibe Googlebot.
+    renderWithState({ _hasHydrated: false, isLoading: true });
+
+    expect(screen.getByTestId('contenido')).toBeInTheDocument();
+    expect(screen.getByText('Significado de El Loco en el tarot')).toBeInTheDocument();
+  });
+
+  it('⚠️ T-PROD-022: renderiza el contenido mientras se valida la sesión', () => {
+    renderWithState({ _hasHydrated: true, isLoading: true });
+
+    expect(screen.getByTestId('contenido')).toBeInTheDocument();
+  });
+
+  it('⚠️ T-PROD-022: no bloquea el sitio con la pantalla de "Verificando sesión"', () => {
+    renderWithState({ _hasHydrated: false, isLoading: true });
+
+    expect(screen.queryByText(/verificando sesión/i)).not.toBeInTheDocument();
+  });
+
+  it('renderiza el contenido con la sesión ya resuelta', () => {
+    renderWithState({ _hasHydrated: true, isLoading: false });
+
+    expect(screen.getByTestId('contenido')).toBeInTheDocument();
+  });
+
+  it('valida la sesión una vez que el store hidrató', () => {
+    renderWithState({ _hasHydrated: true, isLoading: false });
+
+    expect(mockCheckAuth).toHaveBeenCalledOnce();
+  });
+
+  it('no valida la sesión antes de hidratar: leería un token que todavía no está', () => {
+    renderWithState({ _hasHydrated: false, isLoading: true });
+
+    expect(mockCheckAuth).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/providers/auth-provider.tsx
+++ b/frontend/src/lib/providers/auth-provider.tsx
@@ -10,15 +10,38 @@ interface AuthProviderProps {
 /**
  * Authentication Provider
  *
- * Initializes authentication state by calling checkAuth on mount.
- * This ensures the auth state is verified when the app loads.
- * Shows a loading spinner until authentication is validated.
+ * Dispara la validación de sesión (`checkAuth`) una vez que Zustand hidrató
+ * desde `localStorage`, y **renderiza el contenido siempre**.
  *
- * Handles Zustand hydration to prevent stale auth state issues.
+ * ## Por qué no bloquea (T-PROD-022)
+ *
+ * Hasta acá devolvía una pantalla de "Verificando sesión..." EN LUGAR de
+ * `children`. Como este provider vive en el layout raíz y en el servidor
+ * `_hasHydrated` es **siempre `false`** (no existe `localStorage`), el resultado
+ * era que **todo render SSR del sitio entero era ese splash**. Medido en
+ * producción con el user-agent de Googlebot:
+ *
+ *     /                            → "Auguria Verificando sesión..."  (3 palabras)
+ *     /enciclopedia/tarot/the-fool → "Auguria Verificando sesión..."  (3 palabras)
+ *
+ * Le costó al sitio el rechazo de AdSense por "contenido de poco valor" —
+ * literalmente no había contenido que evaluar— y era la mitad que faltaba del
+ * "Duplicada: Google eligió otra canónica" de T-PROD-020: los `<title>` quedaron
+ * únicos, pero los cuerpos seguían siendo todos idénticos.
+ *
+ * ## Dónde vive ahora la protección contra el FOUC
+ *
+ * En cada componente que la necesita, que es donde corresponde:
+ * - `HomePageContent` muestra su propio skeleton mientras `isLoading`, para no
+ *   parpadear la landing antes del dashboard.
+ * - Las rutas privadas usan `useRequireAuth`, que redirige por su cuenta.
+ * - `useAdsEnabled` exige `_hasHydrated` antes de habilitar anuncios, así que un
+ *   Premium sigue sin ver ni un flash de publicidad (T-PROD-008).
+ *
+ * ⚠️ NO volver a devolver un splash desde acá: apaga el sitio para los buscadores.
  */
 export function AuthProvider({ children }: AuthProviderProps) {
   const checkAuth = useAuthStore((state) => state.checkAuth);
-  const isLoading = useAuthStore((state) => state.isLoading);
   const hasHydrated = useAuthStore((state) => state._hasHydrated);
 
   useEffect(() => {
@@ -27,20 +50,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
       checkAuth();
     }
   }, [checkAuth, hasHydrated]);
-
-  // Show loading state while:
-  // 1. Zustand is hydrating from localStorage
-  // 2. checkAuth is validating the session
-  if (!hasHydrated || isLoading) {
-    return (
-      <div className="bg-bg-main flex min-h-screen items-center justify-center">
-        <div className="flex flex-col items-center gap-4">
-          <div className="border-primary h-8 w-8 animate-spin rounded-full border-4 border-t-transparent" />
-          <p className="text-text-muted text-sm">Verificando sesión...</p>
-        </div>
-      </div>
-    );
-  }
 
   return <>{children}</>;
 }

--- a/frontend/src/lib/providers/auth-provider.tsx
+++ b/frontend/src/lib/providers/auth-provider.tsx
@@ -29,20 +29,27 @@ interface AuthProviderProps {
  * "Duplicada: Google eligió otra canónica" de T-PROD-020: los `<title>` quedaron
  * únicos, pero los cuerpos seguían siendo todos idénticos.
  *
- * ## Dónde vive ahora la protección contra el FOUC
+ * ## Qué protege qué ahora
  *
- * En cada componente que la necesita, que es donde corresponde:
- * - `HomePageContent` muestra su propio skeleton mientras `isLoading`, para no
- *   parpadear la landing antes del dashboard.
- * - Las rutas privadas usan `useRequireAuth`, que redirige por su cuenta.
+ * - Las rutas privadas usan `useRequireAuth`, que espera a que `isLoading` sea
+ *   `false` antes de redirigir y muestra su propio spinner mientras tanto.
  * - `useAdsEnabled` exige `_hasHydrated` antes de habilitar anuncios, así que un
  *   Premium sigue sin ver ni un flash de publicidad (T-PROD-008).
+ * - `HomePageContent` renderiza la landing por defecto y cambia al dashboard en
+ *   cuanto hay sesión. El parpadeo para un usuario logueado es un costo asumido.
  *
  * ⚠️ NO volver a devolver un splash desde acá: apaga el sitio para los buscadores.
  */
 export function AuthProvider({ children }: AuthProviderProps) {
   const checkAuth = useAuthStore((state) => state.checkAuth);
   const hasHydrated = useAuthStore((state) => state._hasHydrated);
+
+  // El store usa `skipHydration` para que el primer render del cliente coincida
+  // con el del servidor (ver `authStore.ts`). La rehidratación se dispara acá,
+  // ya montados, y al terminar pone `_hasHydrated` en `true`.
+  useEffect(() => {
+    void useAuthStore.persist.rehydrate();
+  }, []);
 
   useEffect(() => {
     // Only check auth after Zustand has hydrated from localStorage

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -172,6 +172,15 @@ export const useAuthStore = create<AuthStore>()(
     }),
     {
       name: 'auth-storage',
+      // ⚠️ T-PROD-022: la rehidratación NO puede ocurrir durante la creación del
+      // store. `localStorage` es síncrono, así que sin esto zustand rehidrata en
+      // el mismo tick y el PRIMER render del cliente ya tiene `user`, mientras que
+      // el del servidor no lo tiene nunca → React detecta un mismatch y descarta
+      // el HTML del servidor, regenerando el árbol entero en el cliente (el
+      // `Header` está en el layout raíz, así que pasaba en todas las páginas).
+      // Con `skipHydration`, `AuthProvider` la dispara en un efecto: el primer
+      // render del cliente coincide con el del servidor y la sesión entra después.
+      skipHydration: true,
       partialize: (state) => ({
         user: state.user,
         isAuthenticated: state.isAuthenticated,


### PR DESCRIPTION
## Contexto

AdSense rechazó `auguriatarot.com` por **"Contenido de poco valor"**. Medí producción con el user-agent de Googlebot y el motivo resultó literal: **todas las páginas devolvían 3 palabras**.

| URL | `<title>` | Palabras visibles |
| --- | --- | --- |
| `/` | Auguria | **3** |
| `/enciclopedia/tarot/the-fool` | Auguria | **3** |
| `/horoscopo/aries` | Auguria | **3** |
| `/numerologia` | Auguria | **3** |

Siempre las mismas: `Auguria Verificando sesión...`

**Causa:** `auth-provider.tsx` devolvía la pantalla de carga **en lugar de** `children` mientras `!hasHydrated || isLoading`. Vive en el layout raíz y en el servidor `_hasHydrated` es **siempre `false`** (no existe `localStorage`) → **todo render SSR del sitio entero era ese splash**.

⚠️ **Era también la mitad que faltaba de T-PROD-020.** Aquella tarea dejó los `<title>` únicos, pero los cuerpos seguían siendo todos idénticos, así que Google habría seguido agrupándolas como duplicadas. Verificado sobre el build con T-PROD-020 aplicado: `"Enciclopedia Mística | Auguria Verificando sesión..."` = 6 palabras.

## Cambios

- **`AuthProvider` renderiza `children` siempre.** La protección contra FOUC baja a quien la necesita: `useRequireAuth` en rutas privadas y `useAdsEnabled`, que **ya** exigía `_hasHydrated` por su cuenta — el gate nunca fue lo que evitaba que un Premium viera un anuncio, así que **T-PROD-008 queda intacto**.
- **`HomePageContent`:** la landing pasa a ser el render por defecto. El skeleton de TASK-017 se mostraba mientras `isLoading`, que **arranca en `true`**, así que ese skeleton **era** el render del servidor de `/`. La home servía 4 palabras propias; ahora sirve **611**.
- **Bug destapado por el arreglo:** `/carta-astral/resultado` rompía el build con `ReferenceError: self is not defined`. `@astrodraw/astrochart` toca `self` al evaluarse y se importaba en el tope de `ChartWheel.hooks.ts`; el gate lo tapaba porque esa página nunca llegaba a renderizarse en el servidor. Pasa a `await import()` dentro del `requestAnimationFrame`, que ya corre en el browser.

## Resultado medido (build local, descontando 39 palabras de header+footer)

| Con contenido propio | Todavía casi vacías |
| --- | --- |
| `/` **611** · `/carta-astral` 376 · `/numerologia` 305 · `/horoscopo-chino` 258 · `/rituales` 223 · `/horoscopo` 217 · `/pendulo` 215 | `/premium` 3 · `/servicios` 5 · `/enciclopedia/guias` 13 · `/explorar` 20 · `/enciclopedia/tarot` 24 · `/horoscopo/aries` 31 |

Las de la derecha son listados y fichas que traen sus datos **por el cliente** con React Query: el crawler sigue recibiendo el cascarón. Ya no es un gate global, pero es el mismo síntoma → candidata a **T-PROD-023** (SSR con `initialData`, como se hizo con `/enciclopedia/tarot/[slug]`). Conviene medirlo contra producción con la API arriba: varias se llenan en prod y el build local las subestima.

## Trade-off asumido

Un usuario ya logueado puede ver un parpadeo de la landing antes del dashboard. Es exactamente lo que el skeleton evitaba. Se acepta a cambio de tener una home indexable: el skeleton ahorraba ese flash a costa de vaciar el sitio para todos los buscadores.

Los tests de TASK-017 que aseveraban *"no renderizar contenido mientras carga"* se **invirtieron a propósito**, con el porqué escrito al lado.

## Checklist

- [x] Tests escritos ANTES (3 de regresión en rojo → verde)
- [x] `npm run test:run` — **5512 tests, 435 suites**, 0 fallos
- [x] `npm run lint:fix` — 0 errores (7 warnings preexistentes)
- [x] `npm run type-check`
- [x] `npm run build` — 85/85 páginas prerenderizadas
- [x] `node scripts/validate-architecture.js`
- [x] Backlog actualizado (T-PROD-022)

## ⚠️ Nota de deploy

Producción corre `main`. **Nada de esto llega al sitio hasta promover `develop` → `main`** — ni T-PROD-020, ni T-PROD-021, ni esto. Después del deploy hay que re-verificar con el mismo `curl` como Googlebot **antes** de apretar "Solicitar revisión" en AdSense. Pendiente aparte: `ads.txt` figura como *No se encuentra* en el panel (contemplado en T-PROD-009).

🤖 Generated with [Claude Code](https://claude.com/claude-code)