### PR TITLE
feat(seo): el contenido de artículos, rituales y servicios se resuelve en el servidor (T-PROD-024)

### DIFF
--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -2046,6 +2046,46 @@ AdSense— y Google los veía vacíos: el `<title>` estaba bien desde T-PROD-020
 - [x] Ciclo de calidad frontend: format, lint (0 errores, los 7 warnings preexistentes), type-check
       (ambos tsconfig), `test:run` (**5514 tests**) y `validate-architecture.js`.
 
+#### 🔍 Hallazgos del revisor local (aplicados en un segundo commit)
+
+- 🟠 **`/servicios/[slug]` nunca 404eaba: daba 500.** `getHolisticServiceDetail` envolvía el `AxiosError`
+      del 404 en un `Error` plano, así que `isNotFoundError` no lo reconocía y `resolveRouteResource` lo
+      re-lanzaba. Y el test lo tapaba: mockeaba un `AxiosError` crudo que la función real **nunca emite**.
+      Ahora la API re-lanza el error original y el test pasa por el comportamiento real.
+- 🟠 **`ServiceDetailPage` seguía vaciando la página ante `error`**, al revés que artículo, ritual y carta.
+      Con `initialService` sembrado, la única forma de que `isError` sea true es un refetch en background
+      fallido — y ahí el usuario perdía el precio, el calendario y **el turno que ya había elegido**.
+      Pasa a guardar por `!service`.
+- 🟡 **`initialData` congelaba el precio hasta 24 h.** Sin `initialDataUpdatedAt`, React Query estampa el
+      dato como recién traído y con el `staleTime` no refetchea al montar: la copia horneada en el HTML
+      quedaba fija. Se agrega `initialDataUpdatedAt: 0` en servicios y rituales (en enciclopedia no hace
+      falta: el contenido es realmente estático).
+- 🟡 **6 `eslint-disable @typescript-eslint/no-explicit-any`** en el test relocalizado de ritual.
+      Reemplazados por `vi.mocked()` con los tipos reales del hook — Rule 0 es tolerancia cero.
+- 💡 **Fuga de slugs entre categorías.** Las 5 rutas de artículo consultan el mismo `getArticle(slug)` sin
+      filtrar, así que `/enciclopedia/elementos/aries` servía el signo Aries: el mismo contenido alcanzable
+      como 5 URLs, justo el duplicado que T-PROD-020 vino a deshacer. Se agrega un chequeo de categoría
+      post-fetch, con test en las 5 rutas.
+
+#### ⚠️ Hallazgo propio al verificar: los `notFound()` son soft-404
+
+Al comprobar los arreglos contra la imagen real medí los códigos HTTP y **no son 404**:
+
+```
+/enciclopedia/elementos/aries    → 200 (página de no-encontrado)
+/servicios/inventado             → 200 (página de no-encontrado)
+/enciclopedia/tarot/inventado-xyz → 200 (página de no-encontrado)
+```
+
+La tercera usa el código de **T-PROD-020, ya en producción**, así que es **preexistente y ajeno a este
+PR** — pero invalida la afirmación de "404 real" que quedó escrita en T-PROD-020 y T-PROD-021. Los
+comentarios se corrigieron para decir lo que realmente hace (`notFound()` corta el render y sirve la
+página de no-encontrado). Un soft-404 es justamente lo que Google penaliza, así que **merece tarea
+propia**: hay que entender por qué Next no está emitiendo el status 404 en estas rutas ISR.
+
+Lo que sí mejora este PR: `/servicios/inventado` pasó de **500** a página de no-encontrado, y
+`/enciclopedia/elementos/aries` dejó de servir contenido duplicado.
+
 #### 📌 Fuera de alcance → **quedan 27 URLs delgadas**
 
 Se atacaron 62 de las ~86. Lo que falta **no es el mismo patrón** y por eso no entró:

--- a/docs/BACKLOG_PRODUCCION_2026_07.md
+++ b/docs/BACKLOG_PRODUCCION_2026_07.md
@@ -343,6 +343,7 @@ Además el frontend define tres tipos que el backend **nunca emite** (`reading_s
 | T-PROD-021 | ✅ **Bomba de timezone en auth**: las columnas `timestamp` de expiración se leen desfasadas si el server no corre en UTC (rompe login y reset de contraseña) | Backend | 🟠 Alta | 2 pts |
 | T-PROD-022 | ✅ **El sitio entero servía 3 palabras a Googlebot**: el `AuthProvider` devolvía "Verificando sesión..." en lugar del contenido en todo render SSR (rechazo de AdSense) | Frontend | 🔴 Crítica | 2 pts |
 | T-PROD-023 | ✅ **El build de Railway venía fallando hace 2 semanas**: sin lockfile resuelve versiones más nuevas que local/CI y `next build` type-checkea los tests | Frontend/Infra | 🔴 Crítica | 1 pt |
+| T-PROD-024 | ✅ **62 URLs servían ~5 palabras al crawler**: artículos, rituales y servicios traían su contenido por el cliente | Frontend | 🔴 Crítica | 3 pts |
 
 ---
 
@@ -1987,6 +1988,77 @@ lockfile propio del frontend. Es una decisión de infra que merece su propia tar
 
 Que CI esté verde no garantiza que el deploy funcione: **CI y Railway instalan dependencias de forma
 distinta**. Vale la pena correr el `docker build` real antes de dar por deployado un cambio.
+
+---
+
+### T-PROD-024: 62 URLs de Contenido Servían ~5 Palabras al Crawler — ✅ COMPLETADA
+
+**Estado:** ✅ COMPLETADA (2026-08-09)
+**Prioridad:** 🔴 Crítica
+**Estimación:** 3 puntos
+**Dependencias:** T-PROD-022 (el gate global) y T-PROD-023 (el deploy)
+**Origen:** medición sobre producción tras el primer deploy exitoso
+**Tipo:** Frontend (`docs/WORKFLOW_FRONTEND.md`)
+
+#### 📋 Problema
+
+Con el sitio ya deployado, medí las 178 URLs del sitemap como Googlebot (muestra estratificada de 62,
+descontando las 39 palabras de header+footer). **Solo 13 superaban las 150 palabras propias.**
+
+Las 79 fichas de tarot estaban bien (126–233 palabras: el SSR de T-PROD-020 funcionó). El resto no:
+
+| Grupo | URLs | Palabras propias |
+| --- | --- | --- |
+| Artículos de enciclopedia (signos, planetas, casas, guías, elementos) | **53** | 5–11 |
+| Fichas de ritual y de servicio | 9 | 7–9 |
+| Horóscopo chino por animal | 12 | 3 |
+| Signos del horóscopo | 12 | 31 |
+
+Los 53 artículos son **el contenido editorial del sitio** —lo más valioso que hay para mostrarle a
+AdSense— y Google los veía vacíos: el `<title>` estaba bien desde T-PROD-020, pero el cuerpo lo traía
+`ArticleDetailPageContent` por el cliente.
+
+#### ✅ Tareas específicas
+
+- [x] `useArticle`, `useRitual` y `useHolisticServiceDetail` aceptan `initialData`.
+- [x] `ArticleDetailPageContent` (el componente que sirve **las 53 fichas**), `RitualDetailPage` y
+      `ServiceDetailPage` reciben el recurso ya resuelto y siembran la query con él.
+- [x] Las 5 rutas de artículo + ritual + servicio resuelven en el servidor con `cache()` de React (para
+      no duplicar el fetch entre `generateMetadata` y la página) y los helpers de `route-data.ts`:
+      404 → `notFound()`, error transitorio → se propaga. `revalidate` de 24 h en las de enciclopedia.
+- [x] Tests: nuevo `ArticleDetailPageContent.test.tsx` (5) y actualizados los de las 5 rutas, que
+      aseveraban el comportamiento viejo (`{}` ante cualquier error).
+
+#### 🎯 Criterios de Aceptación
+
+- [x] **Verificado corriendo la imagen de producción contra la API real** (no solo con el build):
+
+  | URL | Antes | Después |
+  | --- | --- | --- |
+  | `/enciclopedia/astrologia/signos/aries` | 5 | **451** |
+  | `/enciclopedia/guias/guia-pendulo` | 7 | **684** |
+  | `/enciclopedia/elementos/elemento-agua` | 6 | **464** |
+  | `/rituales/ritual-luna-nueva` | 7 | **461** |
+  | `/servicios/arbol-genealogico` | 9 | **282** |
+  | `/enciclopedia/tarot/the-fool` | 260 | 260 (sin regresión) |
+
+- [x] `docker build` reproduciendo Railway: exit 0.
+- [x] Ciclo de calidad frontend: format, lint (0 errores, los 7 warnings preexistentes), type-check
+      (ambos tsconfig), `test:run` (**5514 tests**) y `validate-architecture.js`.
+
+#### 📌 Fuera de alcance → **quedan 27 URLs delgadas**
+
+Se atacaron 62 de las ~86. Lo que falta **no es el mismo patrón** y por eso no entró:
+
+- **Horóscopo chino por animal (12 URLs, 3 palabras).** Es el peor caso y tiene otra causa:
+  `AnimalHoroscopePage` usa `useSearchParams()` en un client component, lo que **deopta la ruta entera**
+  del prerender estático — por eso sirve menos que el resto. Arreglarlo implica separar la parte estática
+  del animal (nombre, elemento, características, años) de la interactiva. Merece su propia tarea.
+- **Signos del horóscopo (12 URLs, 31 palabras).** El horóscopo del día depende del **día calendario local
+  del visitante** (decisión deliberada de T-PROD-020), así que no se puede resolver en el servidor. Lo que
+  sí se puede es renderizar la ficha estática del signo (fechas, elemento, rasgos) alrededor.
+- **Listados/hubs**: `/enciclopedia/tarot` (24), `/explorar` (20), `/enciclopedia/guias` (13),
+  `/servicios` (5), `/premium` (3). Mismo patrón que este PR, pero sobre listados.
 
 ---
 

--- a/frontend/src/app/enciclopedia/astrologia/casas/[slug]/page.test.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/casas/[slug]/page.test.tsx
@@ -75,6 +75,7 @@ describe('generateMetadata (casas)', () => {
       slug: 'primera-casa',
       nameEs: 'Primera Casa',
       snippet: 'La casa del yo.',
+      category: 'astro_house',
     });
 
     const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'primera-casa' }) });
@@ -90,6 +91,7 @@ describe('generateMetadata (casas)', () => {
       slug: 'primera-casa',
       nameEs: 'Primera Casa',
       snippet,
+      category: 'astro_house',
     });
 
     const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'primera-casa' }) });
@@ -103,6 +105,7 @@ describe('generateMetadata (casas)', () => {
       slug: 'primera-casa',
       nameEs: 'Primera Casa',
       snippet: 'La casa del yo.',
+      category: 'astro_house',
     });
 
     const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'primera-casa' }) });
@@ -114,7 +117,7 @@ describe('generateMetadata (casas)', () => {
     });
   });
 
-  it('⚠️ T-PROD-024: un slug inexistente 404ea en vez de servir un 200 genérico', async () => {
+  it('⚠️ T-PROD-024: un slug inexistente corta con notFound() en vez de servir el recurso', async () => {
     mockGetArticle.mockRejectedValue(apiError(404));
 
     await expect(
@@ -128,6 +131,23 @@ describe('generateMetadata (casas)', () => {
     await expect(generateMetadata({ params: Promise.resolve({ slug: 'aries' }) })).rejects.toThrow(
       'boom'
     );
+  });
+
+  it('⚠️ T-PROD-024: un artículo de otra categoría corta con notFound() en esta ruta', async () => {
+    // Todas las rutas de artículo consultan el mismo `getArticle(slug)`. Sin el
+    // chequeo de categoría, el mismo contenido quedaba alcanzable como 5 URLs
+    // distintas: contenido duplicado ante Google.
+    mockGetArticle.mockResolvedValue({
+      id: 99,
+      slug: 'intruso',
+      nameEs: 'Intruso',
+      snippet: 'De otra sección.',
+      category: 'zodiac_sign',
+    });
+
+    await expect(
+      generateMetadata({ params: Promise.resolve({ slug: 'intruso' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND');
   });
 });
 

--- a/frontend/src/app/enciclopedia/astrologia/casas/[slug]/page.test.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/casas/[slug]/page.test.tsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { AxiosError, AxiosHeaders } from 'axios';
 
-import CasaDetailPage, { generateMetadata, generateStaticParams } from './page';
+import { generateMetadata, generateStaticParams } from './page';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
 vi.mock('next/navigation', () => ({
-  useParams: () => ({ slug: 'primera-casa' }),
+  notFound: () => {
+    throw new Error('NEXT_NOT_FOUND');
+  },
 }));
 
 vi.mock('next/link', () => ({
@@ -50,48 +52,17 @@ vi.mock('@/lib/api/encyclopedia-articles-api', () => ({
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
-describe('CasaDetailPage (/enciclopedia/astrologia/casas/[slug])', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('debe renderizar ArticleDetailView cuando el artículo existe', () => {
-    mockUseArticle.mockReturnValue({
-      data: {
-        id: 3,
-        slug: 'primera-casa',
-        nameEs: 'Primera Casa',
-        nameEn: 'First House',
-        category: 'astro_house',
-        snippet: 'La casa del yo.',
-        imageUrl: null,
-        sortOrder: 1,
-        content: '## Primera Casa',
-        metadata: null,
-        relatedArticles: [],
-        relatedTarotCards: null,
-      },
-      isLoading: false,
-      error: null,
-    });
-
-    render(<CasaDetailPage />);
-
-    expect(screen.getByTestId('article-detail-view')).toBeInTheDocument();
-  });
-
-  it('debe retornar 404 para slug inexistente', () => {
-    mockUseArticle.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Not found'),
-    });
-
-    render(<CasaDetailPage />);
-
-    expect(screen.getByText('Artículo no encontrado')).toBeInTheDocument();
-  });
-});
+function apiError(status: number): AxiosError {
+  const error = new AxiosError('boom');
+  error.response = {
+    status,
+    statusText: '',
+    data: null,
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+}
 
 describe('generateMetadata (casas)', () => {
   beforeEach(() => {
@@ -143,12 +114,20 @@ describe('generateMetadata (casas)', () => {
     });
   });
 
-  it('debe retornar objeto vacío si el artículo no existe', async () => {
-    mockGetArticle.mockRejectedValue(new Error('Not found'));
+  it('⚠️ T-PROD-024: un slug inexistente 404ea en vez de servir un 200 genérico', async () => {
+    mockGetArticle.mockRejectedValue(apiError(404));
 
-    const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'inexistente' }) });
+    await expect(
+      generateMetadata({ params: Promise.resolve({ slug: 'inexistente' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
 
-    expect(metadata).toEqual({});
+  it('⚠️ T-PROD-024: propaga un fallo transitorio en vez de cachear metadata degradada', async () => {
+    mockGetArticle.mockRejectedValue(apiError(503));
+
+    await expect(generateMetadata({ params: Promise.resolve({ slug: 'aries' }) })).rejects.toThrow(
+      'boom'
+    );
   });
 });
 

--- a/frontend/src/app/enciclopedia/astrologia/casas/[slug]/page.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/casas/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { cache } from 'react';
+import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 
 import { getArticle, getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
@@ -26,7 +27,23 @@ interface PageProps {
  * `fetch()` y acá abajo hay axios, así que sin `cache()` serían dos requests por
  * página renderizada.
  */
-const getArticleCached = cache((slug: string) => resolveRouteResource(() => getArticle(slug)));
+const ROUTE_CATEGORIES: readonly ArticleCategory[] = [ArticleCategory.ASTROLOGICAL_HOUSE];
+
+/**
+ * Las 5 rutas de artículo consultan el MISMO `getArticle(slug)`, sin filtrar por
+ * categoría. Sin este chequeo, `/enciclopedia/elementos/aries` devolvía 200 con el
+ * signo Aries: cada artículo quedaba alcanzable como 5 URLs distintas con el mismo
+ * contenido — justo el agrupamiento por duplicado que T-PROD-020 vino a deshacer.
+ */
+const getArticleCached = cache(async (slug: string) => {
+  const article = await resolveRouteResource(() => getArticle(slug));
+
+  if (!ROUTE_CATEGORIES.includes(article.category)) {
+    notFound();
+  }
+
+  return article;
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;

--- a/frontend/src/app/enciclopedia/astrologia/casas/[slug]/page.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/casas/[slug]/page.tsx
@@ -1,7 +1,9 @@
+import { cache } from 'react';
 import type { Metadata } from 'next';
 
 import { getArticle, getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
 import { getArticleMetadata } from '@/lib/metadata/seo';
+import { resolveRouteResource, safeStaticParams } from '@/lib/metadata/route-data';
 import { ROUTES } from '@/lib/constants/routes';
 import { ArticleCategory } from '@/types/encyclopedia-article.types';
 import { ArticleDetailPageContent } from '@/components/features/encyclopedia/ArticleDetailPageContent';
@@ -12,29 +14,35 @@ import { ArticleDetailPageContent } from '@/components/features/encyclopedia/Art
  * Route: /enciclopedia/astrologia/casas/[slug]
  */
 
+/** La enciclopedia es contenido estático; un día de ISR alcanza. */
+export const revalidate = 86400;
+
 interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
+/**
+ * `generateMetadata` y la página resuelven el MISMO artículo. Next solo dedupea
+ * `fetch()` y acá abajo hay axios, así que sin `cache()` serían dos requests por
+ * página renderizada.
+ */
+const getArticleCached = cache((slug: string) => resolveRouteResource(() => getArticle(slug)));
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  try {
-    const article = await getArticle(slug);
-    return getArticleMetadata(article, ROUTES.ENCICLOPEDIA_CASA(slug));
-  } catch {
-    return {};
-  }
+
+  return getArticleMetadata(await getArticleCached(slug), ROUTES.ENCICLOPEDIA_CASA(slug));
 }
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
-  try {
-    const articles = await getArticlesByCategory(ArticleCategory.ASTROLOGICAL_HOUSE);
-    return articles.map((article) => ({ slug: article.slug }));
-  } catch {
-    return [];
-  }
+  return safeStaticParams(
+    () => getArticlesByCategory(ArticleCategory.ASTROLOGICAL_HOUSE),
+    (article) => ({ slug: article.slug })
+  );
 }
 
-export default function CasaDetailPage() {
-  return <ArticleDetailPageContent />;
+export default async function CasaDetailPage({ params }: PageProps) {
+  const { slug } = await params;
+
+  return <ArticleDetailPageContent slug={slug} initialArticle={await getArticleCached(slug)} />;
 }

--- a/frontend/src/app/enciclopedia/astrologia/planetas/[slug]/page.test.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/planetas/[slug]/page.test.tsx
@@ -75,6 +75,7 @@ describe('generateMetadata (planetas)', () => {
       slug: 'mercurio',
       nameEs: 'Mercurio',
       snippet: 'El planeta de la comunicación.',
+      category: 'planet',
     });
 
     const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'mercurio' }) });
@@ -90,6 +91,7 @@ describe('generateMetadata (planetas)', () => {
       slug: 'mercurio',
       nameEs: 'Mercurio',
       snippet,
+      category: 'planet',
     });
 
     const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'mercurio' }) });
@@ -103,6 +105,7 @@ describe('generateMetadata (planetas)', () => {
       slug: 'mercurio',
       nameEs: 'Mercurio',
       snippet: 'El planeta de la comunicación.',
+      category: 'planet',
     });
 
     const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'mercurio' }) });
@@ -114,7 +117,7 @@ describe('generateMetadata (planetas)', () => {
     });
   });
 
-  it('⚠️ T-PROD-024: un slug inexistente 404ea en vez de servir un 200 genérico', async () => {
+  it('⚠️ T-PROD-024: un slug inexistente corta con notFound() en vez de servir el recurso', async () => {
     mockGetArticle.mockRejectedValue(apiError(404));
 
     await expect(
@@ -128,6 +131,23 @@ describe('generateMetadata (planetas)', () => {
     await expect(generateMetadata({ params: Promise.resolve({ slug: 'aries' }) })).rejects.toThrow(
       'boom'
     );
+  });
+
+  it('⚠️ T-PROD-024: un artículo de otra categoría corta con notFound() en esta ruta', async () => {
+    // Todas las rutas de artículo consultan el mismo `getArticle(slug)`. Sin el
+    // chequeo de categoría, el mismo contenido quedaba alcanzable como 5 URLs
+    // distintas: contenido duplicado ante Google.
+    mockGetArticle.mockResolvedValue({
+      id: 99,
+      slug: 'intruso',
+      nameEs: 'Intruso',
+      snippet: 'De otra sección.',
+      category: 'zodiac_sign',
+    });
+
+    await expect(
+      generateMetadata({ params: Promise.resolve({ slug: 'intruso' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND');
   });
 });
 

--- a/frontend/src/app/enciclopedia/astrologia/planetas/[slug]/page.test.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/planetas/[slug]/page.test.tsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { AxiosError, AxiosHeaders } from 'axios';
 
-import PlanetaDetailPage, { generateMetadata, generateStaticParams } from './page';
+import { generateMetadata, generateStaticParams } from './page';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
 vi.mock('next/navigation', () => ({
-  useParams: () => ({ slug: 'mercurio' }),
+  notFound: () => {
+    throw new Error('NEXT_NOT_FOUND');
+  },
 }));
 
 vi.mock('next/link', () => ({
@@ -50,48 +52,17 @@ vi.mock('@/lib/api/encyclopedia-articles-api', () => ({
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
-describe('PlanetaDetailPage (/enciclopedia/astrologia/planetas/[slug])', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('debe renderizar ArticleDetailView cuando el artículo existe', () => {
-    mockUseArticle.mockReturnValue({
-      data: {
-        id: 2,
-        slug: 'mercurio',
-        nameEs: 'Mercurio',
-        nameEn: 'Mercury',
-        category: 'planet',
-        snippet: 'El planeta de la comunicación.',
-        imageUrl: null,
-        sortOrder: 2,
-        content: '## Mercurio',
-        metadata: null,
-        relatedArticles: [],
-        relatedTarotCards: null,
-      },
-      isLoading: false,
-      error: null,
-    });
-
-    render(<PlanetaDetailPage />);
-
-    expect(screen.getByTestId('article-detail-view')).toBeInTheDocument();
-  });
-
-  it('debe retornar 404 para slug inexistente', () => {
-    mockUseArticle.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Not found'),
-    });
-
-    render(<PlanetaDetailPage />);
-
-    expect(screen.getByText('Artículo no encontrado')).toBeInTheDocument();
-  });
-});
+function apiError(status: number): AxiosError {
+  const error = new AxiosError('boom');
+  error.response = {
+    status,
+    statusText: '',
+    data: null,
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+}
 
 describe('generateMetadata (planetas)', () => {
   beforeEach(() => {
@@ -143,12 +114,20 @@ describe('generateMetadata (planetas)', () => {
     });
   });
 
-  it('debe retornar objeto vacío si el artículo no existe', async () => {
-    mockGetArticle.mockRejectedValue(new Error('Not found'));
+  it('⚠️ T-PROD-024: un slug inexistente 404ea en vez de servir un 200 genérico', async () => {
+    mockGetArticle.mockRejectedValue(apiError(404));
 
-    const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'inexistente' }) });
+    await expect(
+      generateMetadata({ params: Promise.resolve({ slug: 'inexistente' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
 
-    expect(metadata).toEqual({});
+  it('⚠️ T-PROD-024: propaga un fallo transitorio en vez de cachear metadata degradada', async () => {
+    mockGetArticle.mockRejectedValue(apiError(503));
+
+    await expect(generateMetadata({ params: Promise.resolve({ slug: 'aries' }) })).rejects.toThrow(
+      'boom'
+    );
   });
 });
 

--- a/frontend/src/app/enciclopedia/astrologia/planetas/[slug]/page.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/planetas/[slug]/page.tsx
@@ -1,7 +1,9 @@
+import { cache } from 'react';
 import type { Metadata } from 'next';
 
 import { getArticle, getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
 import { getArticleMetadata } from '@/lib/metadata/seo';
+import { resolveRouteResource, safeStaticParams } from '@/lib/metadata/route-data';
 import { ROUTES } from '@/lib/constants/routes';
 import { ArticleCategory } from '@/types/encyclopedia-article.types';
 import { ArticleDetailPageContent } from '@/components/features/encyclopedia/ArticleDetailPageContent';
@@ -12,29 +14,35 @@ import { ArticleDetailPageContent } from '@/components/features/encyclopedia/Art
  * Route: /enciclopedia/astrologia/planetas/[slug]
  */
 
+/** La enciclopedia es contenido estático; un día de ISR alcanza. */
+export const revalidate = 86400;
+
 interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
+/**
+ * `generateMetadata` y la página resuelven el MISMO artículo. Next solo dedupea
+ * `fetch()` y acá abajo hay axios, así que sin `cache()` serían dos requests por
+ * página renderizada.
+ */
+const getArticleCached = cache((slug: string) => resolveRouteResource(() => getArticle(slug)));
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  try {
-    const article = await getArticle(slug);
-    return getArticleMetadata(article, ROUTES.ENCICLOPEDIA_PLANETA(slug));
-  } catch {
-    return {};
-  }
+
+  return getArticleMetadata(await getArticleCached(slug), ROUTES.ENCICLOPEDIA_PLANETA(slug));
 }
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
-  try {
-    const articles = await getArticlesByCategory(ArticleCategory.PLANET);
-    return articles.map((article) => ({ slug: article.slug }));
-  } catch {
-    return [];
-  }
+  return safeStaticParams(
+    () => getArticlesByCategory(ArticleCategory.PLANET),
+    (article) => ({ slug: article.slug })
+  );
 }
 
-export default function PlanetaDetailPage() {
-  return <ArticleDetailPageContent />;
+export default async function PlanetaDetailPage({ params }: PageProps) {
+  const { slug } = await params;
+
+  return <ArticleDetailPageContent slug={slug} initialArticle={await getArticleCached(slug)} />;
 }

--- a/frontend/src/app/enciclopedia/astrologia/planetas/[slug]/page.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/planetas/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { cache } from 'react';
+import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 
 import { getArticle, getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
@@ -26,7 +27,23 @@ interface PageProps {
  * `fetch()` y acá abajo hay axios, así que sin `cache()` serían dos requests por
  * página renderizada.
  */
-const getArticleCached = cache((slug: string) => resolveRouteResource(() => getArticle(slug)));
+const ROUTE_CATEGORIES: readonly ArticleCategory[] = [ArticleCategory.PLANET];
+
+/**
+ * Las 5 rutas de artículo consultan el MISMO `getArticle(slug)`, sin filtrar por
+ * categoría. Sin este chequeo, `/enciclopedia/elementos/aries` devolvía 200 con el
+ * signo Aries: cada artículo quedaba alcanzable como 5 URLs distintas con el mismo
+ * contenido — justo el agrupamiento por duplicado que T-PROD-020 vino a deshacer.
+ */
+const getArticleCached = cache(async (slug: string) => {
+  const article = await resolveRouteResource(() => getArticle(slug));
+
+  if (!ROUTE_CATEGORIES.includes(article.category)) {
+    notFound();
+  }
+
+  return article;
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;

--- a/frontend/src/app/enciclopedia/astrologia/signos/[slug]/page.test.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/signos/[slug]/page.test.tsx
@@ -75,6 +75,7 @@ describe('generateMetadata (signos)', () => {
       slug: 'aries',
       nameEs: 'Aries',
       snippet: 'El primer signo del zodíaco.',
+      category: 'zodiac_sign',
     });
 
     const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'aries' }) });
@@ -90,6 +91,7 @@ describe('generateMetadata (signos)', () => {
       slug: 'aries',
       nameEs: 'Aries',
       snippet,
+      category: 'zodiac_sign',
     });
 
     const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'aries' }) });
@@ -103,6 +105,7 @@ describe('generateMetadata (signos)', () => {
       slug: 'aries',
       nameEs: 'Aries',
       snippet: 'El primer signo del zodíaco.',
+      category: 'zodiac_sign',
     });
 
     const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'aries' }) });
@@ -114,7 +117,7 @@ describe('generateMetadata (signos)', () => {
     });
   });
 
-  it('⚠️ T-PROD-024: un slug inexistente 404ea en vez de servir un 200 genérico', async () => {
+  it('⚠️ T-PROD-024: un slug inexistente corta con notFound() en vez de servir el recurso', async () => {
     mockGetArticle.mockRejectedValue(apiError(404));
 
     await expect(
@@ -128,6 +131,23 @@ describe('generateMetadata (signos)', () => {
     await expect(generateMetadata({ params: Promise.resolve({ slug: 'aries' }) })).rejects.toThrow(
       'boom'
     );
+  });
+
+  it('⚠️ T-PROD-024: un artículo de otra categoría corta con notFound() en esta ruta', async () => {
+    // Todas las rutas de artículo consultan el mismo `getArticle(slug)`. Sin el
+    // chequeo de categoría, el mismo contenido quedaba alcanzable como 5 URLs
+    // distintas: contenido duplicado ante Google.
+    mockGetArticle.mockResolvedValue({
+      id: 99,
+      slug: 'intruso',
+      nameEs: 'Intruso',
+      snippet: 'De otra sección.',
+      category: 'planet',
+    });
+
+    await expect(
+      generateMetadata({ params: Promise.resolve({ slug: 'intruso' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND');
   });
 });
 

--- a/frontend/src/app/enciclopedia/astrologia/signos/[slug]/page.test.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/signos/[slug]/page.test.tsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { AxiosError, AxiosHeaders } from 'axios';
 
-import SignoDetailPage, { generateMetadata, generateStaticParams } from './page';
+import { generateMetadata, generateStaticParams } from './page';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
 vi.mock('next/navigation', () => ({
-  useParams: () => ({ slug: 'aries' }),
+  notFound: () => {
+    throw new Error('NEXT_NOT_FOUND');
+  },
 }));
 
 vi.mock('next/link', () => ({
@@ -50,48 +52,17 @@ vi.mock('@/lib/api/encyclopedia-articles-api', () => ({
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
-describe('SignoDetailPage (/enciclopedia/astrologia/signos/[slug])', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('debe renderizar ArticleDetailView cuando el artículo existe', () => {
-    mockUseArticle.mockReturnValue({
-      data: {
-        id: 1,
-        slug: 'aries',
-        nameEs: 'Aries',
-        nameEn: 'Aries',
-        category: 'zodiac_sign',
-        snippet: 'El primer signo del zodíaco.',
-        imageUrl: null,
-        sortOrder: 1,
-        content: '## Aries',
-        metadata: null,
-        relatedArticles: [],
-        relatedTarotCards: null,
-      },
-      isLoading: false,
-      error: null,
-    });
-
-    render(<SignoDetailPage />);
-
-    expect(screen.getByTestId('article-detail-view')).toBeInTheDocument();
-  });
-
-  it('debe retornar 404 para slug inexistente', () => {
-    mockUseArticle.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Not found'),
-    });
-
-    render(<SignoDetailPage />);
-
-    expect(screen.getByText('Artículo no encontrado')).toBeInTheDocument();
-  });
-});
+function apiError(status: number): AxiosError {
+  const error = new AxiosError('boom');
+  error.response = {
+    status,
+    statusText: '',
+    data: null,
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+}
 
 describe('generateMetadata (signos)', () => {
   beforeEach(() => {
@@ -143,12 +114,20 @@ describe('generateMetadata (signos)', () => {
     });
   });
 
-  it('debe retornar objeto vacío si el artículo no existe', async () => {
-    mockGetArticle.mockRejectedValue(new Error('Not found'));
+  it('⚠️ T-PROD-024: un slug inexistente 404ea en vez de servir un 200 genérico', async () => {
+    mockGetArticle.mockRejectedValue(apiError(404));
 
-    const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'inexistente' }) });
+    await expect(
+      generateMetadata({ params: Promise.resolve({ slug: 'inexistente' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
 
-    expect(metadata).toEqual({});
+  it('⚠️ T-PROD-024: propaga un fallo transitorio en vez de cachear metadata degradada', async () => {
+    mockGetArticle.mockRejectedValue(apiError(503));
+
+    await expect(generateMetadata({ params: Promise.resolve({ slug: 'aries' }) })).rejects.toThrow(
+      'boom'
+    );
   });
 });
 

--- a/frontend/src/app/enciclopedia/astrologia/signos/[slug]/page.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/signos/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { cache } from 'react';
+import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 
 import { getArticle, getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
@@ -26,7 +27,23 @@ interface PageProps {
  * `fetch()` y acá abajo hay axios, así que sin `cache()` serían dos requests por
  * página renderizada.
  */
-const getArticleCached = cache((slug: string) => resolveRouteResource(() => getArticle(slug)));
+const ROUTE_CATEGORIES: readonly ArticleCategory[] = [ArticleCategory.ZODIAC_SIGN];
+
+/**
+ * Las 5 rutas de artículo consultan el MISMO `getArticle(slug)`, sin filtrar por
+ * categoría. Sin este chequeo, `/enciclopedia/elementos/aries` devolvía 200 con el
+ * signo Aries: cada artículo quedaba alcanzable como 5 URLs distintas con el mismo
+ * contenido — justo el agrupamiento por duplicado que T-PROD-020 vino a deshacer.
+ */
+const getArticleCached = cache(async (slug: string) => {
+  const article = await resolveRouteResource(() => getArticle(slug));
+
+  if (!ROUTE_CATEGORIES.includes(article.category)) {
+    notFound();
+  }
+
+  return article;
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;

--- a/frontend/src/app/enciclopedia/astrologia/signos/[slug]/page.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/signos/[slug]/page.tsx
@@ -1,7 +1,9 @@
+import { cache } from 'react';
 import type { Metadata } from 'next';
 
 import { getArticle, getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
 import { getArticleMetadata } from '@/lib/metadata/seo';
+import { resolveRouteResource, safeStaticParams } from '@/lib/metadata/route-data';
 import { ROUTES } from '@/lib/constants/routes';
 import { ArticleCategory } from '@/types/encyclopedia-article.types';
 import { ArticleDetailPageContent } from '@/components/features/encyclopedia/ArticleDetailPageContent';
@@ -12,29 +14,35 @@ import { ArticleDetailPageContent } from '@/components/features/encyclopedia/Art
  * Route: /enciclopedia/astrologia/signos/[slug]
  */
 
+/** La enciclopedia es contenido estático; un día de ISR alcanza. */
+export const revalidate = 86400;
+
 interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
+/**
+ * `generateMetadata` y la página resuelven el MISMO artículo. Next solo dedupea
+ * `fetch()` y acá abajo hay axios, así que sin `cache()` serían dos requests por
+ * página renderizada.
+ */
+const getArticleCached = cache((slug: string) => resolveRouteResource(() => getArticle(slug)));
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  try {
-    const article = await getArticle(slug);
-    return getArticleMetadata(article, ROUTES.ENCICLOPEDIA_SIGNO(slug));
-  } catch {
-    return {};
-  }
+
+  return getArticleMetadata(await getArticleCached(slug), ROUTES.ENCICLOPEDIA_SIGNO(slug));
 }
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
-  try {
-    const articles = await getArticlesByCategory(ArticleCategory.ZODIAC_SIGN);
-    return articles.map((article) => ({ slug: article.slug }));
-  } catch {
-    return [];
-  }
+  return safeStaticParams(
+    () => getArticlesByCategory(ArticleCategory.ZODIAC_SIGN),
+    (article) => ({ slug: article.slug })
+  );
 }
 
-export default function SignoDetailPage() {
-  return <ArticleDetailPageContent />;
+export default async function SignoDetailPage({ params }: PageProps) {
+  const { slug } = await params;
+
+  return <ArticleDetailPageContent slug={slug} initialArticle={await getArticleCached(slug)} />;
 }

--- a/frontend/src/app/enciclopedia/elementos/[slug]/page.test.tsx
+++ b/frontend/src/app/enciclopedia/elementos/[slug]/page.test.tsx
@@ -75,6 +75,7 @@ describe('generateMetadata (elementos)', () => {
       slug: 'fuego',
       nameEs: 'Fuego',
       snippet: 'El elemento del fuego.',
+      category: 'element',
     });
 
     const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'fuego' }) });
@@ -90,6 +91,7 @@ describe('generateMetadata (elementos)', () => {
       slug: 'fuego',
       nameEs: 'Fuego',
       snippet,
+      category: 'element',
     });
 
     const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'fuego' }) });
@@ -103,6 +105,7 @@ describe('generateMetadata (elementos)', () => {
       slug: 'fuego',
       nameEs: 'Fuego',
       snippet: 'El elemento del fuego.',
+      category: 'element',
     });
 
     const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'fuego' }) });
@@ -114,7 +117,7 @@ describe('generateMetadata (elementos)', () => {
     });
   });
 
-  it('⚠️ T-PROD-024: un slug inexistente 404ea en vez de servir un 200 genérico', async () => {
+  it('⚠️ T-PROD-024: un slug inexistente corta con notFound() en vez de servir el recurso', async () => {
     mockGetArticle.mockRejectedValue(apiError(404));
 
     await expect(
@@ -128,6 +131,23 @@ describe('generateMetadata (elementos)', () => {
     await expect(generateMetadata({ params: Promise.resolve({ slug: 'aries' }) })).rejects.toThrow(
       'boom'
     );
+  });
+
+  it('⚠️ T-PROD-024: un artículo de otra categoría corta con notFound() en esta ruta', async () => {
+    // Todas las rutas de artículo consultan el mismo `getArticle(slug)`. Sin el
+    // chequeo de categoría, el mismo contenido quedaba alcanzable como 5 URLs
+    // distintas: contenido duplicado ante Google.
+    mockGetArticle.mockResolvedValue({
+      id: 99,
+      slug: 'intruso',
+      nameEs: 'Intruso',
+      snippet: 'De otra sección.',
+      category: 'zodiac_sign',
+    });
+
+    await expect(
+      generateMetadata({ params: Promise.resolve({ slug: 'intruso' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND');
   });
 });
 

--- a/frontend/src/app/enciclopedia/elementos/[slug]/page.test.tsx
+++ b/frontend/src/app/enciclopedia/elementos/[slug]/page.test.tsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { AxiosError, AxiosHeaders } from 'axios';
 
-import ElementoDetailPage, { generateMetadata, generateStaticParams } from './page';
+import { generateMetadata, generateStaticParams } from './page';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
 vi.mock('next/navigation', () => ({
-  useParams: () => ({ slug: 'fuego' }),
+  notFound: () => {
+    throw new Error('NEXT_NOT_FOUND');
+  },
 }));
 
 vi.mock('next/link', () => ({
@@ -50,48 +52,17 @@ vi.mock('@/lib/api/encyclopedia-articles-api', () => ({
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
-describe('ElementoDetailPage (/enciclopedia/elementos/[slug])', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('debe renderizar ArticleDetailView cuando el artículo existe', () => {
-    mockUseArticle.mockReturnValue({
-      data: {
-        id: 5,
-        slug: 'fuego',
-        nameEs: 'Fuego',
-        nameEn: 'Fire',
-        category: 'element',
-        snippet: 'El elemento del fuego.',
-        imageUrl: null,
-        sortOrder: 1,
-        content: '## Fuego',
-        metadata: null,
-        relatedArticles: [],
-        relatedTarotCards: null,
-      },
-      isLoading: false,
-      error: null,
-    });
-
-    render(<ElementoDetailPage />);
-
-    expect(screen.getByTestId('article-detail-view')).toBeInTheDocument();
-  });
-
-  it('debe retornar 404 para slug inexistente', () => {
-    mockUseArticle.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Not found'),
-    });
-
-    render(<ElementoDetailPage />);
-
-    expect(screen.getByText('Artículo no encontrado')).toBeInTheDocument();
-  });
-});
+function apiError(status: number): AxiosError {
+  const error = new AxiosError('boom');
+  error.response = {
+    status,
+    statusText: '',
+    data: null,
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+}
 
 describe('generateMetadata (elementos)', () => {
   beforeEach(() => {
@@ -143,12 +114,20 @@ describe('generateMetadata (elementos)', () => {
     });
   });
 
-  it('debe retornar objeto vacío si el artículo no existe', async () => {
-    mockGetArticle.mockRejectedValue(new Error('Not found'));
+  it('⚠️ T-PROD-024: un slug inexistente 404ea en vez de servir un 200 genérico', async () => {
+    mockGetArticle.mockRejectedValue(apiError(404));
 
-    const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'inexistente' }) });
+    await expect(
+      generateMetadata({ params: Promise.resolve({ slug: 'inexistente' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
 
-    expect(metadata).toEqual({});
+  it('⚠️ T-PROD-024: propaga un fallo transitorio en vez de cachear metadata degradada', async () => {
+    mockGetArticle.mockRejectedValue(apiError(503));
+
+    await expect(generateMetadata({ params: Promise.resolve({ slug: 'aries' }) })).rejects.toThrow(
+      'boom'
+    );
   });
 });
 

--- a/frontend/src/app/enciclopedia/elementos/[slug]/page.tsx
+++ b/frontend/src/app/enciclopedia/elementos/[slug]/page.tsx
@@ -1,7 +1,9 @@
+import { cache } from 'react';
 import type { Metadata } from 'next';
 
 import { getArticle, getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
 import { getArticleMetadata } from '@/lib/metadata/seo';
+import { resolveRouteResource } from '@/lib/metadata/route-data';
 import { ROUTES } from '@/lib/constants/routes';
 import { ArticleCategory } from '@/types/encyclopedia-article.types';
 import { ArticleDetailPageContent } from '@/components/features/encyclopedia/ArticleDetailPageContent';
@@ -14,18 +16,24 @@ import { ArticleDetailPageContent } from '@/components/features/encyclopedia/Art
 
 const ELEMENT_CATEGORIES = [ArticleCategory.ELEMENT, ArticleCategory.MODALITY] as const;
 
+/** La enciclopedia es contenido estático; un día de ISR alcanza. */
+export const revalidate = 86400;
+
 interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
+/**
+ * `generateMetadata` y la página resuelven el MISMO artículo. Next solo dedupea
+ * `fetch()` y acá abajo hay axios, así que sin `cache()` serían dos requests por
+ * página renderizada.
+ */
+const getArticleCached = cache((slug: string) => resolveRouteResource(() => getArticle(slug)));
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  try {
-    const article = await getArticle(slug);
-    return getArticleMetadata(article, ROUTES.ENCICLOPEDIA_ELEMENTO(slug));
-  } catch {
-    return {};
-  }
+
+  return getArticleMetadata(await getArticleCached(slug), ROUTES.ENCICLOPEDIA_ELEMENTO(slug));
 }
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
@@ -39,6 +47,8 @@ export async function generateStaticParams(): Promise<{ slug: string }[]> {
   }
 }
 
-export default function ElementoDetailPage() {
-  return <ArticleDetailPageContent />;
+export default async function ElementoDetailPage({ params }: PageProps) {
+  const { slug } = await params;
+
+  return <ArticleDetailPageContent slug={slug} initialArticle={await getArticleCached(slug)} />;
 }

--- a/frontend/src/app/enciclopedia/elementos/[slug]/page.tsx
+++ b/frontend/src/app/enciclopedia/elementos/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { cache } from 'react';
+import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 
 import { getArticle, getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
@@ -28,7 +29,23 @@ interface PageProps {
  * `fetch()` y acá abajo hay axios, así que sin `cache()` serían dos requests por
  * página renderizada.
  */
-const getArticleCached = cache((slug: string) => resolveRouteResource(() => getArticle(slug)));
+const ROUTE_CATEGORIES: readonly ArticleCategory[] = ELEMENT_CATEGORIES;
+
+/**
+ * Las 5 rutas de artículo consultan el MISMO `getArticle(slug)`, sin filtrar por
+ * categoría. Sin este chequeo, `/enciclopedia/elementos/aries` devolvía 200 con el
+ * signo Aries: cada artículo quedaba alcanzable como 5 URLs distintas con el mismo
+ * contenido — justo el agrupamiento por duplicado que T-PROD-020 vino a deshacer.
+ */
+const getArticleCached = cache(async (slug: string) => {
+  const article = await resolveRouteResource(() => getArticle(slug));
+
+  if (!ROUTE_CATEGORIES.includes(article.category)) {
+    notFound();
+  }
+
+  return article;
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;

--- a/frontend/src/app/enciclopedia/guias/[slug]/page.test.tsx
+++ b/frontend/src/app/enciclopedia/guias/[slug]/page.test.tsx
@@ -75,6 +75,7 @@ describe('generateMetadata (guias)', () => {
       slug: 'guia-numerologia',
       nameEs: 'Guía de Numerología',
       snippet: 'Aprende sobre numerología.',
+      category: 'guide_tarot',
     });
 
     const metadata = await generateMetadata({
@@ -92,6 +93,7 @@ describe('generateMetadata (guias)', () => {
       slug: 'guia-numerologia',
       nameEs: 'Guía de Numerología',
       snippet,
+      category: 'guide_tarot',
     });
 
     const metadata = await generateMetadata({
@@ -107,6 +109,7 @@ describe('generateMetadata (guias)', () => {
       slug: 'guia-numerologia',
       nameEs: 'Guía de Numerología',
       snippet: 'Aprende sobre numerología.',
+      category: 'guide_tarot',
     });
 
     const metadata = await generateMetadata({
@@ -120,7 +123,7 @@ describe('generateMetadata (guias)', () => {
     });
   });
 
-  it('⚠️ T-PROD-024: un slug inexistente 404ea en vez de servir un 200 genérico', async () => {
+  it('⚠️ T-PROD-024: un slug inexistente corta con notFound() en vez de servir el recurso', async () => {
     mockGetArticle.mockRejectedValue(apiError(404));
 
     await expect(
@@ -134,6 +137,23 @@ describe('generateMetadata (guias)', () => {
     await expect(generateMetadata({ params: Promise.resolve({ slug: 'aries' }) })).rejects.toThrow(
       'boom'
     );
+  });
+
+  it('⚠️ T-PROD-024: un artículo de otra categoría corta con notFound() en esta ruta', async () => {
+    // Todas las rutas de artículo consultan el mismo `getArticle(slug)`. Sin el
+    // chequeo de categoría, el mismo contenido quedaba alcanzable como 5 URLs
+    // distintas: contenido duplicado ante Google.
+    mockGetArticle.mockResolvedValue({
+      id: 99,
+      slug: 'intruso',
+      nameEs: 'Intruso',
+      snippet: 'De otra sección.',
+      category: 'zodiac_sign',
+    });
+
+    await expect(
+      generateMetadata({ params: Promise.resolve({ slug: 'intruso' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND');
   });
 });
 

--- a/frontend/src/app/enciclopedia/guias/[slug]/page.test.tsx
+++ b/frontend/src/app/enciclopedia/guias/[slug]/page.test.tsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { AxiosError, AxiosHeaders } from 'axios';
 
-import GuiaDetailPage, { generateMetadata, generateStaticParams } from './page';
+import { generateMetadata, generateStaticParams } from './page';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
 vi.mock('next/navigation', () => ({
-  useParams: () => ({ slug: 'guia-numerologia' }),
+  notFound: () => {
+    throw new Error('NEXT_NOT_FOUND');
+  },
 }));
 
 vi.mock('next/link', () => ({
@@ -50,48 +52,17 @@ vi.mock('@/lib/api/encyclopedia-articles-api', () => ({
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
-describe('GuiaDetailPage (/enciclopedia/guias/[slug])', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('debe renderizar ArticleDetailView cuando el artículo existe', () => {
-    mockUseArticle.mockReturnValue({
-      data: {
-        id: 4,
-        slug: 'guia-numerologia',
-        nameEs: 'Guía de Numerología',
-        nameEn: null,
-        category: 'guide_numerology',
-        snippet: 'Aprende sobre numerología.',
-        imageUrl: null,
-        sortOrder: 1,
-        content: '## Guía de Numerología',
-        metadata: null,
-        relatedArticles: [],
-        relatedTarotCards: null,
-      },
-      isLoading: false,
-      error: null,
-    });
-
-    render(<GuiaDetailPage />);
-
-    expect(screen.getByTestId('article-detail-view')).toBeInTheDocument();
-  });
-
-  it('debe retornar 404 para slug inexistente', () => {
-    mockUseArticle.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: new Error('Not found'),
-    });
-
-    render(<GuiaDetailPage />);
-
-    expect(screen.getByText('Artículo no encontrado')).toBeInTheDocument();
-  });
-});
+function apiError(status: number): AxiosError {
+  const error = new AxiosError('boom');
+  error.response = {
+    status,
+    statusText: '',
+    data: null,
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+}
 
 describe('generateMetadata (guias)', () => {
   beforeEach(() => {
@@ -149,12 +120,20 @@ describe('generateMetadata (guias)', () => {
     });
   });
 
-  it('debe retornar objeto vacío si el artículo no existe', async () => {
-    mockGetArticle.mockRejectedValue(new Error('Not found'));
+  it('⚠️ T-PROD-024: un slug inexistente 404ea en vez de servir un 200 genérico', async () => {
+    mockGetArticle.mockRejectedValue(apiError(404));
 
-    const metadata = await generateMetadata({ params: Promise.resolve({ slug: 'inexistente' }) });
+    await expect(
+      generateMetadata({ params: Promise.resolve({ slug: 'inexistente' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+  });
 
-    expect(metadata).toEqual({});
+  it('⚠️ T-PROD-024: propaga un fallo transitorio en vez de cachear metadata degradada', async () => {
+    mockGetArticle.mockRejectedValue(apiError(503));
+
+    await expect(generateMetadata({ params: Promise.resolve({ slug: 'aries' }) })).rejects.toThrow(
+      'boom'
+    );
   });
 });
 

--- a/frontend/src/app/enciclopedia/guias/[slug]/page.tsx
+++ b/frontend/src/app/enciclopedia/guias/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { cache } from 'react';
+import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 
 import { getArticle, getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
@@ -36,7 +37,23 @@ interface PageProps {
  * `fetch()` y acá abajo hay axios, así que sin `cache()` serían dos requests por
  * página renderizada.
  */
-const getArticleCached = cache((slug: string) => resolveRouteResource(() => getArticle(slug)));
+const ROUTE_CATEGORIES: readonly ArticleCategory[] = GUIDE_CATEGORIES;
+
+/**
+ * Las 5 rutas de artículo consultan el MISMO `getArticle(slug)`, sin filtrar por
+ * categoría. Sin este chequeo, `/enciclopedia/elementos/aries` devolvía 200 con el
+ * signo Aries: cada artículo quedaba alcanzable como 5 URLs distintas con el mismo
+ * contenido — justo el agrupamiento por duplicado que T-PROD-020 vino a deshacer.
+ */
+const getArticleCached = cache(async (slug: string) => {
+  const article = await resolveRouteResource(() => getArticle(slug));
+
+  if (!ROUTE_CATEGORIES.includes(article.category)) {
+    notFound();
+  }
+
+  return article;
+});
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;

--- a/frontend/src/app/enciclopedia/guias/[slug]/page.tsx
+++ b/frontend/src/app/enciclopedia/guias/[slug]/page.tsx
@@ -1,7 +1,9 @@
+import { cache } from 'react';
 import type { Metadata } from 'next';
 
 import { getArticle, getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
 import { getArticleMetadata } from '@/lib/metadata/seo';
+import { resolveRouteResource } from '@/lib/metadata/route-data';
 import { ROUTES } from '@/lib/constants/routes';
 import { ArticleCategory } from '@/types/encyclopedia-article.types';
 import { ArticleDetailPageContent } from '@/components/features/encyclopedia/ArticleDetailPageContent';
@@ -22,18 +24,24 @@ const GUIDE_CATEGORIES = [
   ArticleCategory.GUIDE_CHINESE,
 ] as const;
 
+/** La enciclopedia es contenido estático; un día de ISR alcanza. */
+export const revalidate = 86400;
+
 interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
+/**
+ * `generateMetadata` y la página resuelven el MISMO artículo. Next solo dedupea
+ * `fetch()` y acá abajo hay axios, así que sin `cache()` serían dos requests por
+ * página renderizada.
+ */
+const getArticleCached = cache((slug: string) => resolveRouteResource(() => getArticle(slug)));
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  try {
-    const article = await getArticle(slug);
-    return getArticleMetadata(article, ROUTES.ENCICLOPEDIA_GUIA(slug));
-  } catch {
-    return {};
-  }
+
+  return getArticleMetadata(await getArticleCached(slug), ROUTES.ENCICLOPEDIA_GUIA(slug));
 }
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
@@ -47,6 +55,8 @@ export async function generateStaticParams(): Promise<{ slug: string }[]> {
   }
 }
 
-export default function GuiaDetailPage() {
-  return <ArticleDetailPageContent />;
+export default async function GuiaDetailPage({ params }: PageProps) {
+  const { slug } = await params;
+
+  return <ArticleDetailPageContent slug={slug} initialArticle={await getArticleCached(slug)} />;
 }

--- a/frontend/src/app/enciclopedia/tarot/[slug]/page.test.tsx
+++ b/frontend/src/app/enciclopedia/tarot/[slug]/page.test.tsx
@@ -74,7 +74,7 @@ describe('/enciclopedia/tarot/[slug] — metadata', () => {
     expect(metadata.alternates?.canonical).toBe('/enciclopedia/tarot/el-loco');
   });
 
-  it('⚠️ T-PROD-020: un slug inexistente 404ea en vez de servir un 200 genérico', async () => {
+  it('⚠️ T-PROD-020: un slug inexistente corta con notFound() en vez de servir el recurso', async () => {
     mockGetCardBySlug.mockRejectedValue(apiError(404));
 
     await expect(

--- a/frontend/src/app/rituales/[slug]/metadata.test.ts
+++ b/frontend/src/app/rituales/[slug]/metadata.test.ts
@@ -58,7 +58,7 @@ describe('/rituales/[slug] — metadata', () => {
     expect(metadata.alternates?.canonical).toBe('/rituales/bano-de-luna');
   });
 
-  it('un slug inexistente 404ea en vez de servir un 200 con metadata genérica', async () => {
+  it('un slug inexistente corta con notFound() en vez de servir metadata genérica', async () => {
     mockGetRitualBySlug.mockRejectedValue(apiError(404));
 
     await expect(

--- a/frontend/src/app/rituales/[slug]/page.tsx
+++ b/frontend/src/app/rituales/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import type { Metadata } from 'next';
 
 import { RitualDetailPage } from '@/components/features/rituals';
@@ -18,16 +19,21 @@ interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
+/** `generateMetadata` y la página piden el mismo ritual; `cache()` evita el doble fetch. */
+const getRitualCached = cache((slug: string) => resolveRouteResource(() => getRitualBySlug(slug)));
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
 
-  return getRitualDetailMetadata(await resolveRouteResource(() => getRitualBySlug(slug)));
+  return getRitualDetailMetadata(await getRitualCached(slug));
 }
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
   return safeStaticParams(getRituals, (ritual) => ({ slug: ritual.slug }));
 }
 
-export default function Page() {
-  return <RitualDetailPage />;
+export default async function Page({ params }: PageProps) {
+  const { slug } = await params;
+
+  return <RitualDetailPage slug={slug} initialRitual={await getRitualCached(slug)} />;
 }

--- a/frontend/src/app/servicios/[slug]/page.test.tsx
+++ b/frontend/src/app/servicios/[slug]/page.test.tsx
@@ -59,7 +59,7 @@ describe('/servicios/[slug] — metadata', () => {
     expect(metadata.alternates?.canonical).toBe('/servicios/registros-akashicos');
   });
 
-  it('un slug inexistente 404ea en vez de servir un 200 genérico', async () => {
+  it('un slug inexistente corta con notFound() en vez de servir el recurso', async () => {
     mockGetDetail.mockRejectedValue(apiError(404));
 
     await expect(

--- a/frontend/src/app/servicios/[slug]/page.tsx
+++ b/frontend/src/app/servicios/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import type { Metadata } from 'next';
 
 import { ServiceDetailPage } from '@/components/features/holistic-services';
@@ -18,10 +19,15 @@ interface Props {
   params: Promise<{ slug: string }>;
 }
 
+/** `generateMetadata` y la página piden el mismo servicio; `cache()` evita el doble fetch. */
+const getServiceCached = cache((slug: string) =>
+  resolveRouteResource(() => getHolisticServiceDetail(slug))
+);
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
 
-  return getServiceDetailMetadata(await resolveRouteResource(() => getHolisticServiceDetail(slug)));
+  return getServiceDetailMetadata(await getServiceCached(slug));
 }
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
@@ -30,5 +36,6 @@ export async function generateStaticParams(): Promise<{ slug: string }[]> {
 
 export default async function ServicioDetailRoute({ params }: Props) {
   const { slug } = await params;
-  return <ServiceDetailPage slug={slug} />;
+
+  return <ServiceDetailPage slug={slug} initialService={await getServiceCached(slug)} />;
 }

--- a/frontend/src/components/features/encyclopedia/ArticleDetailPageContent.test.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailPageContent.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ArticleDetailPageContent } from './ArticleDetailPageContent';
+import type { ArticleDetail } from '@/types/encyclopedia-article.types';
+
+/**
+ * Guardarraíl T-PROD-024.
+ *
+ * Este componente sirve las **53 fichas de artículo** de la enciclopedia (signos,
+ * planetas, casas, guías y elementos): el contenido editorial más valioso del
+ * sitio. Traía el artículo por el cliente, así que el HTML que recibía Googlebot
+ * era el skeleton. Medido en producción tras el deploy de T-PROD-022:
+ *
+ *     /enciclopedia/astrologia/signos/geminis   → 5 palabras propias
+ *     /enciclopedia/guias/guia-pendulo          → 7 palabras propias
+ *
+ * La ruta ahora resuelve el artículo en el servidor y lo pasa por `initialArticle`,
+ * el mismo patrón ya probado en producción con la ficha de tarot (T-PROD-020),
+ * que sirve entre 126 y 233 palabras.
+ */
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const mockUseArticle = vi.fn();
+
+vi.mock('@/hooks/api/useEncyclopediaArticles', () => ({
+  useArticle: (slug: string, initialData?: ArticleDetail) => mockUseArticle(slug, initialData),
+}));
+
+vi.mock('@/components/features/encyclopedia/ArticleDetailView', () => ({
+  ArticleDetailView: ({ article }: { article: { nameEs: string; content: string } }) => (
+    <article data-testid="article-detail-view">
+      <h1>{article.nameEs}</h1>
+      <div>{article.content}</div>
+    </article>
+  ),
+}));
+
+const article = {
+  id: 1,
+  slug: 'geminis',
+  nameEs: 'Géminis',
+  content: 'Géminis es un signo de aire regido por Mercurio, curioso y comunicativo.',
+} as ArticleDetail;
+
+describe('ArticleDetailPageContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('⚠️ T-PROD-024: siembra la query con el artículo resuelto en el servidor', () => {
+    mockUseArticle.mockReturnValue({ data: article, isLoading: false, error: null });
+
+    render(<ArticleDetailPageContent slug="geminis" initialArticle={article} />);
+
+    expect(mockUseArticle).toHaveBeenCalledWith('geminis', article);
+  });
+
+  it('⚠️ T-PROD-024: emite el contenido del artículo, no un skeleton', () => {
+    mockUseArticle.mockReturnValue({ data: article, isLoading: false, error: null });
+
+    render(<ArticleDetailPageContent slug="geminis" initialArticle={article} />);
+
+    expect(screen.getByTestId('article-detail-view')).toBeInTheDocument();
+    expect(screen.getByText(/regido por Mercurio/)).toBeInTheDocument();
+  });
+
+  it('muestra el skeleton solo mientras carga', () => {
+    mockUseArticle.mockReturnValue({ data: undefined, isLoading: true, error: null });
+
+    render(<ArticleDetailPageContent slug="geminis" initialArticle={article} />);
+
+    expect(screen.queryByTestId('article-detail-view')).not.toBeInTheDocument();
+  });
+
+  it('muestra el mensaje de no encontrado cuando no hay artículo', () => {
+    mockUseArticle.mockReturnValue({ data: undefined, isLoading: false, error: null });
+
+    render(<ArticleDetailPageContent slug="geminis" initialArticle={article} />);
+
+    expect(screen.getByText('Artículo no encontrado')).toBeInTheDocument();
+  });
+
+  it('mantiene el artículo visible si falla un refetch en background', () => {
+    // Mismo criterio que `CardDetailPageContent`: en React Query v5 un refetch
+    // fallido puebla `error` conservando el `data` bueno.
+    mockUseArticle.mockReturnValue({
+      data: article,
+      isLoading: false,
+      error: new Error('Network'),
+    });
+
+    render(<ArticleDetailPageContent slug="geminis" initialArticle={article} />);
+
+    expect(screen.getByTestId('article-detail-view')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/encyclopedia/ArticleDetailPageContent.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailPageContent.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useParams } from 'next/navigation';
 import Link from 'next/link';
 
 import { ArticleDetailView } from '@/components/features/encyclopedia/ArticleDetailView';
 import { useArticle } from '@/hooks/api/useEncyclopediaArticles';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ROUTES } from '@/lib/constants/routes';
+import type { ArticleDetail } from '@/types/encyclopedia-article.types';
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -14,14 +14,21 @@ import { ROUTES } from '@/lib/constants/routes';
  * ArticleDetailPageContent
  *
  * Shared client component for article detail pages (signos, planetas, casas,
- * guías, elementos). Reads the `slug` param from the URL and fetches + renders
- * the corresponding article via ArticleDetailView.
+ * guías, elementos). Renderiza el artículo vía ArticleDetailView.
+ *
+ * La ruta lo resuelve en el servidor y lo entrega por `initialArticle`: son las
+ * 53 fichas de contenido editorial de la enciclopedia y servían 5 palabras al
+ * crawler porque el artículo se traía por el cliente (T-PROD-024). Mismo patrón
+ * que `CardDetailPageContent`.
  */
-export function ArticleDetailPageContent() {
-  const params = useParams();
-  const slug = params.slug as string;
+interface ArticleDetailPageContentProps {
+  slug: string;
+  /** Artículo resuelto en el servidor. La ruta 404ea si el slug no existe. */
+  initialArticle: ArticleDetail;
+}
 
-  const { data: article, isLoading, error } = useArticle(slug);
+export function ArticleDetailPageContent({ slug, initialArticle }: ArticleDetailPageContentProps) {
+  const { data: article, isLoading } = useArticle(slug, initialArticle);
 
   if (isLoading) {
     return (
@@ -31,7 +38,9 @@ export function ArticleDetailPageContent() {
     );
   }
 
-  if (error || !article) {
+  // Sin `error`: un refetch fallido en background puebla `error` conservando el
+  // `data` bueno, y tirar abajo un artículo ya cargado sería peor.
+  if (!article) {
     return (
       <div className="container mx-auto px-4 py-8 text-center">
         <h1 className="mb-4 text-2xl">Artículo no encontrado</h1>

--- a/frontend/src/components/features/encyclopedia/ArticleDetailPageContent.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleDetailPageContent.tsx
@@ -23,7 +23,7 @@ import type { ArticleDetail } from '@/types/encyclopedia-article.types';
  */
 interface ArticleDetailPageContentProps {
   slug: string;
-  /** Artículo resuelto en el servidor. La ruta 404ea si el slug no existe. */
+  /** Artículo resuelto en el servidor. La ruta corta con notFound() si el slug no existe. */
   initialArticle: ArticleDetail;
 }
 

--- a/frontend/src/components/features/encyclopedia/CardDetailPageContent.tsx
+++ b/frontend/src/components/features/encyclopedia/CardDetailPageContent.tsx
@@ -25,7 +25,7 @@ import type { CardDetail } from '@/types/encyclopedia.types';
 
 interface CardDetailPageContentProps {
   slug: string;
-  /** Carta resuelta en el servidor. La ruta 404ea si el slug no existe. */
+  /** Carta resuelta en el servidor. La ruta corta con notFound() si el slug no existe. */
   initialCard: CardDetail;
 }
 

--- a/frontend/src/components/features/holistic-services/ServiceDetailPage.test.tsx
+++ b/frontend/src/components/features/holistic-services/ServiceDetailPage.test.tsx
@@ -5,6 +5,7 @@
  * User must select a date + time slot before the CTA is enabled.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AxiosError, AxiosHeaders } from 'axios';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -65,6 +66,18 @@ const mockServiceDetail: HolisticServiceDetail = {
   createdAt: '2025-01-01T00:00:00.000Z',
   updatedAt: '2025-01-01T00:00:00.000Z',
 };
+
+function notFoundAxiosError(): AxiosError {
+  const error = new AxiosError('Not found');
+  error.response = {
+    status: 404,
+    statusText: '',
+    data: null,
+    headers: new AxiosHeaders(),
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+}
 
 describe('ServiceDetailPage', () => {
   let queryClient: QueryClient;
@@ -320,7 +333,9 @@ describe('ServiceDetailPage', () => {
       data: undefined,
       isLoading: false,
       isError: true,
-      error: new Error('Servicio no encontrado'),
+      // `getHolisticServiceDetail` preserva el AxiosError original en el 404 para
+      // que la ruta pueda cortar con notFound(); envolverlo daba 500 (T-PROD-024).
+      error: notFoundAxiosError(),
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
     render(<ServiceDetailPage slug="slug-inexistente" initialService={mockServiceDetail} />, {

--- a/frontend/src/components/features/holistic-services/ServiceDetailPage.test.tsx
+++ b/frontend/src/components/features/holistic-services/ServiceDetailPage.test.tsx
@@ -86,7 +86,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     expect(screen.getByTestId('service-detail-page')).toBeInTheDocument();
   });
@@ -99,7 +101,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     expect(
       screen.getByRole('heading', { level: 1, name: 'Árbol Genealógico' })
@@ -114,7 +118,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     expect(screen.getByText(/El trabajo con el árbol genealógico/)).toBeInTheDocument();
   });
@@ -127,7 +133,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     expect(screen.getByText(/15\.000/)).toBeInTheDocument();
     expect(screen.getByText(/ARS/i)).toBeInTheDocument();
@@ -141,7 +149,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     expect(screen.getByText(/90/)).toBeInTheDocument();
     expect(screen.getByText(/min/i)).toBeInTheDocument();
@@ -155,7 +165,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     // Should not show any phone number (e.g. +54...) or text like "número de whatsapp"
     expect(screen.queryByText(/\+54/)).not.toBeInTheDocument();
@@ -170,7 +182,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     const calendar = screen.getByTestId('booking-calendar');
     expect(calendar).toBeInTheDocument();
@@ -185,7 +199,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     const calendar = screen.getByTestId('booking-calendar');
     expect(calendar).toHaveAttribute('data-service-slug', 'arbol-genealogico');
@@ -199,7 +215,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     const calendar = screen.getByTestId('booking-calendar');
     expect(calendar).toHaveAttribute(
@@ -216,7 +234,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     const button = screen.getByTestId('contratar-button');
     expect(button).toBeInTheDocument();
@@ -231,7 +251,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     expect(screen.getByTestId('slot-required-hint')).toBeInTheDocument();
   });
@@ -244,7 +266,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     // Simulate slot selection via BookingCalendar mock
     await userEvent.click(screen.getByTestId('mock-select-slot'));
@@ -265,7 +289,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     await userEvent.click(screen.getByTestId('mock-select-slot'));
 
@@ -282,7 +308,9 @@ describe('ServiceDetailPage', () => {
       error: null,
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     expect(screen.getByTestId('service-detail-skeleton')).toBeInTheDocument();
   });
@@ -295,7 +323,9 @@ describe('ServiceDetailPage', () => {
       error: new Error('Servicio no encontrado'),
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="slug-inexistente" />, { wrapper });
+    render(<ServiceDetailPage slug="slug-inexistente" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     expect(screen.getByTestId('service-detail-not-found')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /volver al catálogo/i })).toBeInTheDocument();
@@ -309,7 +339,9 @@ describe('ServiceDetailPage', () => {
       error: new Error('Network Error'),
     } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServiceDetail>);
 
-    render(<ServiceDetailPage slug="arbol-genealogico" />, { wrapper });
+    render(<ServiceDetailPage slug="arbol-genealogico" initialService={mockServiceDetail} />, {
+      wrapper,
+    });
 
     expect(screen.getByTestId('service-detail-error')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /volver al catálogo/i })).toBeInTheDocument();

--- a/frontend/src/components/features/holistic-services/ServiceDetailPage.tsx
+++ b/frontend/src/components/features/holistic-services/ServiceDetailPage.tsx
@@ -11,6 +11,8 @@
  */
 'use client';
 
+import type { HolisticServiceDetail } from '@/types/holistic-service.types';
+
 import { useState, useCallback } from 'react';
 import Link from 'next/link';
 import { BookingCalendar } from '@/components/features/marketplace/BookingCalendar';
@@ -21,6 +23,8 @@ import { ROUTES } from '@/lib/constants/routes';
 
 interface ServiceDetailPageProps {
   slug: string;
+  /** Servicio resuelto en el servidor; la ruta 404ea si no existe (T-PROD-024). */
+  initialService: HolisticServiceDetail;
 }
 
 // Flavia's tarotistaId — single tarotista MVP
@@ -30,8 +34,13 @@ function formatArs(amount: number): string {
   return amount.toLocaleString('es-AR');
 }
 
-export function ServiceDetailPage({ slug }: ServiceDetailPageProps) {
-  const { data: service, isLoading, isError, error } = useHolisticServiceDetail(slug);
+export function ServiceDetailPage({ slug, initialService }: ServiceDetailPageProps) {
+  const {
+    data: service,
+    isLoading,
+    isError,
+    error,
+  } = useHolisticServiceDetail(slug, initialService);
 
   // Selected slot state — user must pick date + time before paying
   const [selectedDate, setSelectedDate] = useState<string>('');

--- a/frontend/src/components/features/holistic-services/ServiceDetailPage.tsx
+++ b/frontend/src/components/features/holistic-services/ServiceDetailPage.tsx
@@ -20,10 +20,11 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useHolisticServiceDetail } from '@/hooks/api/useHolisticServices';
 import { ROUTES } from '@/lib/constants/routes';
+import { isNotFoundError } from '@/lib/metadata/route-data';
 
 interface ServiceDetailPageProps {
   slug: string;
-  /** Servicio resuelto en el servidor; la ruta 404ea si no existe (T-PROD-024). */
+  /** Servicio resuelto en el servidor; la ruta corta con notFound() si no existe (T-PROD-024). */
   initialService: HolisticServiceDetail;
 }
 
@@ -35,12 +36,7 @@ function formatArs(amount: number): string {
 }
 
 export function ServiceDetailPage({ slug, initialService }: ServiceDetailPageProps) {
-  const {
-    data: service,
-    isLoading,
-    isError,
-    error,
-  } = useHolisticServiceDetail(slug, initialService);
+  const { data: service, isLoading, error } = useHolisticServiceDetail(slug, initialService);
 
   // Selected slot state — user must pick date + time before paying
   const [selectedDate, setSelectedDate] = useState<string>('');
@@ -58,10 +54,28 @@ export function ServiceDetailPage({ slug, initialService }: ServiceDetailPagePro
     ? `${ROUTES.SERVICIO_PAGO(slug)}?date=${encodeURIComponent(selectedDate)}&time=${encodeURIComponent(selectedTime)}`
     : ROUTES.SERVICIO_PAGO(slug);
 
-  // Handle 404 — render client-side not-found state
-  if (isError) {
-    const isNotFound = error instanceof Error && error.message === 'Servicio no encontrado';
-    if (isNotFound) {
+  if (isLoading) {
+    return (
+      <div
+        data-testid="service-detail-skeleton"
+        className="bg-bg-main min-h-screen px-4 py-8 md:px-8"
+      >
+        <Skeleton className="mb-4 h-10 w-3/4" />
+        <Skeleton className="mb-2 h-4 w-full" />
+        <Skeleton className="mb-2 h-4 w-full" />
+        <Skeleton className="mb-2 h-4 w-2/3" />
+        <Skeleton className="mb-8 h-4 w-1/2" />
+        <Skeleton className="h-10 w-40" />
+      </div>
+    );
+  }
+
+  // Sin `isError` como primer guard: con `initialService` sembrado, la única
+  // forma de que `isError` sea true es un refetch en background fallido, y ahí
+  // hay que conservar el servicio bueno en vez de vaciar la página (y perder el
+  // turno que el usuario ya eligió). Mismo criterio que artículo, ritual y carta.
+  if (!service) {
+    if (isNotFoundError(error)) {
       return (
         <div
           data-testid="service-detail-not-found"
@@ -92,26 +106,6 @@ export function ServiceDetailPage({ slug, initialService }: ServiceDetailPagePro
         </Button>
       </div>
     );
-  }
-
-  if (isLoading) {
-    return (
-      <div
-        data-testid="service-detail-skeleton"
-        className="bg-bg-main min-h-screen px-4 py-8 md:px-8"
-      >
-        <Skeleton className="mb-4 h-10 w-3/4" />
-        <Skeleton className="mb-2 h-4 w-full" />
-        <Skeleton className="mb-2 h-4 w-full" />
-        <Skeleton className="mb-2 h-4 w-2/3" />
-        <Skeleton className="mb-8 h-4 w-1/2" />
-        <Skeleton className="h-10 w-40" />
-      </div>
-    );
-  }
-
-  if (!service) {
-    return null;
   }
 
   return (

--- a/frontend/src/components/features/rituals/RitualDetailPage.test.tsx
+++ b/frontend/src/components/features/rituals/RitualDetailPage.test.tsx
@@ -1,5 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Los mocks devuelven solo lo que el componente consume. Se tipan contra el
+// retorno real del hook (sin `any`, prohibido por CLAUDE.md Rule 0).
+type RitualQuery = ReturnType<typeof useRitual>;
+type CompleteRitualMutation = ReturnType<typeof useCompleteRitual>;
 import userEvent from '@testing-library/user-event';
 import { RitualDetailPage } from './RitualDetailPage';
 import { RitualCategory, RitualDifficulty, MaterialType } from '@/types/ritual.types';
@@ -75,23 +80,20 @@ describe('RitualDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useAuthStore as any).mockReturnValue({
+    vi.mocked(useAuthStore).mockReturnValue({
       isAuthenticated: false,
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useRitual as any).mockReturnValue({
+    vi.mocked(useRitual).mockReturnValue({
       data: mockRitual,
       isLoading: false,
       error: null,
-    });
+    } as unknown as RitualQuery);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useCompleteRitual as any).mockReturnValue({
+    vi.mocked(useCompleteRitual).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    });
+    } as unknown as CompleteRitualMutation);
   });
 
   it('renders ritual title', () => {
@@ -101,12 +103,11 @@ describe('RitualDetailPage', () => {
   });
 
   it('shows loading skeleton when loading', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useRitual as any).mockReturnValue({
+    vi.mocked(useRitual).mockReturnValue({
       data: undefined,
       isLoading: true,
       error: null,
-    });
+    } as unknown as RitualQuery);
 
     render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
@@ -115,12 +116,11 @@ describe('RitualDetailPage', () => {
   });
 
   it('shows error message when ritual not found', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useRitual as any).mockReturnValue({
+    vi.mocked(useRitual).mockReturnValue({
       data: null,
       isLoading: false,
       error: new Error('Not found'),
-    });
+    } as unknown as RitualQuery);
 
     render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
@@ -146,8 +146,7 @@ describe('RitualDetailPage', () => {
   });
 
   it('does not show login message when authenticated', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (useAuthStore as any).mockReturnValue({
+    vi.mocked(useAuthStore).mockReturnValue({
       isAuthenticated: true,
     });
 

--- a/frontend/src/components/features/rituals/RitualDetailPage.test.tsx
+++ b/frontend/src/components/features/rituals/RitualDetailPage.test.tsx
@@ -1,15 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import RitualDetailPage from './page';
+import { RitualDetailPage } from './RitualDetailPage';
 import { RitualCategory, RitualDifficulty, MaterialType } from '@/types/ritual.types';
-
-// Mock Next.js router
-vi.mock('next/navigation', () => ({
-  useParams: () => ({
-    slug: 'ritual-luna-nueva',
-  }),
-}));
 
 // Mock hooks
 vi.mock('@/hooks/api/useRituals', () => ({
@@ -102,7 +95,7 @@ describe('RitualDetailPage', () => {
   });
 
   it('renders ritual title', () => {
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.getByText('Ritual de Luna Nueva')).toBeInTheDocument();
   });
@@ -115,7 +108,7 @@ describe('RitualDetailPage', () => {
       error: null,
     });
 
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     // Skeleton should be rendered
     expect(screen.queryByText('Ritual de Luna Nueva')).not.toBeInTheDocument();
@@ -129,25 +122,25 @@ describe('RitualDetailPage', () => {
       error: new Error('Not found'),
     });
 
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.getByText('Ritual no encontrado')).toBeInTheDocument();
   });
 
   it('renders back button', () => {
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.getByText('Rituales')).toBeInTheDocument();
   });
 
   it('renders complete button', () => {
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.getByText('Marcar como Completado')).toBeInTheDocument();
   });
 
   it('shows login message when not authenticated', () => {
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.getByText('Inicia sesión para guardar tu progreso')).toBeInTheDocument();
   });
@@ -158,48 +151,48 @@ describe('RitualDetailPage', () => {
       isAuthenticated: true,
     });
 
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.queryByText('Inicia sesión para guardar tu progreso')).not.toBeInTheDocument();
   });
 
   it('renders purpose section', () => {
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.getByText('Propósito')).toBeInTheDocument();
     expect(screen.getByText('Establecer intenciones para el nuevo ciclo')).toBeInTheDocument();
   });
 
   it('renders preparation section', () => {
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.getByText('Preparación')).toBeInTheDocument();
     expect(screen.getByText('Preparar espacio tranquilo')).toBeInTheDocument();
   });
 
   it('renders materials section', () => {
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.getByText('Materiales Necesarios')).toBeInTheDocument();
     expect(screen.getByText('Vela blanca')).toBeInTheDocument();
   });
 
   it('renders steps section', () => {
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.getByText('Pasos del Ritual')).toBeInTheDocument();
     expect(screen.getByText('Preparar espacio')).toBeInTheDocument();
   });
 
   it('renders closing section', () => {
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.getByText('Cierre del Ritual')).toBeInTheDocument();
     expect(screen.getByText('Agradecer y cerrar')).toBeInTheDocument();
   });
 
   it('renders tips section', () => {
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.getByText('Consejos')).toBeInTheDocument();
     expect(screen.getByText('• Tip 1')).toBeInTheDocument();
@@ -209,7 +202,7 @@ describe('RitualDetailPage', () => {
   it('opens completion modal when button clicked', async () => {
     const user = userEvent.setup();
 
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     const completeButton = screen.getByText('Marcar como Completado');
     await user.click(completeButton);
@@ -219,7 +212,7 @@ describe('RitualDetailPage', () => {
   });
 
   it('renders best time of day', () => {
-    render(<RitualDetailPage />);
+    render(<RitualDetailPage slug="ritual-luna-nueva" initialRitual={mockRitual} />);
 
     expect(screen.getByText('Mejor momento para realizar')).toBeInTheDocument();
     expect(screen.getByText('Noche')).toBeInTheDocument();

--- a/frontend/src/components/features/rituals/RitualDetailPage.tsx
+++ b/frontend/src/components/features/rituals/RitualDetailPage.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { useParams } from 'next/navigation';
 import { ArrowLeft, CheckCircle } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -14,17 +13,22 @@ import {
   RitualsSkeleton,
 } from '@/components/features/rituals';
 import { useRitual, useCompleteRitual } from '@/hooks/api/useRituals';
+import type { RitualDetail } from '@/types/ritual.types';
 import { useAuthStore } from '@/stores/authStore';
 import { useToast } from '@/hooks/utils/useToast';
 import { ROUTES } from '@/lib/constants/routes';
 
-export function RitualDetailPage() {
-  const params = useParams();
-  const slug = params.slug as string;
+interface RitualDetailPageProps {
+  slug: string;
+  /** Ritual resuelto en el servidor; la ruta 404ea si el slug no existe (T-PROD-024). */
+  initialRitual: RitualDetail;
+}
+
+export function RitualDetailPage({ slug, initialRitual }: RitualDetailPageProps) {
   const { toast } = useToast();
 
   const { isAuthenticated } = useAuthStore();
-  const { data: ritual, isLoading, error } = useRitual(slug);
+  const { data: ritual, isLoading } = useRitual(slug, initialRitual);
   const { mutate: completeRitual, isPending } = useCompleteRitual();
 
   const [showCompletedModal, setShowCompletedModal] = useState(false);
@@ -69,7 +73,8 @@ export function RitualDetailPage() {
     );
   }
 
-  if (error || !ritual) {
+  // Sin `error`: un refetch fallido en background conserva el `data` bueno.
+  if (!ritual) {
     return (
       <div className="container mx-auto px-4 py-8 text-center">
         <h1 className="mb-4 text-2xl">Ritual no encontrado</h1>

--- a/frontend/src/components/features/rituals/RitualDetailPage.tsx
+++ b/frontend/src/components/features/rituals/RitualDetailPage.tsx
@@ -20,7 +20,7 @@ import { ROUTES } from '@/lib/constants/routes';
 
 interface RitualDetailPageProps {
   slug: string;
-  /** Ritual resuelto en el servidor; la ruta 404ea si el slug no existe (T-PROD-024). */
+  /** Ritual resuelto en el servidor; la ruta corta con notFound() si el slug no existe (T-PROD-024). */
   initialRitual: RitualDetail;
 }
 

--- a/frontend/src/hooks/api/useEncyclopediaArticles.ts
+++ b/frontend/src/hooks/api/useEncyclopediaArticles.ts
@@ -11,7 +11,7 @@ import {
   getArticlesByCategory,
   globalSearch,
 } from '@/lib/api/encyclopedia-articles-api';
-import type { ArticleCategory } from '@/types/encyclopedia-article.types';
+import type { ArticleCategory, ArticleDetail } from '@/types/encyclopedia-article.types';
 
 const STALE_TIME_STATIC = 1000 * 60 * 60; // 1 hour — static encyclopedia content
 
@@ -36,12 +36,19 @@ export function useArticleSnippet(slug: string) {
   });
 }
 
-export function useArticle(slug: string) {
+/**
+ * @param initialData artículo ya resuelto por la ruta en el servidor. Siembra la
+ *   caché para que el primer render —el HTML que ve Googlebot— traiga el artículo
+ *   en vez del skeleton (T-PROD-024). Con `STALE_TIME_STATIC` no dispara refetch
+ *   inmediato: la enciclopedia es contenido estático.
+ */
+export function useArticle(slug: string, initialData?: ArticleDetail) {
   return useQuery({
     queryKey: articleKeys.detail(slug),
     queryFn: () => getArticle(slug),
     staleTime: STALE_TIME_STATIC,
     enabled: !!slug,
+    initialData,
   });
 }
 

--- a/frontend/src/hooks/api/useHolisticServices.ts
+++ b/frontend/src/hooks/api/useHolisticServices.ts
@@ -5,6 +5,7 @@
  */
 'use client';
 
+import type { HolisticServiceDetail } from '@/types/holistic-service.types';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getHolisticServices,
@@ -53,12 +54,16 @@ export function useHolisticServices() {
  * @param slug - Service slug
  * @returns TanStack Query result with service detail (includes longDescription)
  */
-export function useHolisticServiceDetail(slug: string) {
+/**
+ * @param initialData servicio resuelto por la ruta en el servidor (T-PROD-024).
+ */
+export function useHolisticServiceDetail(slug: string, initialData?: HolisticServiceDetail) {
   return useQuery({
     queryKey: holisticServiceQueryKeys.detail(slug),
     queryFn: () => getHolisticServiceDetail(slug),
     enabled: slug.length > 0,
     staleTime: 5 * 60 * 1000, // 5 minutes
+    initialData,
   });
 }
 

--- a/frontend/src/hooks/api/useHolisticServices.ts
+++ b/frontend/src/hooks/api/useHolisticServices.ts
@@ -64,6 +64,10 @@ export function useHolisticServiceDetail(slug: string, initialData?: HolisticSer
     enabled: slug.length > 0,
     staleTime: 5 * 60 * 1000, // 5 minutes
     initialData,
+    // El precio y la duración cambian desde el admin: sin esto, `initialData` se estampa como recién
+    // traído y con el `staleTime` el cliente NO refetchea al montar, así que la
+    // copia horneada en el HTML (hasta 24 h por el ISR) quedaría fija (T-PROD-024).
+    initialDataUpdatedAt: 0,
   });
 }
 

--- a/frontend/src/hooks/api/useRituals.ts
+++ b/frontend/src/hooks/api/useRituals.ts
@@ -127,6 +127,10 @@ export function useRitual(slug: string, initialData?: RitualDetail) {
     enabled: !!slug,
     staleTime: 1000 * 60 * 30,
     initialData,
+    // El `completionCount` cambia con cada usuario: sin esto, `initialData` se estampa como recién
+    // traído y con el `staleTime` el cliente NO refetchea al montar, así que la
+    // copia horneada en el HTML (hasta 24 h por el ISR) quedaría fija (T-PROD-024).
+    initialDataUpdatedAt: 0,
   });
 }
 

--- a/frontend/src/hooks/api/useRituals.ts
+++ b/frontend/src/hooks/api/useRituals.ts
@@ -11,7 +11,7 @@ import {
   getRitualHistory,
   getRitualStats,
 } from '@/lib/api/rituals-api';
-import type { RitualFilters, CompleteRitualRequest } from '@/types/ritual.types';
+import type { RitualFilters, CompleteRitualRequest, RitualDetail } from '@/types/ritual.types';
 
 /**
  * Query keys for ritual-related queries
@@ -116,12 +116,17 @@ export function useLunarInfo() {
  * const { data: ritual } = useRitual('ritual-luna-nueva');
  * ```
  */
-export function useRitual(slug: string) {
+/**
+ * @param initialData ritual resuelto por la ruta en el servidor, para que el HTML
+ *   inicial traiga el contenido en vez del skeleton (T-PROD-024).
+ */
+export function useRitual(slug: string, initialData?: RitualDetail) {
   return useQuery({
     queryKey: ritualKeys.detail(slug),
     queryFn: () => getRitualBySlug(slug),
     enabled: !!slug,
     staleTime: 1000 * 60 * 30,
+    initialData,
   });
 }
 

--- a/frontend/src/lib/api/holistic-services-api.test.ts
+++ b/frontend/src/lib/api/holistic-services-api.test.ts
@@ -116,10 +116,14 @@ describe('Holistic Services API', () => {
       expect(apiClient.get).toHaveBeenCalledWith('/holistic-services/arbol-genealogico');
     });
 
-    it('should throw "Servicio no encontrado" on 404', async () => {
-      vi.mocked(apiClient.get).mockRejectedValue({ response: { status: 404 } });
+    it('⚠️ T-PROD-024: en 404 re-lanza el error ORIGINAL, no uno plano', async () => {
+      // `isNotFoundError` de `route-data.ts` necesita el AxiosError para distinguir
+      // "no existe" (→ notFound) de un fallo transitorio (→ se propaga). Envolverlo
+      // en un `Error` plano hacía que `/servicios/inventado` devolviera 500.
+      const original = { response: { status: 404 } };
+      vi.mocked(apiClient.get).mockRejectedValue(original);
 
-      await expect(getHolisticServiceDetail('no-existe')).rejects.toThrow('Servicio no encontrado');
+      await expect(getHolisticServiceDetail('no-existe')).rejects.toBe(original);
     });
 
     it('should throw generic error on non-404 failures', async () => {

--- a/frontend/src/lib/api/holistic-services-api.ts
+++ b/frontend/src/lib/api/holistic-services-api.ts
@@ -48,7 +48,11 @@ export async function getHolisticServiceDetail(slug: string): Promise<HolisticSe
     if (error && typeof error === 'object' && 'response' in error) {
       const axiosError = error as { response?: { status?: number } };
       if (axiosError.response?.status === 404) {
-        throw new Error('Servicio no encontrado');
+        // Se re-lanza el error ORIGINAL, no uno plano: `isNotFoundError` de
+        // `route-data.ts` necesita el `AxiosError` para distinguir "no existe"
+        // (→ notFound) de un fallo transitorio (→ se propaga). Envolverlo hacía
+        // que `/servicios/inventado` respondiera 500 en vez de 404 (T-PROD-024).
+        throw error;
       }
     }
     throw new Error('Error al obtener detalle del servicio');

--- a/frontend/src/lib/metadata/route-data.ts
+++ b/frontend/src/lib/metadata/route-data.ts
@@ -7,10 +7,14 @@ import { notFound } from 'next/navigation';
  * Existen para que las 5 rutas dinámicas no diverjan en el criterio de
  * degradación. La distinción que hacen es la que importa para SEO:
  *
- * - **404 de la API** → el recurso no existe → `notFound()` (un 404 de verdad).
- *   Sin esto, `/enciclopedia/tarot/inventado` respondía **200** con el título
- *   genérico heredado: un soft-404 indexable que suma otra URL al grupo de
- *   duplicadas que T-PROD-020 vino a deshacer.
+ * - **404 de la API** → el recurso no existe → `notFound()`, que corta el render
+ *   y sirve la página de no-encontrado en vez del recurso. Sin esto,
+ *   `/enciclopedia/tarot/inventado` servía el título genérico heredado y sumaba
+ *   otra URL al grupo de duplicadas que T-PROD-020 vino a deshacer.
+ *
+ *   ⚠️ Medido: hoy esas URLs responden **200** con la página de no-encontrado, no
+ *   un 404 HTTP (soft-404). Es preexistente y afecta también a las rutas que ya
+ *   están en producción; queda anotado como pendiente en T-PROD-024.
  * - **Cualquier otro error** (API caída, timeout, 5xx) → se propaga. Es
  *   deliberado: tragarlo dejaría prerenderizada —y cacheada por todo el ISR— una
  *   página con metadata heredada y el esqueleto vacío, exactamente el estado que


### PR DESCRIPTION
## Contexto

Medí las 178 URLs del sitemap como Googlebot **después** del primer deploy exitoso. Muestra estratificada de 62, descontando las 39 palabras de header+footer: **solo 13 superaban las 150 palabras propias.**

Las 79 fichas de tarot estaban bien (126–233 palabras — el SSR de T-PROD-020 funcionó). El resto no:

| Grupo | URLs | Palabras propias |
| --- | --- | --- |
| **Artículos de enciclopedia** (signos, planetas, casas, guías, elementos) | **53** | 5–11 |
| Fichas de ritual y servicio | 9 | 7–9 |
| Horóscopo chino por animal | 12 | 3 |
| Signos del horóscopo | 12 | 31 |

Los 53 artículos son **el contenido editorial del sitio** —el argumento más fuerte ante AdSense— y Google los veía vacíos: el `<title>` estaba bien desde T-PROD-020, pero el cuerpo lo traía el cliente.

## Cambios

Se replica el patrón ya probado **en producción** con la ficha de tarot:

- `useArticle`, `useRitual` y `useHolisticServiceDetail` aceptan `initialData`.
- `ArticleDetailPageContent` (un solo componente sirve **las 53 fichas**), `RitualDetailPage` y `ServiceDetailPage` reciben el recurso ya resuelto y siembran la query.
- Las rutas resuelven en el servidor con `cache()` de React —para no duplicar el fetch entre `generateMetadata` y la página— y los helpers de `route-data.ts`: 404 → `notFound()`, error transitorio → se propaga. `revalidate` de 24 h en enciclopedia.

## Verificación: la imagen real contra la API real

Esta vez no me quedé en el build. Levanté la imagen de producción apuntando a la API y medí el HTML:

| URL | Antes | Después |
| --- | --- | --- |
| `/enciclopedia/astrologia/signos/aries` | 5 | **451** |
| `/enciclopedia/guias/guia-pendulo` | 7 | **684** |
| `/enciclopedia/elementos/elemento-agua` | 6 | **464** |
| `/rituales/ritual-luna-nueva` | 7 | **461** |
| `/servicios/arbol-genealogico` | 9 | **282** |
| `/enciclopedia/tarot/the-fool` | 260 | 260 (sin regresión) |

`docker build` reproduciendo Railway: exit 0. Ciclo de calidad: format, lint (0 errores; los 7 warnings preexistentes), type-check (ambos tsconfig), **5514 tests / 435 suites**, `validate-architecture.js` ✅.

## ⚠️ Quedan 27 URLs delgadas, y no son el mismo patrón

Se atacaron 62 de las ~86. Lo que falta necesita trabajo distinto, por eso no entró acá:

- **Horóscopo chino por animal (12 URLs, 3 palabras).** Es el peor caso y tiene **otra causa**: `AnimalHoroscopePage` usa `useSearchParams()` en un client component, lo que **deopta la ruta entera** del prerender estático. Arreglarlo implica separar la ficha estática del animal de la parte interactiva.
- **Signos del horóscopo (12 URLs, 31 palabras).** El horóscopo del día depende del **día calendario local del visitante** (decisión deliberada de T-PROD-020), así que no se resuelve en el servidor. Sí se puede renderizar la ficha estática del signo alrededor.
- **Listados/hubs**: `/enciclopedia/tarot` (24), `/explorar` (20), `/enciclopedia/guias` (13), `/servicios` (5), `/premium` (3).

## Nota sobre los tests actualizados

Los 5 tests de ruta aseveraban `expect(metadata).toEqual({})` ante cualquier error. Ese comportamiento se cambió a propósito (404 → `notFound()`, transitorio → propaga), alineándolos con la ficha de tarot: devolver `{}` dejaba cacheada una página con metadata heredada, que es el bug que T-PROD-020 vino a arreglar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)