### PR TITLE
feat(seo): contenido indexable en las 12 fichas del horóscopo chino (T-SEO-002)

### DIFF
--- a/docs/BACKLOG_SEO_ADSENSE_2026_08.md
+++ b/docs/BACKLOG_SEO_ADSENSE_2026_08.md
@@ -37,11 +37,12 @@ Muestra estratificada de 62 de las 178 URLs del sitemap, midiendo **palabras pro
 | Artículos de enciclopedia (signos, planetas, casas, guías, elementos) | 53 | 400–645 | ✅ |
 | Hubs con texto estático (numerología, carta astral, péndulo, horóscopo, rituales, chino) | ~8 | 215–415 | ✅ |
 | Fichas de ritual y servicio | 9 | 243–422 | ✅ |
-| **Horóscopo chino por animal** | **12** | **3** | ❌ T-SEO-002 |
+| Horóscopo chino por animal | 12 | 3 → **355–401** | ✅ T-SEO-002 (10-ago) |
 | **Signos del horóscopo** | **12** | **31** | ❌ T-SEO-004 |
 | **Listados y hubs** (`/premium` 3, `/servicios` 5, `/explorar` 20, `/enciclopedia/tarot` 24, `/enciclopedia/guias` 13) | **5** | 3–24 | ❌ T-SEO-003 |
 
 **29 de 62 URLs muestreadas superan las 150 palabras propias** (antes de este trabajo: 13).
+Con T-SEO-002 cerrada, **41 de 62**: los 12 animales del horóscopo chino pasaron de 3 a 355–401.
 
 ### El patrón que ya funciona (replicalo, no inventes otro)
 
@@ -141,7 +142,7 @@ lógica en `app/`.
 | ID | Tarea | Tipo | Prioridad | Estimación |
 | --- | --- | --- | --- | --- |
 | T-SEO-001 | Guardarraíl automático de contenido indexable ✅ | Frontend/CI | 🔴 Crítica | 2 pts |
-| T-SEO-002 | Horóscopo chino por animal: 12 URLs sirven 3 palabras | Frontend | 🔴 Crítica | 3 pts |
+| T-SEO-002 | Horóscopo chino por animal: 12 URLs sirven 3 palabras ✅ | Frontend | 🔴 Crítica | 3 pts |
 | T-SEO-003 | Listados y hubs sin contenido para el crawler | Frontend | 🟠 Alta | 2 pts |
 | T-SEO-004 | Signos del horóscopo: ficha estática del signo | Frontend | 🟠 Alta | 2 pts |
 | T-SEO-005 | El build de Docker no usa lockfile (deriva de dependencias) | Infra | 🟠 Alta | 2 pts |
@@ -243,6 +244,7 @@ miden 34 URLs y **aparecen las 10 clases de problema**, no un subconjunto.
 ## T-SEO-002: Horóscopo Chino — 12 URLs Sirven 3 Palabras
 
 **Prioridad:** 🔴 Crítica · **Estimación:** 3 pts · **Dependencias:** conviene tener T-SEO-001
+**Estado:** ✅ COMPLETADA (10-ago-2026)
 
 ### Problema
 
@@ -258,21 +260,58 @@ Next no puede generar HTML porque el árbol depende de la query string. Por eso 
 
 Separar lo estático de lo interactivo:
 
-- [ ] La ficha del animal (nombre, emoji, elemento, características, años de nacimiento) sale de
-      constantes locales — `CHINESE_ZODIAC_INFO` en
-      [chinese-zodiac.ts](../frontend/src/lib/utils/chinese-zodiac.ts) — así que **puede renderizarse en el
-      servidor sin tocar la API**. Ése es el contenido indexable.
-- [ ] La predicción del año (que depende del elemento elegido y de la sesión) queda client-side, envuelta
-      en `<Suspense>` para que el `useSearchParams` no arrastre a toda la ruta.
-- [ ] Revisar si el modal de selección de elemento puede aparecer *después* del contenido en lugar de
-      bloquearlo.
-- [ ] `generateStaticParams` ya existe y devuelve los 12 animales; verificar que el prerender los emita.
+- [x] La ficha del animal se renderiza en el servidor sin tocar la API. `CHINESE_ZODIAC_INFO` alcanzaba
+      para el encabezado pero no para 150 palabras (son ~10), así que el contenido propio se escribió en
+      [chinese-zodiac-profiles.data.ts](../frontend/src/lib/constants/chinese-zodiac-profiles.data.ts):
+      titular, dos párrafos de introducción, tres rasgos explicados, fortalezas, desafíos, amor, trabajo,
+      compatibilidades y datos de suerte, **únicos por animal**.
+- [x] La predicción del año queda client-side (`AnimalHoroscopePanel`), dentro de un `<Suspense>` en
+      `AnimalHoroscopeRoute`. Ése es el corte que permite prerenderizar el resto.
+- [x] El modal ya no bloquea: arranca cerrado y se abre con un botón (*Elegir mi elemento*) desde un
+      aviso inline. Ver *Decisión de UX* abajo.
+- [x] `generateStaticParams` emite los 12 animales: el build los lista como `●` (SSG) con `revalidate` de
+      1 día.
 
 ### Criterios de aceptación
 
-- [ ] Las 12 URLs superan las 150 palabras propias, medido con el método de *Cómo verificar*.
-- [ ] El selector de elemento y la predicción siguen funcionando igual para el usuario.
-- [ ] `getChineseZodiacMetadata` sigue dando títulos únicos por animal (T-PROD-020, no romperlo).
+- [x] Las 12 URLs superan las 150 palabras propias: **355–401** (antes 3), medido contra el build de
+      producción con el chrome en 39 palabras. Verificado también con
+      `npm run check:indexable --base-url http://localhost:3099`: las 12 en ✅.
+- [x] El selector de elemento y la predicción siguen funcionando: mismo `ElementSelectorModal`, mismo
+      `handleElementSelect`, misma navegación con `?element=`. Cambia **cuándo** se abre el modal.
+- [x] `getChineseZodiacMetadata` intacto: títulos únicos verificados en el HTML servido
+      (`Horóscopo Chino: Rata` / `: Dragón` / `: Cerdo`) y canonical propio por URL.
+
+### Decisión de UX: el modal ya no se auto-abre
+
+Antes, al entrar a la ficha sin `?element=`, el modal se abría solo. Con la ficha nueva eso es un
+problema doble: tapa el contenido con el overlay y, además, Radix marca `aria-hidden` en el resto del
+documento mientras el diálogo está abierto, así que las 380 palabras recién agregadas quedaban fuera del
+árbol de accesibilidad. Ahora la ficha se lee primero y aparece un aviso con dos salidas: *Elegir mi
+elemento* (abre el mismo modal) y el enlace al calculador. Se eliminó el estado `userDismissedModal`, que
+existía solo para no reabrir el modal descartado.
+
+### Notas técnicas
+
+- **La causa era el `useSearchParams` sin límite de Suspense**, como decía el diagnóstico. El árbol quedó
+  así: `page.tsx` (server, `revalidate = 86400`) → `AnimalHoroscopeRoute` (server: valida el segmento,
+  ficha, `<Suspense>`) → `AnimalHoroscopePanel` (`'use client'`, selector + predicción).
+- **`AnimalHoroscopePage` pasó a llamarse `AnimalHoroscopePanel`** (ya no es la página) y perdió el
+  branch de "Animal no válido": esa validación vive ahora en el componente de ruta, en el servidor, con
+  una sola fuente de verdad. El "volver al listado" del encabezado es un `<Link>` real en lugar de un
+  `router.push`, así que el crawler lo recorre.
+- **`ChineseHoroscopeDetail` bajó su `<h1>` a `<h2>`**: el `<h1>` de la página es el de la ficha.
+- **Los años de nacimiento se calculan**, no se hardcodean: `getAnimalBirthYears` en
+  [chinese-zodiac.ts](../frontend/src/lib/utils/chinese-zodiac.ts) los deriva del ciclo de 12 sobre un
+  rango fijo (1936–2043). El rango es fijo a propósito: con `new Date()` el HTML prerenderizado quedaría
+  congelado en el año del build. La ficha aclara que el año chino empieza con el Año Nuevo Chino y deriva
+  al calculador para las fechas de enero/febrero.
+- **Guardarraíl de contenido en los tests**: `getProfileWordCount` + `MIN_PROFILE_WORDS` fallan si un
+  perfil baja de 200 palabras, y hay tests de unicidad de párrafos, de reciprocidad de las afinidades y
+  de que el choque sea el opuesto de la rueda. Si alguien recorta el contenido, se entera en CI y no en
+  el próximo rechazo de AdSense.
+- **El soft-404 sigue vivo** (`/horoscopo-chino/inventado-xyz` responde 200): es T-SEO-006, fuera de
+  alcance acá.
 
 ---
 

--- a/docs/BACKLOG_SEO_ADSENSE_2026_08.md
+++ b/docs/BACKLOG_SEO_ADSENSE_2026_08.md
@@ -313,6 +313,23 @@ existía solo para no reabrir el modal descartado.
 - **El soft-404 sigue vivo** (`/horoscopo-chino/inventado-xyz` responde 200): es T-SEO-006, fuera de
   alcance acá.
 
+### Ajustes tras la revisión
+
+- **Dos bloques de compatibilidad y dos de suerte convivían sin distinguirse.** La ficha trae los datos
+  tradicionales del signo y la predicción trae los del año, y no coinciden (la API guarda dos animales en
+  choque, la tradición uno). Ahora los títulos lo dicen: "Compatibilidad tradicional de X" / "Suerte
+  tradicional del signo X" contra "Afinidades de {año}" / "Elementos de Suerte de {año}".
+  `ChineseCompatibility` acepta un `title` opcional para eso.
+- **El barrel dejó de exportar los componentes de ruta.** `index → AnimalHoroscopeRoute → AnimalHoroscopePanel
+  → index` era un ciclo, y el barrel es lo que un client component importa: un import con side-effect y las
+  536 líneas de perfiles terminan en el bundle del navegador. El panel importa a sus hijos por ruta directa.
+- **`showElementModal` pasó a `needsElementSelection`** en el hook: ya no controla ningún modal.
+  Se eliminó también `isValidAnimal`, que quedó sin consumidores cuando la validación se fue al servidor.
+- **Se sacó el `revalidate = 86400`**: el HTML sale entero de constantes del repo, así que un ISR diario
+  regeneraba 12 URLs por día para producir el mismo byte.
+- **El aviso de "elegí tu elemento" ya no parpadea** para el usuario autenticado en su propio animal: el
+  hook expone `isResolvingUserAnimal` y el panel espera esa resolución.
+
 ---
 
 ## T-SEO-003: Listados y Hubs sin Contenido para el Crawler

--- a/frontend/src/app/horoscopo-chino/[animal]/page.test.tsx
+++ b/frontend/src/app/horoscopo-chino/[animal]/page.test.tsx
@@ -1,9 +1,17 @@
+/**
+ * `/horoscopo-chino/[animal]` - Tests de la ruta.
+ *
+ * Desde T-SEO-002 la ruta es un server component: resuelve el segmento y delega
+ * en `AnimalHoroscopeRoute`, que sirve la ficha estática y monta la parte
+ * interactiva dentro de un `<Suspense>`.
+ */
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-import ChineseHoroscopeAnimalPage from './page';
+import Page, { generateStaticParams } from './page';
 import { ChineseZodiacAnimal, ChineseElementCode } from '@/types/chinese-horoscope.types';
 
 // Mock next/navigation
@@ -43,7 +51,6 @@ vi.mock('@/hooks/api/useChineseHoroscope', () => ({
   useCalculateAnimal: (birthDate: string | null) => mockUseCalculateAnimal(birthDate),
 }));
 
-// Test wrapper
 function createTestQueryClient() {
   return new QueryClient({
     defaultOptions: {
@@ -55,10 +62,39 @@ function createTestQueryClient() {
   });
 }
 
-function renderWithProviders(ui: React.ReactElement) {
-  const queryClient = createTestQueryClient();
-  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+/** Renderiza el server component ya resuelto, con los providers de cliente. */
+async function renderPage(animal: string) {
+  mockParams.animal = animal;
+  const ui = await Page({ params: Promise.resolve({ animal }) });
+
+  return render(<QueryClientProvider client={createTestQueryClient()}>{ui}</QueryClientProvider>);
 }
+
+const mockHoroscope = {
+  id: 1,
+  animal: ChineseZodiacAnimal.DRAGON,
+  birthElement: 'wood' as ChineseElementCode,
+  year: 2026,
+  generalOverview: 'Test overview for dragon',
+  areas: {
+    love: { content: 'Love content', score: 8 },
+    career: { content: 'Career content', score: 7 },
+    wellness: { content: 'Wellness content', score: 9 },
+    finance: { content: 'Finance content', score: 6 },
+  },
+  luckyElements: {
+    numbers: [3, 7, 9],
+    colors: ['Rojo', 'Dorado'],
+    directions: ['Sur', 'Este'],
+    months: [3, 6, 9],
+  },
+  compatibility: {
+    best: [ChineseZodiacAnimal.RAT],
+    good: [ChineseZodiacAnimal.MONKEY],
+    challenging: [ChineseZodiacAnimal.DOG],
+  },
+  monthlyHighlights: 'Test highlights',
+};
 
 describe('ChineseHoroscopeAnimalPage', () => {
   beforeEach(() => {
@@ -68,253 +104,156 @@ describe('ChineseHoroscopeAnimalPage', () => {
     mockParams.animal = 'dragon';
     mockAuthStore.user = null;
     mockAuthStore.isAuthenticated = false;
-    mockUseCalculateAnimal.mockReturnValue({
-      data: null,
-      isLoading: false,
-    });
-  });
-
-  it('should render animal selector', () => {
-    mockUseMyAnimalHoroscope.mockReturnValue({
-      isLoading: false,
-      data: null,
-      error: null,
-    });
+    mockUseCalculateAnimal.mockReturnValue({ data: null, isLoading: false });
+    mockUseMyAnimalHoroscope.mockReturnValue({ isLoading: false, data: null, error: null });
     mockUseChineseHoroscopeByElement.mockReturnValue({
       isLoading: false,
       data: null,
       error: null,
     });
-
-    renderWithProviders(<ChineseHoroscopeAnimalPage />);
-
-    expect(screen.getByTestId('chinese-animal-selector')).toBeInTheDocument();
   });
 
-  it('should show ElementSelectorModal when not user animal and no element', () => {
-    mockUseMyAnimalHoroscope.mockReturnValue({
-      isLoading: false,
-      data: null,
-      error: null,
-    });
-    mockUseChineseHoroscopeByElement.mockReturnValue({
-      isLoading: false,
-      data: null,
-      error: null,
+  describe('contenido indexable (T-SEO-002)', () => {
+    it('sirve la ficha estática del animal sin depender de la API', async () => {
+      const { container } = await renderPage('dragon');
+
+      expect(screen.getByTestId('animal-profile')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 1, name: /Dragón/ })).toBeInTheDocument();
+
+      const words = (container.textContent ?? '').replace(/\s+/g, ' ').trim().split(' ');
+      expect(words.length).toBeGreaterThan(150);
     });
 
-    renderWithProviders(<ChineseHoroscopeAnimalPage />);
+    it('mantiene un solo h1 en la página', async () => {
+      mockSearchParams.get.mockReturnValue('wood');
+      mockUseChineseHoroscopeByElement.mockReturnValue({
+        isLoading: false,
+        data: mockHoroscope,
+        error: null,
+      });
 
-    // Should show the element selector modal
-    expect(screen.getByTestId('element-selector-modal')).toBeInTheDocument();
-    expect(screen.getByText(/Selecciona tu elemento/i)).toBeInTheDocument();
+      await renderPage('dragon');
+
+      expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    });
+
+    it('prerenderiza los 12 animales', () => {
+      expect(generateStaticParams()).toHaveLength(12);
+    });
   });
 
-  it('should render loading state when fetching horoscope', () => {
-    mockSearchParams.get.mockReturnValue('wood');
-    mockUseMyAnimalHoroscope.mockReturnValue({
-      isLoading: false,
-      data: null,
-      error: null,
-    });
-    mockUseChineseHoroscopeByElement.mockReturnValue({
-      isLoading: true,
-      data: null,
-      error: null,
+  describe('parte interactiva', () => {
+    it('should render animal selector', async () => {
+      await renderPage('dragon');
+
+      expect(screen.getByTestId('chinese-animal-selector')).toBeInTheDocument();
     });
 
-    renderWithProviders(<ChineseHoroscopeAnimalPage />);
+    it('invita a elegir el elemento sin tapar la ficha con un modal', async () => {
+      await renderPage('dragon');
 
-    expect(screen.getByText('Cargando horóscopo...')).toBeInTheDocument();
+      expect(screen.getByTestId('element-selection-prompt')).toBeInTheDocument();
+      expect(screen.getByText(/Selecciona tu elemento/i)).toBeInTheDocument();
+      expect(screen.queryByTestId('element-selector-modal')).not.toBeInTheDocument();
+    });
+
+    it('abre el selector de elemento al pedirlo', async () => {
+      const user = userEvent.setup();
+      await renderPage('dragon');
+
+      await user.click(screen.getByRole('button', { name: /Elegir mi elemento/i }));
+
+      expect(screen.getByTestId('element-selector-modal')).toBeInTheDocument();
+    });
+
+    it('should render loading state when fetching horoscope', async () => {
+      mockSearchParams.get.mockReturnValue('wood');
+      mockUseChineseHoroscopeByElement.mockReturnValue({
+        isLoading: true,
+        data: null,
+        error: null,
+      });
+
+      await renderPage('dragon');
+
+      expect(screen.getByText('Cargando horóscopo...')).toBeInTheDocument();
+    });
+
+    it('should render error state when horoscope not found', async () => {
+      mockSearchParams.get.mockReturnValue('wood');
+      mockUseChineseHoroscopeByElement.mockReturnValue({
+        isLoading: false,
+        data: null,
+        error: Object.assign(new Error('Not found'), { response: { status: 404 } }),
+      });
+
+      await renderPage('dragon');
+
+      expect(screen.getByText(/horóscopo en preparación/i)).toBeInTheDocument();
+    });
+
+    it('should render horoscope detail when data is loaded', async () => {
+      mockSearchParams.get.mockReturnValue('wood');
+      mockUseChineseHoroscopeByElement.mockReturnValue({
+        isLoading: false,
+        data: mockHoroscope,
+        error: null,
+      });
+
+      await renderPage('dragon');
+
+      expect(screen.getByText('Test overview for dragon')).toBeInTheDocument();
+    });
+
+    it('should show horoscope directly when viewing own animal (isMyAnimal === true)', async () => {
+      mockAuthStore.user = { birthDate: '1988-03-15' };
+      mockAuthStore.isAuthenticated = true;
+      mockUseCalculateAnimal.mockReturnValue({
+        data: {
+          animal: ChineseZodiacAnimal.DRAGON,
+          birthElement: 'earth' as ChineseElementCode,
+        },
+        isLoading: false,
+      });
+      mockUseMyAnimalHoroscope.mockReturnValue({
+        isLoading: false,
+        data: { ...mockHoroscope, generalOverview: 'Tu año como Dragón de Tierra' },
+        error: null,
+      });
+
+      await renderPage('dragon');
+
+      expect(screen.getByText('Tu año como Dragón de Tierra')).toBeInTheDocument();
+    });
   });
 
-  it('should render error state when horoscope not found', () => {
-    mockSearchParams.get.mockReturnValue('wood');
-    mockUseMyAnimalHoroscope.mockReturnValue({
-      isLoading: false,
-      data: null,
-      error: null,
-    });
-    mockUseChineseHoroscopeByElement.mockReturnValue({
-      isLoading: false,
-      data: null,
-      error: Object.assign(new Error('Not found'), { response: { status: 404 } }),
+  describe('animal inválido', () => {
+    it('muestra el mensaje de animal no válido y un enlace al listado', async () => {
+      await renderPage('invalid-animal');
+
+      expect(screen.getByText('Animal no válido')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /Ver todos los animales/i })).toHaveAttribute(
+        'href',
+        '/horoscopo-chino'
+      );
     });
 
-    renderWithProviders(<ChineseHoroscopeAnimalPage />);
+    it('no renderiza la ficha ni el panel para un animal inválido', async () => {
+      await renderPage('invalid-animal');
 
-    expect(screen.getByText(/horóscopo en preparación/i)).toBeInTheDocument();
+      expect(screen.queryByTestId('animal-profile')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('chinese-animal-selector')).not.toBeInTheDocument();
+    });
   });
 
-  it('should render horoscope detail when data is loaded', () => {
-    mockSearchParams.get.mockReturnValue('wood');
-    mockUseMyAnimalHoroscope.mockReturnValue({
-      isLoading: false,
-      data: null,
-      error: null,
+  describe('navegación', () => {
+    it('vuelve al listado con un enlace rastreable', async () => {
+      await renderPage('dragon');
+
+      expect(screen.getByRole('link', { name: /Todos los animales/i })).toHaveAttribute(
+        'href',
+        '/horoscopo-chino'
+      );
     });
-    mockUseChineseHoroscopeByElement.mockReturnValue({
-      isLoading: false,
-      data: {
-        id: 1,
-        animal: ChineseZodiacAnimal.DRAGON,
-        birthElement: 'wood' as ChineseElementCode,
-        year: 2026,
-        generalOverview: 'Test overview for dragon',
-        areas: {
-          love: { content: 'Love content', rating: 8 },
-          career: { content: 'Career content', rating: 7 },
-          wellness: { content: 'Wellness content', rating: 9 },
-          finance: { content: 'Finance content', rating: 6 },
-        },
-        luckyElements: {
-          numbers: [3, 7, 9],
-          colors: ['Rojo', 'Dorado'],
-          directions: ['Sur', 'Este'],
-          months: [3, 6, 9],
-        },
-        compatibility: {
-          best: [ChineseZodiacAnimal.RAT],
-          good: [ChineseZodiacAnimal.MONKEY],
-          challenging: [ChineseZodiacAnimal.DOG],
-        },
-        monthlyHighlights: 'Test highlights',
-      },
-      error: null,
-    });
-
-    renderWithProviders(<ChineseHoroscopeAnimalPage />);
-
-    expect(screen.getByText('Test overview for dragon')).toBeInTheDocument();
-  });
-
-  it('should show invalid animal message for invalid animal', () => {
-    mockParams.animal = 'invalid-animal';
-
-    mockUseMyAnimalHoroscope.mockReturnValue({
-      isLoading: false,
-      data: null,
-      error: null,
-    });
-    mockUseChineseHoroscopeByElement.mockReturnValue({
-      isLoading: false,
-      data: null,
-      error: null,
-    });
-
-    renderWithProviders(<ChineseHoroscopeAnimalPage />);
-
-    expect(screen.getByText('Animal no válido')).toBeInTheDocument();
-    expect(screen.getByText('Ver todos los animales')).toBeInTheDocument();
-  });
-
-  it('should navigate back when clicking back button', async () => {
-    const user = userEvent.setup();
-    mockParams.animal = 'dragon';
-    mockSearchParams.get.mockReturnValue('wood'); // Add element so modal doesn't show
-
-    mockUseMyAnimalHoroscope.mockReturnValue({
-      isLoading: false,
-      data: null,
-      error: null,
-    });
-    mockUseChineseHoroscopeByElement.mockReturnValue({
-      isLoading: false,
-      data: {
-        id: 1,
-        animal: ChineseZodiacAnimal.DRAGON,
-        birthElement: 'wood' as ChineseElementCode,
-        year: 2026,
-        generalOverview: 'Test overview',
-        areas: {
-          love: { content: 'Love content', rating: 8 },
-          career: { content: 'Career content', rating: 7 },
-          wellness: { content: 'Wellness content', rating: 9 },
-          finance: { content: 'Finance content', rating: 6 },
-        },
-        luckyElements: {
-          numbers: [3, 7, 9],
-          colors: ['Rojo', 'Dorado'],
-          directions: ['Sur', 'Este'],
-          months: [3, 6, 9],
-        },
-        compatibility: {
-          best: [ChineseZodiacAnimal.RAT],
-          good: [ChineseZodiacAnimal.MONKEY],
-          challenging: [ChineseZodiacAnimal.DOG],
-        },
-        monthlyHighlights: 'Test highlights',
-      },
-      error: null,
-    });
-
-    renderWithProviders(<ChineseHoroscopeAnimalPage />);
-
-    // Look for "Todos los animales" button
-    const backButton = screen.getByRole('button', { name: /Todos los animales/i });
-    await user.click(backButton);
-
-    expect(mockPush).toHaveBeenCalledWith('/horoscopo-chino');
-  });
-
-  it('should show horoscope directly when viewing own animal (isMyAnimal === true)', () => {
-    mockParams.animal = 'dragon';
-    mockAuthStore.user = { birthDate: '1988-03-15' };
-    mockAuthStore.isAuthenticated = true;
-
-    // User's calculated animal matches the current animal
-    mockUseCalculateAnimal.mockReturnValue({
-      data: {
-        animal: ChineseZodiacAnimal.DRAGON,
-        birthElement: 'earth' as ChineseElementCode,
-      },
-      isLoading: false,
-    });
-
-    mockUseMyAnimalHoroscope.mockReturnValue({
-      isLoading: false,
-      data: {
-        id: 1,
-        animal: ChineseZodiacAnimal.DRAGON,
-        birthElement: 'earth' as ChineseElementCode,
-        year: 2026,
-        generalOverview: 'Tu año como Dragón de Tierra',
-        areas: {
-          love: { content: 'Love content', rating: 8 },
-          career: { content: 'Career content', rating: 7 },
-          wellness: { content: 'Wellness content', rating: 9 },
-          finance: { content: 'Finance content', rating: 6 },
-        },
-        luckyElements: {
-          numbers: [3, 7, 9],
-          colors: ['Rojo', 'Dorado'],
-          directions: ['Sur', 'Este'],
-          months: [3, 6, 9],
-        },
-        compatibility: {
-          best: [ChineseZodiacAnimal.RAT],
-          good: [ChineseZodiacAnimal.MONKEY],
-          challenging: [ChineseZodiacAnimal.DOG],
-        },
-        monthlyHighlights: 'Test highlights',
-      },
-      error: null,
-    });
-
-    mockUseChineseHoroscopeByElement.mockReturnValue({
-      isLoading: false,
-      data: null,
-      error: null,
-    });
-
-    renderWithProviders(<ChineseHoroscopeAnimalPage />);
-
-    // Should NOT show YearInputBanner
-    expect(
-      screen.queryByText(/Ingresa el año de nacimiento para ver el horóscopo personalizado/i)
-    ).not.toBeInTheDocument();
-
-    // Should show the horoscope directly
-    expect(screen.getByText('Tu año como Dragón de Tierra')).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/horoscopo-chino/[animal]/page.tsx
+++ b/frontend/src/app/horoscopo-chino/[animal]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 
-import { AnimalHoroscopePage } from '@/components/features/chinese-horoscope/AnimalHoroscopePage';
+import { AnimalHoroscopeRoute } from '@/components/features/chinese-horoscope/AnimalHoroscopeRoute';
 import {
   INVALID_ROUTE_PARAM_METADATA,
   getChineseZodiacMetadata,
@@ -11,11 +11,21 @@ import { getAllChineseZodiacAnimals, isChineseZodiacAnimal } from '@/lib/utils/c
  * Ficha de horóscopo chino por animal.
  *
  * Route: /horoscopo-chino/[animal]
+ *
+ * Server component (T-SEO-002): la ficha del animal sale de constantes locales y
+ * se prerenderiza. La predicción del año queda tras un `<Suspense>` dentro de
+ * `AnimalHoroscopeRoute`, porque depende de la query string y de la sesión.
  */
 
 interface PageProps {
   params: Promise<{ animal: string }>;
 }
+
+/**
+ * Contenido estático: se revalida a diario para que el ISR no quede congelado
+ * cuando cambie el texto de un perfil.
+ */
+export const revalidate = 86400;
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { animal } = await params;
@@ -31,6 +41,8 @@ export function generateStaticParams(): { animal: string }[] {
   return getAllChineseZodiacAnimals().map((animal) => ({ animal }));
 }
 
-export default function Page() {
-  return <AnimalHoroscopePage />;
+export default async function Page({ params }: PageProps) {
+  const { animal } = await params;
+
+  return <AnimalHoroscopeRoute animal={animal} />;
 }

--- a/frontend/src/app/horoscopo-chino/[animal]/page.tsx
+++ b/frontend/src/app/horoscopo-chino/[animal]/page.tsx
@@ -21,11 +21,9 @@ interface PageProps {
   params: Promise<{ animal: string }>;
 }
 
-/**
- * Contenido estático: se revalida a diario para que el ISR no quede congelado
- * cuando cambie el texto de un perfil.
- */
-export const revalidate = 86400;
+// Sin `revalidate`: el HTML sale entero de constantes del repo, así que solo
+// cambia con un deploy —que ya regenera las páginas—. Un ISR diario regeneraría
+// 12 URLs por día para producir el mismo byte.
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { animal } = await params;

--- a/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePanel.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePanel.test.tsx
@@ -1,5 +1,5 @@
 /**
- * AnimalHoroscopePage - Tests
+ * AnimalHoroscopePanel - Tests
  *
  * Cubre estados: loading, error 404, error 5xx, éxito
  */
@@ -7,7 +7,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { AnimalHoroscopePage } from './AnimalHoroscopePage';
+import { AnimalHoroscopePanel } from './AnimalHoroscopePanel';
 
 // Mock next/navigation
 const mockPush = vi.fn();
@@ -37,7 +37,7 @@ vi.mock('@/lib/constants/routes', () => ({
   },
 }));
 
-function createBaseHookResult(overrides = {}) {
+function createBaseHookResult() {
   return {
     animal: 'rata' as const,
     isValidAnimal: true,
@@ -54,7 +54,7 @@ function createBaseHookResult(overrides = {}) {
   };
 }
 
-describe('AnimalHoroscopePage', () => {
+describe('AnimalHoroscopePanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -66,7 +66,7 @@ describe('AnimalHoroscopePage', () => {
         isLoading: true,
       });
 
-      render(<AnimalHoroscopePage />);
+      render(<AnimalHoroscopePanel />);
 
       expect(screen.getByText(/cargando horóscopo/i)).toBeInTheDocument();
     });
@@ -83,7 +83,7 @@ describe('AnimalHoroscopePage', () => {
         error: error404,
       });
 
-      render(<AnimalHoroscopePage />);
+      render(<AnimalHoroscopePanel />);
 
       expect(screen.getByText(/en preparación/i)).toBeInTheDocument();
     });
@@ -98,7 +98,7 @@ describe('AnimalHoroscopePage', () => {
         error: error404,
       });
 
-      render(<AnimalHoroscopePage />);
+      render(<AnimalHoroscopePanel />);
 
       expect(screen.getByRole('button', { name: /volver al listado/i })).toBeInTheDocument();
     });
@@ -113,7 +113,7 @@ describe('AnimalHoroscopePage', () => {
         error: error404,
       });
 
-      render(<AnimalHoroscopePage />);
+      render(<AnimalHoroscopePanel />);
 
       await userEvent.click(screen.getByRole('button', { name: /volver al listado/i }));
 
@@ -132,7 +132,7 @@ describe('AnimalHoroscopePage', () => {
         error: error500,
       });
 
-      render(<AnimalHoroscopePage />);
+      render(<AnimalHoroscopePanel />);
 
       expect(screen.getByRole('button', { name: /reintentar/i })).toBeInTheDocument();
     });
@@ -147,7 +147,7 @@ describe('AnimalHoroscopePage', () => {
         error: error503,
       });
 
-      render(<AnimalHoroscopePage />);
+      render(<AnimalHoroscopePanel />);
 
       expect(screen.getByTestId('error-server')).toBeInTheDocument();
     });
@@ -160,7 +160,7 @@ describe('AnimalHoroscopePage', () => {
         horoscopeData: { id: 1, year: 2025 },
       });
 
-      render(<AnimalHoroscopePage />);
+      render(<AnimalHoroscopePanel />);
 
       expect(screen.getByTestId('horoscope-detail')).toBeInTheDocument();
     });
@@ -171,7 +171,7 @@ describe('AnimalHoroscopePage', () => {
         horoscopeData: { id: 1, year: 2025 },
       });
 
-      render(<AnimalHoroscopePage />);
+      render(<AnimalHoroscopePanel />);
 
       expect(screen.queryByText(/en preparación/i)).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /reintentar/i })).not.toBeInTheDocument();
@@ -179,16 +179,29 @@ describe('AnimalHoroscopePage', () => {
   });
 
   describe('Estado: animal inválido', () => {
-    it('muestra mensaje de animal no válido', () => {
+    it('no renderiza nada: el mensaje lo sirve AnimalHoroscopeRoute en el servidor', () => {
       mockUseAnimalHoroscopePage.mockReturnValue({
         ...createBaseHookResult(),
         isValidAnimal: false,
         animalInfo: null,
       });
 
-      render(<AnimalHoroscopePage />);
+      render(<AnimalHoroscopePanel />);
 
-      expect(screen.getByText(/animal no válido/i)).toBeInTheDocument();
+      expect(screen.queryByTestId('animal-horoscope-panel')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Contenido indexable (T-SEO-002)', () => {
+    it('no duplica el h1 de la ficha estática', () => {
+      mockUseAnimalHoroscopePage.mockReturnValue({
+        ...createBaseHookResult(),
+        horoscopeData: { id: 1, year: 2025 },
+      });
+
+      render(<AnimalHoroscopePanel />);
+
+      expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePanel.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePanel.test.tsx
@@ -23,10 +23,15 @@ vi.mock('@/hooks/utils/useAnimalHoroscopePage', () => ({
   useAnimalHoroscopePage: () => mockUseAnimalHoroscopePage(),
 }));
 
-// Mock child components to simplify tests
-vi.mock('@/components/features/chinese-horoscope', () => ({
+// Mock child components to simplify tests (por ruta directa: el panel ya no
+// importa del barrel, para no crear un ciclo con el componente de ruta)
+vi.mock('./ChineseHoroscopeDetail', () => ({
   ChineseHoroscopeDetail: () => <div data-testid="horoscope-detail">Detalle horóscopo</div>,
+}));
+vi.mock('./ChineseAnimalSelector', () => ({
   ChineseAnimalSelector: () => <div data-testid="animal-selector">Selector</div>,
+}));
+vi.mock('./ElementSelectorModal', () => ({
   ElementSelectorModal: () => null,
 }));
 
@@ -40,7 +45,6 @@ vi.mock('@/lib/constants/routes', () => ({
 function createBaseHookResult() {
   return {
     animal: 'rata' as const,
-    isValidAnimal: true,
     animalInfo: { nameEs: 'Rata', emoji: '🐭' },
     userAnimal: undefined,
     isMyAnimal: false,
@@ -49,7 +53,8 @@ function createBaseHookResult() {
     isLoading: false,
     error: null,
     currentYear: 2025,
-    showElementModal: false,
+    needsElementSelection: false,
+    isResolvingUserAnimal: false,
     handleElementSelect: vi.fn(),
   };
 }
@@ -182,7 +187,6 @@ describe('AnimalHoroscopePanel', () => {
     it('no renderiza nada: el mensaje lo sirve AnimalHoroscopeRoute en el servidor', () => {
       mockUseAnimalHoroscopePage.mockReturnValue({
         ...createBaseHookResult(),
-        isValidAnimal: false,
         animalInfo: null,
       });
 
@@ -192,16 +196,31 @@ describe('AnimalHoroscopePanel', () => {
     });
   });
 
-  describe('Contenido indexable (T-SEO-002)', () => {
-    it('no duplica el h1 de la ficha estática', () => {
+  describe('Selección de elemento (T-SEO-002)', () => {
+    it('ofrece elegir el elemento sin abrir el modal solo', () => {
       mockUseAnimalHoroscopePage.mockReturnValue({
         ...createBaseHookResult(),
-        horoscopeData: { id: 1, year: 2025 },
+        element: null,
+        needsElementSelection: true,
       });
 
       render(<AnimalHoroscopePanel />);
 
-      expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+      expect(screen.getByTestId('element-selection-prompt')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Elegir mi elemento/i })).toBeInTheDocument();
+    });
+
+    it('no parpadea el aviso mientras se resuelve el animal del usuario', () => {
+      mockUseAnimalHoroscopePage.mockReturnValue({
+        ...createBaseHookResult(),
+        element: null,
+        needsElementSelection: true,
+        isResolvingUserAnimal: true,
+      });
+
+      render(<AnimalHoroscopePanel />);
+
+      expect(screen.queryByTestId('element-selection-prompt')).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePanel.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePanel.tsx
@@ -1,7 +1,15 @@
 /**
- * Chinese Horoscope Animal Detail Page Component
+ * AnimalHoroscopePanel Component
  *
- * Handles the business logic for displaying a specific animal's horoscope
+ * Parte **interactiva** de `/horoscopo-chino/[animal]`: selector de animal,
+ * selector de elemento Wu Xing y predicción del año.
+ *
+ * Depende de `useSearchParams` (el elemento viaja en la query string), así que
+ * `AnimalHoroscopeRoute` lo monta dentro de un `<Suspense>`: sin ese límite, Next
+ * deopta el prerender de **toda** la ruta y las 12 URLs sirven un cascarón vacío
+ * al crawler (T-SEO-002).
+ *
+ * La ficha estática del animal —el contenido indexable— vive en `AnimalProfile`.
  */
 
 'use client';
@@ -29,11 +37,10 @@ function getErrorStatus(error: Error): number | null {
   return err.response?.status ?? null;
 }
 
-export function AnimalHoroscopePage() {
+export function AnimalHoroscopePanel() {
   const router = useRouter();
   const {
     animal,
-    isValidAnimal,
     animalInfo,
     userAnimal,
     element,
@@ -45,77 +52,61 @@ export function AnimalHoroscopePage() {
     handleElementSelect,
   } = useAnimalHoroscopePage();
 
-  // Track if user manually dismissed the modal
-  // Use animal as key to reset state when animal changes
-  const [userDismissedModal, setUserDismissedModal] = useState<Record<string, boolean>>({});
+  // El modal arranca cerrado y se abre a pedido (T-SEO-002).
+  //
+  // Antes se auto-abría cuando faltaba el elemento, y eso tapaba la ficha del
+  // animal: además del overlay visual, Radix marca `aria-hidden` en el resto del
+  // documento mientras el diálogo está abierto, así que el contenido recién
+  // agregado quedaba invisible para lectores de pantalla. Ahora la ficha se lee
+  // primero y el selector es un paso explícito.
+  const [isElementModalOpen, setIsElementModalOpen] = useState(false);
 
-  // Show modal only if:
-  // 1. showElementModal is true (no element and not user's animal)
-  // 2. User hasn't dismissed it yet for this animal
-  const shouldShowModal = showElementModal && !userDismissedModal[animal];
+  // `showElementModal` del hook significa "falta elegir elemento": no es el
+  // animal del usuario y no vino ninguno en la query string.
+  const needsElementSelection = showElementModal;
 
-  const handleModalClose = (open: boolean) => {
-    if (!open) {
-      setUserDismissedModal((prev) => ({ ...prev, [animal]: true }));
-    }
-  };
-
-  // Invalid animal - show error
-  if (!isValidAnimal || !animalInfo) {
-    return (
-      <div className="container mx-auto px-4 py-8 text-center">
-        <h1 className="mb-4 text-2xl">Animal no válido</h1>
-        <Button onClick={() => router.push(ROUTES.HOROSCOPO_CHINO)}>Ver todos los animales</Button>
-      </div>
-    );
+  // La validez del segmento la resuelve `AnimalHoroscopeRoute` en el servidor
+  // (una sola fuente de verdad, y así el mensaje de error también es indexable).
+  if (!animalInfo) {
+    return null;
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() => router.push(ROUTES.HOROSCOPO_CHINO)}
-        className="mb-4"
-      >
-        <ArrowLeft className="mr-2 h-4 w-4" />
-        Todos los animales
-      </Button>
+    <div className="space-y-6" data-testid="animal-horoscope-panel">
+      <ChineseAnimalSelector
+        selectedAnimal={animal}
+        userAnimal={userAnimal}
+        variant="carousel"
+        onSelect={(a) => {
+          router.push(ROUTES.HOROSCOPO_CHINO_ANIMAL(a));
+        }}
+      />
 
-      <div className="mb-8">
-        <ChineseAnimalSelector
-          selectedAnimal={animal}
-          userAnimal={userAnimal}
-          variant="carousel"
-          onSelect={(a) => {
-            router.push(ROUTES.HOROSCOPO_CHINO_ANIMAL(a));
-          }}
-        />
-      </div>
-
-      {/* Show element selector modal when element is missing */}
+      {/* El selector se abre a pedido, sin tapar la ficha */}
       <ElementSelectorModal
-        open={shouldShowModal}
+        open={isElementModalOpen}
         animal={animal}
         animalNameEs={animalInfo.nameEs}
         onSelectElement={handleElementSelect}
-        onOpenChange={handleModalClose}
+        onOpenChange={setIsElementModalOpen}
       />
 
-      {/* Show info message with calculator link when user dismissed modal */}
-      {!element && userDismissedModal[animal] && (
-        <Alert className="mb-6">
+      {needsElementSelection && (
+        <Alert data-testid="element-selection-prompt">
           <Calculator className="h-4 w-4" />
-          <AlertDescription className="flex items-center justify-between">
-            <span>Selecciona tu elemento para ver el horóscopo completo</span>
-            <Button
-              variant="link"
-              size="sm"
-              onClick={() => router.push(ROUTES.HOROSCOPO_CHINO)}
-              className="ml-2"
-            >
-              ¿No sabes tu elemento? Usa el calculador
-            </Button>
+          <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+            <span>
+              Selecciona tu elemento Wu Xing para ver la predicción de {animalInfo.nameEs} para{' '}
+              {currentYear}
+            </span>
+            <span className="flex flex-wrap items-center gap-2">
+              <Button size="sm" onClick={() => setIsElementModalOpen(true)}>
+                Elegir mi elemento
+              </Button>
+              <Button variant="link" size="sm" onClick={() => router.push(ROUTES.HOROSCOPO_CHINO)}>
+                ¿No sabes tu elemento? Usa el calculador
+              </Button>
+            </span>
           </AlertDescription>
         </Alert>
       )}

--- a/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePanel.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalHoroscopePanel.tsx
@@ -20,13 +20,15 @@ import { ArrowLeft, Calculator, Clock, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Spinner } from '@/components/ui/spinner';
-import {
-  ChineseHoroscopeDetail,
-  ChineseAnimalSelector,
-  ElementSelectorModal,
-} from '@/components/features/chinese-horoscope';
 import { useAnimalHoroscopePage } from '@/hooks/utils/useAnimalHoroscopePage';
 import { ROUTES } from '@/lib/constants/routes';
+
+// Imports directos, no por el barrel: el barrel también exporta el componente de
+// ruta, que importa este panel, y el ciclo hace fácil arrastrar al bundle de
+// cliente el contenido estático de las 12 fichas.
+import { ChineseAnimalSelector } from './ChineseAnimalSelector';
+import { ChineseHoroscopeDetail } from './ChineseHoroscopeDetail';
+import { ElementSelectorModal } from './ElementSelectorModal';
 
 interface ErrorWithResponse {
   response?: { status: number };
@@ -48,7 +50,8 @@ export function AnimalHoroscopePanel() {
     isLoading,
     error,
     currentYear,
-    showElementModal,
+    needsElementSelection,
+    isResolvingUserAnimal,
     handleElementSelect,
   } = useAnimalHoroscopePage();
 
@@ -61,9 +64,9 @@ export function AnimalHoroscopePanel() {
   // primero y el selector es un paso explícito.
   const [isElementModalOpen, setIsElementModalOpen] = useState(false);
 
-  // `showElementModal` del hook significa "falta elegir elemento": no es el
-  // animal del usuario y no vino ninguno en la query string.
-  const needsElementSelection = showElementModal;
+  // Mientras se resuelve el animal del usuario no sabemos si va a hacer falta
+  // elegir elemento; sin esperar, el aviso aparece y desaparece solo.
+  const showElementPrompt = needsElementSelection && !isResolvingUserAnimal;
 
   // La validez del segmento la resuelve `AnimalHoroscopeRoute` en el servidor
   // (una sola fuente de verdad, y así el mensaje de error también es indexable).
@@ -91,7 +94,7 @@ export function AnimalHoroscopePanel() {
         onOpenChange={setIsElementModalOpen}
       />
 
-      {needsElementSelection && (
+      {showElementPrompt && (
         <Alert data-testid="element-selection-prompt">
           <Calculator className="h-4 w-4" />
           <AlertDescription className="flex flex-wrap items-center justify-between gap-2">

--- a/frontend/src/components/features/chinese-horoscope/AnimalHoroscopeRoute.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalHoroscopeRoute.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * AnimalHoroscopeRoute - Tests (T-SEO-002)
+ *
+ * Es el componente de ruta (servidor) de `/horoscopo-chino/[animal]`: valida el
+ * segmento, sirve la ficha estática y aísla la parte interactiva en `<Suspense>`
+ * para que su `useSearchParams` no deopte el prerender de toda la ruta.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { AnimalHoroscopeRoute } from './AnimalHoroscopeRoute';
+import { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
+
+vi.mock('./AnimalHoroscopePanel', () => ({
+  AnimalHoroscopePanel: () => <div data-testid="animal-horoscope-panel" />,
+}));
+
+describe('AnimalHoroscopeRoute', () => {
+  describe('animal válido', () => {
+    it('renderiza la ficha estática del animal', () => {
+      render(<AnimalHoroscopeRoute animal={ChineseZodiacAnimal.DRAGON} />);
+
+      expect(screen.getByTestId('animal-profile')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 1, name: /Dragón/ })).toBeInTheDocument();
+    });
+
+    it('renderiza el panel interactivo del horóscopo', () => {
+      render(<AnimalHoroscopeRoute animal={ChineseZodiacAnimal.DRAGON} />);
+
+      expect(screen.getByTestId('animal-horoscope-panel')).toBeInTheDocument();
+    });
+
+    it('sirve la ficha estática antes del panel interactivo', () => {
+      render(<AnimalHoroscopeRoute animal={ChineseZodiacAnimal.DRAGON} />);
+
+      const profile = screen.getByTestId('animal-profile');
+      const panel = screen.getByTestId('animal-horoscope-panel');
+
+      expect(profile.compareDocumentPosition(panel) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING
+      );
+    });
+
+    it('vuelve al listado con un enlace real (rastreable), no con un onClick', () => {
+      render(<AnimalHoroscopeRoute animal={ChineseZodiacAnimal.DRAGON} />);
+
+      expect(screen.getByRole('link', { name: /Todos los animales/i })).toHaveAttribute(
+        'href',
+        '/horoscopo-chino'
+      );
+    });
+  });
+
+  describe('animal inválido', () => {
+    it('muestra el mensaje de animal no válido', () => {
+      render(<AnimalHoroscopeRoute animal="unicornio" />);
+
+      expect(screen.getByText('Animal no válido')).toBeInTheDocument();
+    });
+
+    it('no renderiza la ficha ni el panel', () => {
+      render(<AnimalHoroscopeRoute animal="unicornio" />);
+
+      expect(screen.queryByTestId('animal-profile')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('animal-horoscope-panel')).not.toBeInTheDocument();
+    });
+
+    it('ofrece un enlace al listado de animales', () => {
+      render(<AnimalHoroscopeRoute animal="unicornio" />);
+
+      expect(screen.getByRole('link', { name: /Ver todos los animales/i })).toHaveAttribute(
+        'href',
+        '/horoscopo-chino'
+      );
+    });
+  });
+});

--- a/frontend/src/components/features/chinese-horoscope/AnimalHoroscopeRoute.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalHoroscopeRoute.tsx
@@ -1,0 +1,66 @@
+/**
+ * AnimalHoroscopeRoute Component
+ *
+ * Componente de ruta de `/horoscopo-chino/[animal]` (T-SEO-002).
+ *
+ * Sin `'use client'`: valida el segmento y sirve la ficha estática del animal en
+ * el servidor. Lo interactivo (`AnimalHoroscopePanel`, que usa `useSearchParams`)
+ * queda dentro de un `<Suspense>`, que es el límite que necesita Next para poder
+ * prerenderizar el resto. Antes de este corte, las 12 URLs servían 3 palabras.
+ */
+
+import { Suspense } from 'react';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { ROUTES } from '@/lib/constants/routes';
+import { isChineseZodiacAnimal } from '@/lib/utils/chinese-zodiac';
+
+import { AnimalHoroscopePanel } from './AnimalHoroscopePanel';
+import { AnimalProfile } from './AnimalProfile';
+import { ChineseHoroscopeSkeleton } from './ChineseHoroscopeSkeleton';
+
+export interface AnimalHoroscopeRouteProps {
+  /** Segmento `[animal]` de la URL, todavía sin validar. */
+  animal: string;
+}
+
+/** Mensaje para un segmento que no es uno de los 12 animales. */
+function AnimalNotFound() {
+  return (
+    <div className="container mx-auto px-4 py-8 text-center" data-testid="animal-not-found">
+      <h1 className="mb-4 text-2xl">Animal no válido</h1>
+      <p className="text-muted-foreground mb-6">
+        El zodiaco chino tiene 12 animales y este no es uno de ellos.
+      </p>
+      <Button asChild>
+        <Link href={ROUTES.HOROSCOPO_CHINO}>Ver todos los animales</Link>
+      </Button>
+    </div>
+  );
+}
+
+export function AnimalHoroscopeRoute({ animal }: AnimalHoroscopeRouteProps) {
+  if (!isChineseZodiacAnimal(animal)) {
+    return <AnimalNotFound />;
+  }
+
+  return (
+    <div className="container mx-auto space-y-8 px-4 py-8">
+      {/* Enlace real, no `router.push`: así el crawler recorre el hub desde la ficha. */}
+      <Button asChild variant="ghost" size="sm">
+        <Link href={ROUTES.HOROSCOPO_CHINO}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Todos los animales
+        </Link>
+      </Button>
+
+      <AnimalProfile animal={animal} />
+
+      <Suspense fallback={<ChineseHoroscopeSkeleton />}>
+        <AnimalHoroscopePanel />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/src/components/features/chinese-horoscope/AnimalProfile.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalProfile.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * AnimalProfile - Tests (T-SEO-002)
+ *
+ * La ficha estática del animal es el contenido indexable de
+ * `/horoscopo-chino/[animal]`: se renderiza en el servidor, sin API ni query
+ * string. Los tests miden el texto que llega al HTML, que es exactamente lo que
+ * mide `npm run check:indexable`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { AnimalProfile } from './AnimalProfile';
+import { CHINESE_ZODIAC_PROFILES } from '@/lib/constants/chinese-zodiac-profiles.data';
+import { CHINESE_ZODIAC_INFO, getAnimalBirthYears } from '@/lib/utils/chinese-zodiac';
+import { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
+
+const ANIMALS = Object.values(ChineseZodiacAnimal);
+
+/** Palabras del texto renderizado, con el mismo criterio del script de SEO. */
+function renderedWordCount(container: HTMLElement): number {
+  const text = container.textContent ?? '';
+  return text.replace(/\s+/g, ' ').trim().split(' ').filter(Boolean).length;
+}
+
+describe('AnimalProfile', () => {
+  it('renderiza el contenedor con su data-testid', () => {
+    render(<AnimalProfile animal={ChineseZodiacAnimal.DRAGON} />);
+
+    expect(screen.getByTestId('animal-profile')).toBeInTheDocument();
+  });
+
+  it('usa el nombre del animal como único h1 de la ficha', () => {
+    render(<AnimalProfile animal={ChineseZodiacAnimal.DRAGON} />);
+
+    const headings = screen.getAllByRole('heading', { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]).toHaveTextContent('Dragón');
+  });
+
+  it.each(ANIMALS)('%s: renderiza más de 150 palabras propias', (animal) => {
+    const { container } = render(<AnimalProfile animal={animal} />);
+
+    expect(renderedWordCount(container)).toBeGreaterThan(150);
+  });
+
+  it('renderiza los párrafos de introducción y el titular', () => {
+    const profile = CHINESE_ZODIAC_PROFILES[ChineseZodiacAnimal.TIGER];
+    render(<AnimalProfile animal={ChineseZodiacAnimal.TIGER} />);
+
+    expect(screen.getByText(profile.tagline)).toBeInTheDocument();
+    profile.intro.forEach((paragraph) => {
+      expect(screen.getByText(paragraph)).toBeInTheDocument();
+    });
+  });
+
+  it('renderiza los rasgos de personalidad, fortalezas y desafíos', () => {
+    const profile = CHINESE_ZODIAC_PROFILES[ChineseZodiacAnimal.RAT];
+    render(<AnimalProfile animal={ChineseZodiacAnimal.RAT} />);
+
+    profile.personality.forEach((trait) => {
+      expect(screen.getByText(new RegExp(trait.term))).toBeInTheDocument();
+    });
+    profile.strengths.forEach((strength) => {
+      expect(screen.getByText(strength)).toBeInTheDocument();
+    });
+    profile.challenges.forEach((challenge) => {
+      expect(screen.getByText(challenge)).toBeInTheDocument();
+    });
+  });
+
+  it('renderiza los textos de amor y de trabajo', () => {
+    const profile = CHINESE_ZODIAC_PROFILES[ChineseZodiacAnimal.GOAT];
+    render(<AnimalProfile animal={ChineseZodiacAnimal.GOAT} />);
+
+    expect(screen.getByText(profile.love)).toBeInTheDocument();
+    expect(screen.getByText(profile.career)).toBeInTheDocument();
+  });
+
+  it('enlaza a la ficha de cada animal compatible (enlazado interno)', () => {
+    const { compatibility } = CHINESE_ZODIAC_PROFILES[ChineseZodiacAnimal.SNAKE];
+    render(<AnimalProfile animal={ChineseZodiacAnimal.SNAKE} />);
+
+    [...compatibility.best, ...compatibility.challenging].forEach((partner) => {
+      const link = screen.getByRole('link', {
+        name: new RegExp(CHINESE_ZODIAC_INFO[partner].nameEs, 'i'),
+      });
+      expect(link).toHaveAttribute('href', `/horoscopo-chino/${partner}`);
+    });
+  });
+
+  it('renderiza los años de nacimiento del animal', () => {
+    render(<AnimalProfile animal={ChineseZodiacAnimal.HORSE} />);
+    const years = getAnimalBirthYears(ChineseZodiacAnimal.HORSE);
+
+    years.forEach((year) => {
+      expect(screen.getByText(String(year))).toBeInTheDocument();
+    });
+  });
+
+  it('renderiza el elemento fijo y los datos de la suerte', () => {
+    const profile = CHINESE_ZODIAC_PROFILES[ChineseZodiacAnimal.MONKEY];
+    render(<AnimalProfile animal={ChineseZodiacAnimal.MONKEY} />);
+
+    expect(
+      screen.getByText(new RegExp(CHINESE_ZODIAC_INFO[ChineseZodiacAnimal.MONKEY].element))
+    ).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(profile.luck.direction, 'i'))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(profile.luck.numbers.join(', ')))).toBeInTheDocument();
+  });
+
+  it('advierte que el año chino empieza con el Año Nuevo Chino', () => {
+    render(<AnimalProfile animal={ChineseZodiacAnimal.PIG} />);
+
+    expect(screen.getByText(/Año Nuevo Chino/i)).toBeInTheDocument();
+  });
+
+  it('no renderiza el mismo texto para dos animales distintos', () => {
+    const { container: rat } = render(<AnimalProfile animal={ChineseZodiacAnimal.RAT} />);
+    const ratText = rat.textContent;
+    const { container: ox } = render(<AnimalProfile animal={ChineseZodiacAnimal.OX} />);
+
+    expect(ox.textContent).not.toBe(ratText);
+  });
+});

--- a/frontend/src/components/features/chinese-horoscope/AnimalProfile.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalProfile.tsx
@@ -93,8 +93,8 @@ export function AnimalProfile({ animal }: AnimalProfileProps) {
       </header>
 
       <Card className="space-y-4 p-6">
-        {profile.intro.map((paragraph) => (
-          <p key={paragraph.slice(0, 24)} className="leading-relaxed">
+        {profile.intro.map((paragraph, index) => (
+          <p key={index} className="leading-relaxed">
             {paragraph}
           </p>
         ))}
@@ -137,7 +137,9 @@ export function AnimalProfile({ animal }: AnimalProfileProps) {
       </div>
 
       <section>
-        <h2 className="mb-3 font-serif text-2xl">Compatibilidad de {info.nameEs}</h2>
+        {/* "tradicional" en el título: más abajo, la predicción del año trae su
+            propio bloque de afinidades con datos distintos. */}
+        <h2 className="mb-3 font-serif text-2xl">Compatibilidad tradicional de {info.nameEs}</h2>
         <div className="grid gap-4 md:grid-cols-2">
           <Card className="space-y-3 p-4">
             <h3 className="font-serif text-lg">Mejores afinidades</h3>
@@ -169,7 +171,7 @@ export function AnimalProfile({ animal }: AnimalProfileProps) {
       </section>
 
       <section>
-        <h2 className="mb-3 font-serif text-2xl">Suerte tradicional</h2>
+        <h2 className="mb-3 font-serif text-2xl">Suerte tradicional del signo {info.nameEs}</h2>
         <Card className="p-4">
           <dl className="grid gap-4 sm:grid-cols-3">
             <div>

--- a/frontend/src/components/features/chinese-horoscope/AnimalProfile.tsx
+++ b/frontend/src/components/features/chinese-horoscope/AnimalProfile.tsx
@@ -1,0 +1,192 @@
+/**
+ * AnimalProfile Component
+ *
+ * Ficha estática de un animal del zodiaco chino: el **contenido indexable** de
+ * `/horoscopo-chino/[animal]` (T-SEO-002).
+ *
+ * Sin `'use client'` a propósito. Todo lo que renderiza sale de constantes
+ * locales (`CHINESE_ZODIAC_PROFILES`, `CHINESE_ZODIAC_INFO`), así que se resuelve
+ * en el servidor sin API, sin sesión y sin query string. La predicción del año,
+ * que sí depende de esas tres cosas, vive en `AnimalHoroscopePanel`.
+ */
+
+import Link from 'next/link';
+import { Calculator } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { getChineseZodiacProfile } from '@/lib/constants/chinese-zodiac-profiles.data';
+import { ROUTES } from '@/lib/constants/routes';
+import { CHINESE_ZODIAC_INFO, getAnimalBirthYears } from '@/lib/utils/chinese-zodiac';
+import type { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
+
+import { ChineseAnimalSymbol } from './ChineseAnimalSymbol';
+
+export interface AnimalProfileProps {
+  /** Animal del zodiaco chino cuya ficha se renderiza. */
+  animal: ChineseZodiacAnimal;
+}
+
+/**
+ * Lista de animales enlazados a su propia ficha.
+ * El enlazado interno es parte del objetivo SEO: las 12 URLs se referencian entre sí.
+ */
+function AnimalLinks({ animals }: { animals: ChineseZodiacAnimal[] }) {
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {animals.map((partner) => {
+        const { nameEs } = CHINESE_ZODIAC_INFO[partner];
+
+        return (
+          <li key={partner}>
+            <Link
+              href={ROUTES.HOROSCOPO_CHINO_ANIMAL(partner)}
+              className="hover:border-primary hover:text-primary flex items-center gap-2 rounded-full border px-3 py-1 text-sm transition-colors"
+            >
+              <ChineseAnimalSymbol animal={partner} label={nameEs} className="text-base" />
+              {nameEs}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/** Lista de etiquetas cortas (fortalezas, desafíos, años). */
+function BadgeList({ items, variant }: { items: string[]; variant?: 'secondary' | 'outline' }) {
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {items.map((item) => (
+        <li key={item}>
+          <Badge variant={variant ?? 'secondary'}>{item}</Badge>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * AnimalProfile Component
+ *
+ * @example
+ * ```tsx
+ * <AnimalProfile animal={ChineseZodiacAnimal.DRAGON} />
+ * ```
+ */
+export function AnimalProfile({ animal }: AnimalProfileProps) {
+  const info = CHINESE_ZODIAC_INFO[animal];
+  const profile = getChineseZodiacProfile(animal);
+  const birthYears = getAnimalBirthYears(animal);
+
+  return (
+    <article className="space-y-6" data-testid="animal-profile">
+      <header className="text-center">
+        <ChineseAnimalSymbol animal={animal} label={info.nameEs} className="text-6xl" />
+        <h1 className="mt-2 font-serif text-3xl">{info.nameEs}</h1>
+        <p className="text-muted-foreground mt-2 text-lg">{profile.tagline}</p>
+        <div className="mt-3 flex flex-wrap justify-center gap-2">
+          <Badge variant="secondary">Elemento fijo: {info.element}</Badge>
+          <Badge variant="outline">Zodiaco chino</Badge>
+        </div>
+      </header>
+
+      <Card className="space-y-4 p-6">
+        {profile.intro.map((paragraph) => (
+          <p key={paragraph.slice(0, 24)} className="leading-relaxed">
+            {paragraph}
+          </p>
+        ))}
+      </Card>
+
+      <section>
+        <h2 className="mb-3 font-serif text-2xl">Personalidad del signo {info.nameEs}</h2>
+        <ul className="space-y-3">
+          {profile.personality.map((trait) => (
+            <li key={trait.term} className="flex items-start gap-2">
+              <span className="text-primary">•</span>
+              <span className="text-muted-foreground">
+                <strong className="text-foreground">{trait.term}:</strong> {trait.description}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card className="space-y-3 p-4">
+          <h3 className="font-serif text-lg">Fortalezas</h3>
+          <BadgeList items={profile.strengths} />
+        </Card>
+        <Card className="space-y-3 p-4">
+          <h3 className="font-serif text-lg">Desafíos</h3>
+          <BadgeList items={profile.challenges} variant="outline" />
+        </Card>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card className="space-y-2 p-6">
+          <h2 className="font-serif text-xl">Amor y vínculos</h2>
+          <p className="text-muted-foreground leading-relaxed">{profile.love}</p>
+        </Card>
+        <Card className="space-y-2 p-6">
+          <h2 className="font-serif text-xl">Trabajo y dinero</h2>
+          <p className="text-muted-foreground leading-relaxed">{profile.career}</p>
+        </Card>
+      </div>
+
+      <section>
+        <h2 className="mb-3 font-serif text-2xl">Compatibilidad de {info.nameEs}</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          <Card className="space-y-3 p-4">
+            <h3 className="font-serif text-lg">Mejores afinidades</h3>
+            <AnimalLinks animals={profile.compatibility.best} />
+          </Card>
+          <Card className="space-y-3 p-4">
+            <h3 className="font-serif text-lg">Relación más desafiante</h3>
+            <AnimalLinks animals={profile.compatibility.challenging} />
+          </Card>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-3 font-serif text-2xl">Años del signo {info.nameEs}</h2>
+        <Card className="space-y-4 p-4">
+          <BadgeList items={birthYears.map(String)} variant="outline" />
+          <p className="text-muted-foreground text-sm">
+            El año chino no arranca el 1 de enero: empieza con el Año Nuevo Chino, que cae entre el
+            21 de enero y el 20 de febrero. Si naciste en esa franja, tu animal es el del año
+            anterior.
+          </p>
+          <Button asChild variant="outline" size="sm">
+            <Link href={ROUTES.HOROSCOPO_CHINO}>
+              <Calculator className="mr-2 h-4 w-4" />
+              Calcular mi animal con mi fecha de nacimiento
+            </Link>
+          </Button>
+        </Card>
+      </section>
+
+      <section>
+        <h2 className="mb-3 font-serif text-2xl">Suerte tradicional</h2>
+        <Card className="p-4">
+          <dl className="grid gap-4 sm:grid-cols-3">
+            <div>
+              <dt className="text-muted-foreground text-sm">Números</dt>
+              <dd className="font-medium">{profile.luck.numbers.join(', ')}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground text-sm">Colores</dt>
+              <dd className="font-medium">{profile.luck.colors.join(', ')}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground text-sm">Dirección favorable</dt>
+              <dd className="font-medium">{profile.luck.direction}</dd>
+            </div>
+          </dl>
+        </Card>
+      </section>
+    </article>
+  );
+}

--- a/frontend/src/components/features/chinese-horoscope/ChineseCompatibility.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseCompatibility.tsx
@@ -17,6 +17,14 @@ export interface ChineseCompatibilityProps {
     good: ChineseZodiacAnimal[];
     challenging: ChineseZodiacAnimal[];
   };
+  /**
+   * Encabezado de la tarjeta. Por defecto "Compatibilidad".
+   *
+   * En `/horoscopo-chino/[animal]` conviven dos bloques de compatibilidad —el
+   * tradicional del signo, en `AnimalProfile`, y el del año que trae la API— y
+   * sin títulos distintos el usuario ve datos contradictorios sin explicación.
+   */
+  title?: string;
 }
 
 /**
@@ -36,7 +44,10 @@ export interface ChineseCompatibilityProps {
  * />
  * ```
  */
-export function ChineseCompatibility({ compatibility }: ChineseCompatibilityProps) {
+export function ChineseCompatibility({
+  compatibility,
+  title = 'Compatibilidad',
+}: ChineseCompatibilityProps) {
   const renderAnimals = (animals: ChineseZodiacAnimal[], variantClass: string) => (
     <div className="flex flex-wrap gap-2" data-testid="compatibility-group">
       {animals.map((animal) => {
@@ -61,7 +72,7 @@ export function ChineseCompatibility({ compatibility }: ChineseCompatibilityProp
 
   return (
     <Card className="p-4" data-testid="chinese-compatibility">
-      <h3 className="mb-4 font-serif text-lg">Compatibilidad</h3>
+      <h3 className="mb-4 font-serif text-lg">{title}</h3>
 
       <div className="space-y-4">
         <div>

--- a/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeDetail.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeDetail.test.tsx
@@ -325,8 +325,16 @@ describe('ChineseHoroscopeDetail', () => {
       const horoscope = createMockHoroscope();
       const { container } = render(<ChineseHoroscopeDetail horoscope={horoscope} />);
 
-      const heading = container.querySelector('h1');
+      // h2 y no h1: el h1 de la ficha lo aporta `AnimalProfile` (T-SEO-002).
+      const heading = container.querySelector('h2');
       expect(heading).toHaveClass('font-serif');
+    });
+
+    it('should not render an h1 (el h1 de la página es la ficha estática)', () => {
+      const horoscope = createMockHoroscope();
+      const { container } = render(<ChineseHoroscopeDetail horoscope={horoscope} />);
+
+      expect(container.querySelector('h1')).toBeNull();
     });
 
     it('should use grid layout for areas with md:grid-cols-2', () => {

--- a/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeDetail.test.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeDetail.test.tsx
@@ -175,7 +175,7 @@ describe('ChineseHoroscopeDetail', () => {
       const horoscope = createMockHoroscope();
       render(<ChineseHoroscopeDetail horoscope={horoscope} />);
 
-      expect(screen.getByText('Elementos de Suerte')).toBeInTheDocument();
+      expect(screen.getByText(/Elementos de Suerte de 2026/)).toBeInTheDocument();
     });
 
     it('should display lucky numbers', () => {
@@ -358,7 +358,7 @@ describe('ChineseHoroscopeDetail', () => {
       });
       render(<ChineseHoroscopeDetail horoscope={horoscope} />);
 
-      expect(screen.getByText('Elementos de Suerte')).toBeInTheDocument();
+      expect(screen.getByText(/Elementos de Suerte de 2026/)).toBeInTheDocument();
       // Should render empty strings without errors
       expect(screen.getByText('Números')).toBeInTheDocument();
     });

--- a/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeDetail.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeDetail.tsx
@@ -52,7 +52,8 @@ export function ChineseHoroscopeDetail({ horoscope, element }: ChineseHoroscopeD
           label={animalInfo.nameEs}
           className="text-6xl"
         />
-        <h1 className="mt-2 font-serif text-3xl">{displayName}</h1>
+        {/* h2, no h1: el h1 de `/horoscopo-chino/[animal]` es el de `AnimalProfile`. */}
+        <h2 className="mt-2 font-serif text-3xl">{displayName}</h2>
         <Badge variant="secondary" className="mt-2">
           Horóscopo {horoscope.year}
         </Badge>

--- a/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeDetail.tsx
+++ b/frontend/src/components/features/chinese-horoscope/ChineseHoroscopeDetail.tsx
@@ -85,7 +85,8 @@ export function ChineseHoroscopeDetail({ horoscope, element }: ChineseHoroscopeD
 
       {/* Lucky Elements */}
       <Card className="p-4">
-        <h3 className="mb-4 font-serif text-lg">Elementos de Suerte</h3>
+        {/* Con el año: la ficha del signo ya muestra su suerte tradicional. */}
+        <h3 className="mb-4 font-serif text-lg">Elementos de Suerte de {horoscope.year}</h3>
         <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
           <div>
             <p className="text-muted-foreground text-sm">Números</p>
@@ -107,7 +108,10 @@ export function ChineseHoroscopeDetail({ horoscope, element }: ChineseHoroscopeD
       </Card>
 
       {/* Compatibility */}
-      <ChineseCompatibility compatibility={horoscope.compatibility} />
+      <ChineseCompatibility
+        compatibility={horoscope.compatibility}
+        title={`Afinidades de ${horoscope.year}`}
+      />
 
       {/* Monthly Highlights */}
       {horoscope.monthlyHighlights && (

--- a/frontend/src/components/features/chinese-horoscope/index.ts
+++ b/frontend/src/components/features/chinese-horoscope/index.ts
@@ -35,4 +35,10 @@ export type { YearSelectorModalProps } from './YearSelectorModal';
 export { YearInputBanner } from './YearInputBanner';
 export type { YearInputBannerProps } from './YearInputBanner';
 
-export { AnimalHoroscopePage } from './AnimalHoroscopePage';
+export { AnimalHoroscopePanel } from './AnimalHoroscopePanel';
+
+export { AnimalHoroscopeRoute } from './AnimalHoroscopeRoute';
+export type { AnimalHoroscopeRouteProps } from './AnimalHoroscopeRoute';
+
+export { AnimalProfile } from './AnimalProfile';
+export type { AnimalProfileProps } from './AnimalProfile';

--- a/frontend/src/components/features/chinese-horoscope/index.ts
+++ b/frontend/src/components/features/chinese-horoscope/index.ts
@@ -35,10 +35,7 @@ export type { YearSelectorModalProps } from './YearSelectorModal';
 export { YearInputBanner } from './YearInputBanner';
 export type { YearInputBannerProps } from './YearInputBanner';
 
-export { AnimalHoroscopePanel } from './AnimalHoroscopePanel';
-
-export { AnimalHoroscopeRoute } from './AnimalHoroscopeRoute';
-export type { AnimalHoroscopeRouteProps } from './AnimalHoroscopeRoute';
-
-export { AnimalProfile } from './AnimalProfile';
-export type { AnimalProfileProps } from './AnimalProfile';
+// `AnimalHoroscopeRoute`, `AnimalProfile` y `AnimalHoroscopePanel` se importan
+// por ruta directa a propósito, y no se exportan acá: el componente de ruta es
+// de servidor y arrastra las 12 fichas de contenido estático. Sacarlas del barrel
+// evita que un client component las meta en su bundle sin darse cuenta.

--- a/frontend/src/hooks/utils/useAnimalHoroscopePage.test.tsx
+++ b/frontend/src/hooks/utils/useAnimalHoroscopePage.test.tsx
@@ -75,7 +75,6 @@ describe('useAnimalHoroscopePage', () => {
   it('should mark dragon as valid animal', () => {
     const { result } = renderHook(() => useAnimalHoroscopePage(), { wrapper });
 
-    expect(result.current.isValidAnimal).toBe(true);
     expect(result.current.animalInfo).not.toBeNull();
     expect(result.current.animalInfo?.nameEs).toBe('Dragón');
   });
@@ -85,7 +84,6 @@ describe('useAnimalHoroscopePage', () => {
 
     const { result } = renderHook(() => useAnimalHoroscopePage(), { wrapper });
 
-    expect(result.current.isValidAnimal).toBe(false);
     expect(result.current.animalInfo).toBeNull();
   });
 
@@ -119,14 +117,14 @@ describe('useAnimalHoroscopePage', () => {
     });
   });
 
-  it('should provide showElementModal flag when element is missing', () => {
+  it('should flag needsElementSelection when element is missing', () => {
     const { result } = renderHook(() => useAnimalHoroscopePage(), { wrapper });
 
-    // No element in query and not my animal -> should show modal
-    expect(result.current.showElementModal).toBe(true);
+    // No element in query and not my animal -> hay que elegir elemento
+    expect(result.current.needsElementSelection).toBe(true);
   });
 
-  it('should not show element modal when element is provided in query', async () => {
+  it('should not need element selection when element is provided in query', async () => {
     vi.mocked(useSearchParams).mockReturnValue({
       get: vi.fn((key: string) => (key === 'element' ? 'fire' : null)),
     } as unknown as ReturnType<typeof useSearchParams>);
@@ -134,7 +132,7 @@ describe('useAnimalHoroscopePage', () => {
     const { result } = renderHook(() => useAnimalHoroscopePage(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.showElementModal).toBe(false);
+      expect(result.current.needsElementSelection).toBe(false);
     });
   });
 

--- a/frontend/src/hooks/utils/useAnimalHoroscopePage.ts
+++ b/frontend/src/hooks/utils/useAnimalHoroscopePage.ts
@@ -28,9 +28,11 @@ import type {
 interface UseAnimalHoroscopePageResult {
   /** The current animal from URL params */
   animal: ChineseZodiacAnimal;
-  /** Whether the current animal is valid */
-  isValidAnimal: boolean;
-  /** Animal info from the zodiac constant */
+  /**
+   * Animal info from the zodiac constant, o `null` si el segmento de la URL no
+   * es uno de los 12 animales. Única señal de validez que necesita el panel: el
+   * mensaje de "animal no válido" lo sirve `AnimalHoroscopeRoute` en el servidor.
+   */
   animalInfo: ChineseZodiacInfo | null;
   /** User's own animal (if authenticated) */
   userAnimal: ChineseZodiacAnimal | undefined;
@@ -46,8 +48,10 @@ interface UseAnimalHoroscopePageResult {
   error: Error | null;
   /** Current year for horoscope */
   currentYear: number;
-  /** Whether to show the element selector modal */
-  showElementModal: boolean;
+  /** Whether the user still has to pick a Wu Xing element to see the prediction */
+  needsElementSelection: boolean;
+  /** Whether the user's own animal is still being resolved (auth + API) */
+  isResolvingUserAnimal: boolean;
   /** Handler when user selects an element from modal */
   handleElementSelect: (element: ChineseElementCode) => void;
 }
@@ -78,7 +82,8 @@ export function useAnimalHoroscopePage(): UseAnimalHoroscopePageResult {
   const userBirthDate = user?.birthDate
     ? new Date(user.birthDate).toISOString().split('T')[0]
     : null;
-  const { data: userAnimalData } = useCalculateAnimal(userBirthDate);
+  const { data: userAnimalData, isLoading: isResolvingUserAnimal } =
+    useCalculateAnimal(userBirthDate);
 
   // Determine if user is viewing their own animal
   const isMyAnimal = useMemo(() => {
@@ -96,10 +101,10 @@ export function useAnimalHoroscopePage(): UseAnimalHoroscopePageResult {
     return null;
   }, [elementFromQuery, isMyAnimal, userAnimalData]);
 
-  // Show element selector modal when:
-  // - Not viewing own animal AND
-  // - No element in query params
-  const showElementModal = !isMyAnimal && !element;
+  // Falta elegir elemento cuando no es el animal del usuario y no vino ninguno
+  // en la query string. El panel lo usa para ofrecer el selector, que ya no se
+  // abre solo (T-SEO-002).
+  const needsElementSelection = !isMyAnimal && !element;
 
   // Queries for horoscope data
   // Only fetch my horoscope when viewing own animal (optimization)
@@ -129,12 +134,10 @@ export function useAnimalHoroscopePage(): UseAnimalHoroscopePageResult {
   };
 
   // Validate animal
-  const isValidAnimal = !!CHINESE_ZODIAC_INFO[animal];
-  const animalInfo = isValidAnimal ? CHINESE_ZODIAC_INFO[animal] : null;
+  const animalInfo = CHINESE_ZODIAC_INFO[animal] ?? null;
 
   return {
     animal,
-    isValidAnimal,
     animalInfo,
     userAnimal: userAnimalData?.animal,
     isMyAnimal,
@@ -143,7 +146,8 @@ export function useAnimalHoroscopePage(): UseAnimalHoroscopePageResult {
     isLoading,
     error,
     currentYear,
-    showElementModal,
+    needsElementSelection,
+    isResolvingUserAnimal,
     handleElementSelect,
   };
 }

--- a/frontend/src/lib/constants/chinese-zodiac-profiles.data.test.ts
+++ b/frontend/src/lib/constants/chinese-zodiac-profiles.data.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests de los perfiles estáticos del zodiaco chino (T-SEO-002).
+ *
+ * Estos tests son el guardarraíl de contenido: si alguien recorta un perfil por
+ * debajo del mínimo indexable, o duplica texto entre animales, falla acá y no en
+ * el próximo rechazo de AdSense.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  CHINESE_ZODIAC_PROFILES,
+  MIN_PROFILE_WORDS,
+  getChineseZodiacProfile,
+  getProfileWordCount,
+} from '@/lib/constants/chinese-zodiac-profiles.data';
+import { getAnimalBirthYears } from '@/lib/utils/chinese-zodiac';
+import { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
+
+const ANIMALS = Object.values(ChineseZodiacAnimal);
+const CYCLE_LENGTH = 12;
+
+/** El animal opuesto en la rueda de 12: el choque tradicional (6 posiciones). */
+function oppositeAnimal(animal: ChineseZodiacAnimal): ChineseZodiacAnimal {
+  const index = ANIMALS.indexOf(animal);
+  return ANIMALS[(index + CYCLE_LENGTH / 2) % CYCLE_LENGTH];
+}
+
+describe('CHINESE_ZODIAC_PROFILES', () => {
+  it('tiene un perfil por cada uno de los 12 animales', () => {
+    expect(Object.keys(CHINESE_ZODIAC_PROFILES)).toHaveLength(CYCLE_LENGTH);
+    ANIMALS.forEach((animal) => {
+      expect(CHINESE_ZODIAC_PROFILES[animal]).toBeDefined();
+    });
+  });
+
+  it.each(ANIMALS)('el perfil de %s tiene todas las secciones pobladas', (animal) => {
+    const profile = CHINESE_ZODIAC_PROFILES[animal];
+
+    expect(profile.tagline.length).toBeGreaterThan(10);
+    expect(profile.intro).toHaveLength(2);
+    profile.intro.forEach((paragraph) => expect(paragraph.length).toBeGreaterThan(80));
+    expect(profile.personality.length).toBeGreaterThanOrEqual(3);
+    profile.personality.forEach((trait) => {
+      expect(trait.term).toBeTruthy();
+      expect(trait.description.length).toBeGreaterThan(40);
+    });
+    expect(profile.strengths.length).toBeGreaterThanOrEqual(3);
+    expect(profile.challenges.length).toBeGreaterThanOrEqual(3);
+    expect(profile.love.length).toBeGreaterThan(80);
+    expect(profile.career.length).toBeGreaterThan(80);
+    expect(profile.luck.numbers.length).toBeGreaterThanOrEqual(2);
+    expect(profile.luck.colors.length).toBeGreaterThanOrEqual(2);
+    expect(profile.luck.direction).toBeTruthy();
+  });
+
+  it.each(ANIMALS)(
+    `el perfil de %s aporta al menos ${MIN_PROFILE_WORDS} palabras propias`,
+    (animal) => {
+      expect(getProfileWordCount(animal)).toBeGreaterThanOrEqual(MIN_PROFILE_WORDS);
+    }
+  );
+
+  it('no repite ningún párrafo entre animales (contenido único por URL)', () => {
+    const seen = new Map<string, ChineseZodiacAnimal>();
+
+    ANIMALS.forEach((animal) => {
+      const profile = CHINESE_ZODIAC_PROFILES[animal];
+      const paragraphs = [
+        profile.tagline,
+        ...profile.intro,
+        profile.love,
+        profile.career,
+        ...profile.personality.map((trait) => trait.description),
+      ];
+
+      paragraphs.forEach((paragraph) => {
+        const normalized = paragraph.trim().toLowerCase();
+        expect(seen.get(normalized)).toBeUndefined();
+        seen.set(normalized, animal);
+      });
+    });
+  });
+
+  describe('compatibilidad', () => {
+    it.each(ANIMALS)('%s no se lista como compatible consigo mismo', (animal) => {
+      const { best, challenging } = CHINESE_ZODIAC_PROFILES[animal].compatibility;
+
+      expect(best).not.toContain(animal);
+      expect(challenging).not.toContain(animal);
+    });
+
+    it.each(ANIMALS)('%s no lista un animal como afín y en choque a la vez', (animal) => {
+      const { best, challenging } = CHINESE_ZODIAC_PROFILES[animal].compatibility;
+
+      expect(best.filter((candidate) => challenging.includes(candidate))).toEqual([]);
+    });
+
+    it.each(ANIMALS)('el choque de %s es su opuesto en la rueda de 12', (animal) => {
+      expect(CHINESE_ZODIAC_PROFILES[animal].compatibility.challenging).toContain(
+        oppositeAnimal(animal)
+      );
+    });
+
+    it.each(ANIMALS)('la afinidad de %s es recíproca', (animal) => {
+      CHINESE_ZODIAC_PROFILES[animal].compatibility.best.forEach((partner) => {
+        expect(CHINESE_ZODIAC_PROFILES[partner].compatibility.best).toContain(animal);
+      });
+    });
+  });
+});
+
+describe('getChineseZodiacProfile', () => {
+  it('devuelve el perfil del animal pedido', () => {
+    const profile = getChineseZodiacProfile(ChineseZodiacAnimal.DRAGON);
+
+    expect(profile).toBe(CHINESE_ZODIAC_PROFILES[ChineseZodiacAnimal.DRAGON]);
+  });
+});
+
+describe('getProfileWordCount', () => {
+  it('cuenta las palabras de todas las secciones de texto', () => {
+    const count = getProfileWordCount(ChineseZodiacAnimal.RAT);
+    const profile = CHINESE_ZODIAC_PROFILES[ChineseZodiacAnimal.RAT];
+    const introWords = profile.intro.join(' ').trim().split(/\s+/).length;
+
+    expect(count).toBeGreaterThan(introWords);
+  });
+});
+
+describe('coherencia con los años del calendario chino', () => {
+  it.each(ANIMALS)('los años de %s salen del helper compartido', (animal) => {
+    // El perfil no duplica la lista de años: la ficha la pide al helper, que ya
+    // está testeado. Este test documenta el contrato para que no se hardcodee.
+    expect(getAnimalBirthYears(animal).length).toBeGreaterThanOrEqual(7);
+  });
+});

--- a/frontend/src/lib/constants/chinese-zodiac-profiles.data.ts
+++ b/frontend/src/lib/constants/chinese-zodiac-profiles.data.ts
@@ -12,6 +12,17 @@
  * ⚠️ El texto de cada animal debe ser **único**: doce URLs con el mismo párrafo
  * son contenido duplicado para Google, que fue el problema original.
  * `chinese-zodiac-profiles.data.test.ts` lo verifica.
+ *
+ * **Fuente de los datos tradicionales** (no inventar al editarlos):
+ * - `compatibility`: los cuatro triángulos de afinidad del zodiaco chino más el
+ *   par de "amigos secretos", y como choque el opuesto de la rueda (6 posiciones).
+ *   Coinciden con `compatibleWith` / `incompatibleWith` del backend en
+ *   `backend/tarot-app/src/common/utils/chinese-zodiac.utils.ts`. Si cambian allá,
+ *   cambian acá: los tests verifican la coherencia interna, no la del backend.
+ * - `luck.numbers` / `luck.colors` / `luck.direction`: tablas tradicionales de
+ *   números, colores y direcciones favorables por animal. La fuente no es única y
+ *   varía entre escuelas; la ficha los presenta como tradición, no como certeza.
+ * - `element`: el elemento fijo sale de `CHINESE_ZODIAC_INFO`, no se repite acá.
  */
 
 import { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
@@ -319,7 +330,7 @@ export const CHINESE_ZODIAC_PROFILES: Record<ChineseZodiacAnimal, ChineseZodiacP
     challenges: ['Dispersión', 'Impaciencia', 'Habla de más', 'Se aburre pronto'],
     love: 'Se enamora rápido y con ganas, y sostiene el vínculo mientras haya aire y proyectos por delante. El control lo espanta; la complicidad y las aventuras compartidas lo fijan mucho más que las exigencias.',
     career:
-      'Rinde en ventas, turismo, deporte, transporte, comunicación, capacitación y cualquier trabajo con movimiento y contacto humano. La oficina sin ventanas y la tarea repetitiva le rinden mal, aun cuando pague bien.',
+      'Rinde en ventas, turismo, deporte, transporte, comunicación, capacitación y cualquier trabajo con movimiento y contacto humano. La oficina sin ventanas y la tarea repetitiva lo desgastan, aun cuando paguen bien.',
     compatibility: {
       best: [ChineseZodiacAnimal.TIGER, ChineseZodiacAnimal.DOG, ChineseZodiacAnimal.GOAT],
       challenging: [ChineseZodiacAnimal.RAT],

--- a/frontend/src/lib/constants/chinese-zodiac-profiles.data.ts
+++ b/frontend/src/lib/constants/chinese-zodiac-profiles.data.ts
@@ -1,0 +1,536 @@
+/**
+ * Perfiles estáticos de los 12 animales del zodiaco chino (T-SEO-002).
+ *
+ * Es el contenido **indexable** de `/horoscopo-chino/[animal]`: no depende de la
+ * API, de la sesión ni de la query string, así que se renderiza en el servidor y
+ * llega completo al crawler. La predicción del año —que sí depende del elemento
+ * elegido y de la sesión— sigue resolviéndose en el cliente.
+ *
+ * Mismo criterio que `service-intros.data.ts`: contenido rico, específico y
+ * veraz por entrada, centralizado en datos tipados en vez de incrustado en JSX.
+ *
+ * ⚠️ El texto de cada animal debe ser **único**: doce URLs con el mismo párrafo
+ * son contenido duplicado para Google, que fue el problema original.
+ * `chinese-zodiac-profiles.data.test.ts` lo verifica.
+ */
+
+import { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
+
+/** Un rasgo de personalidad: término destacado + su explicación. */
+export interface ChineseZodiacTrait {
+  /** Nombre del rasgo (se muestra en negrita). */
+  term: string;
+  /** Explicación del rasgo. */
+  description: string;
+}
+
+/** Datos tradicionales de la suerte de un animal. */
+export interface ChineseZodiacLuck {
+  /** Números afortunados según la tradición. */
+  numbers: number[];
+  /** Colores afortunados, en español. */
+  colors: string[];
+  /** Dirección favorable (feng shui), en español. */
+  direction: string;
+}
+
+/** Afinidades y choques de un animal con el resto de la rueda. */
+export interface ChineseZodiacCompatibility {
+  /**
+   * Animales afines: los dos del mismo triángulo de afinidad más el "amigo
+   * secreto" (el par que suma doce en la rueda). La relación es recíproca.
+   */
+  best: ChineseZodiacAnimal[];
+  /** Animales en choque: el opuesto de la rueda, a seis posiciones. */
+  challenging: ChineseZodiacAnimal[];
+}
+
+/** Ficha estática de un animal del zodiaco chino. */
+export interface ChineseZodiacProfile {
+  /** Titular corto que resume el arquetipo. */
+  tagline: string;
+  /** Dos párrafos de introducción. */
+  intro: [string, string];
+  /** Rasgos de personalidad explicados. */
+  personality: ChineseZodiacTrait[];
+  /** Fortalezas, en etiquetas cortas. */
+  strengths: string[];
+  /** Desafíos, en etiquetas cortas. */
+  challenges: string[];
+  /** Cómo vive los vínculos afectivos. */
+  love: string;
+  /** Cómo se mueve en el trabajo y con el dinero. */
+  career: string;
+  /** Afinidades y choques. */
+  compatibility: ChineseZodiacCompatibility;
+  /** Números, colores y dirección tradicionales. */
+  luck: ChineseZodiacLuck;
+}
+
+/**
+ * Mínimo de palabras propias que debe aportar cada perfil.
+ *
+ * El umbral del guardarraíl de T-SEO-001 es 120 palabras **de la página entera**,
+ * y el criterio de aceptación de T-SEO-002 son 150. Se pide 200 acá para dejar
+ * margen: la ficha no es todo lo que la página renderiza, pero sí lo único
+ * garantizado cuando la API no responde.
+ */
+export const MIN_PROFILE_WORDS = 200;
+
+export const CHINESE_ZODIAC_PROFILES: Record<ChineseZodiacAnimal, ChineseZodiacProfile> = {
+  [ChineseZodiacAnimal.RAT]: {
+    tagline: 'El estratega que ve la oportunidad antes que nadie',
+    intro: [
+      'La Rata abre el ciclo de doce años del zodiaco chino, y esa primera posición la define: es el signo de quien llega temprano, estudia el terreno y se queda con la mejor jugada. La tradición la asocia al agua que se filtra por cualquier rendija, con una inteligencia práctica que resuelve mientras el resto todavía evalúa.',
+      'Quien nace bajo la Rata suele tener memoria fina para los detalles y un radar afinado para el riesgo. No es un signo temerario: acumula, guarda y planifica, y por eso la tradición china lo vincula a la prosperidad doméstica y al ahorro que sostiene una casa en los años difíciles.',
+    ],
+    personality: [
+      {
+        term: 'Astucia práctica',
+        description:
+          'Lee rápido las reglas de cualquier situación y encuentra el atajo que nadie había mirado. No improvisa por gusto, sino porque ya calculó las alternativas.',
+      },
+      {
+        term: 'Sociabilidad selectiva',
+        description:
+          'Se mueve con soltura en grupos grandes, pero reserva su confianza para un círculo chico y comprobado, que después cuida durante años.',
+      },
+      {
+        term: 'Prudencia con los recursos',
+        description:
+          'Guarda para el invierno por instinto. Esa cautela la vuelve una consejera natural en asuntos de dinero, aunque a veces le cueste disfrutar lo que consiguió.',
+      },
+    ],
+    strengths: ['Ingenio veloz', 'Encanto social', 'Olfato para la oportunidad', 'Constancia'],
+    challenges: ['Desconfianza', 'Necesidad de controlar', 'Crítica afilada', 'Cuesta delegar'],
+    love: 'En pareja es leal y protectora, aunque tarda en bajar la guardia: necesita pruebas antes que promesas. Cuando confía se vuelve un sostén cotidiano y muy concreto, más de gestos que de discursos largos.',
+    career:
+      'Rinde en oficios que premian leer rápido el contexto: comercio, negociación, análisis, comunicación, administración de recursos. Trabaja mejor con margen de maniobra que con procedimientos rígidos, y detecta la falla de un plan antes de que se ejecute.',
+    compatibility: {
+      best: [ChineseZodiacAnimal.DRAGON, ChineseZodiacAnimal.MONKEY, ChineseZodiacAnimal.OX],
+      challenging: [ChineseZodiacAnimal.HORSE],
+    },
+    luck: { numbers: [2, 3], colors: ['Azul', 'Dorado', 'Verde'], direction: 'Sudeste' },
+  },
+
+  [ChineseZodiacAnimal.OX]: {
+    tagline: 'La fuerza tranquila que termina lo que empieza',
+    intro: [
+      'El Buey es el signo del trabajo sostenido. Donde otros buscan el atajo, él elige el surco derecho y lo recorre entero, sin apuro y sin abandonarlo a mitad de camino. La tradición lo asocia a la tierra labrada: nada crece de un día para el otro, pero lo que crece se queda.',
+      'Su prestigio en el zodiaco chino viene de la confiabilidad. Cuando el Buey da una palabra, esa palabra vale, y su entorno lo sabe: es el signo al que se le encargan las cosas que no pueden fallar. La contracara es una terquedad honesta que no se negocia con argumentos apresurados.',
+    ],
+    personality: [
+      {
+        term: 'Perseverancia',
+        description:
+          'Sostiene el esfuerzo mucho después de que se apagó el entusiasmo inicial. Los proyectos largos son su terreno natural, no su castigo.',
+      },
+      {
+        term: 'Integridad',
+        description:
+          'Prefiere una verdad incómoda a una diplomacia hueca. Esa franqueza le gana respeto duradero y algún enemigo circunstancial.',
+      },
+      {
+        term: 'Necesidad de orden',
+        description:
+          'Trabaja mejor con reglas claras y tiempos previsibles. El caos no lo paraliza, pero lo agota más de lo que admite.',
+      },
+    ],
+    strengths: ['Confiabilidad', 'Paciencia', 'Fuerza de voluntad', 'Sentido de la justicia'],
+    challenges: ['Terquedad', 'Rigidez frente al cambio', 'Poca expresividad', 'Exceso de trabajo'],
+    love: 'Ama sin espectáculo: aparece, cumple y se queda. No promete lo que no piensa sostener, y necesita una pareja que sepa leer el afecto en la constancia más que en las palabras o los gestos vistosos.',
+    career:
+      'Se destaca en la construcción, la agricultura, la producción, la contabilidad, la ingeniería y cualquier oficio donde el resultado se mida en obra terminada. Su valor aparece con el tiempo: es el que sigue firme cuando el proyecto deja de ser novedad.',
+    compatibility: {
+      best: [ChineseZodiacAnimal.SNAKE, ChineseZodiacAnimal.ROOSTER, ChineseZodiacAnimal.RAT],
+      challenging: [ChineseZodiacAnimal.GOAT],
+    },
+    luck: { numbers: [1, 9], colors: ['Blanco', 'Amarillo', 'Verde'], direction: 'Norte' },
+  },
+
+  [ChineseZodiacAnimal.TIGER]: {
+    tagline: 'El coraje que abre camino donde no había sendero',
+    intro: [
+      'El Tigre es el signo del arranque. Entra a las situaciones de frente, con una autoridad natural que no necesita cargo ni permiso, y suele ser el primero en decir en voz alta lo que los demás piensan en silencio. La tradición china lo considera protector: su rugido espanta lo que amenaza a los suyos.',
+      'Vive en ciclos de intensidad. Se entrega por completo a lo que lo apasiona y pierde interés de golpe cuando algo se vuelve rutina. Ese vaivén explica tanto sus logros grandes como sus proyectos a medio terminar, y lo vuelve un compañero estimulante y algo imprevisible.',
+    ],
+    personality: [
+      {
+        term: 'Valentía frontal',
+        description:
+          'No esquiva el conflicto cuando cree que hay una injusticia. Prefiere la confrontación clara a la incomodidad que se acumula sin nombrarse.',
+      },
+      {
+        term: 'Liderazgo magnético',
+        description:
+          'Arrastra voluntades por convicción y no por jerarquía. La gente lo sigue porque cree en su impulso, no porque le deba obediencia.',
+      },
+      {
+        term: 'Impaciencia',
+        description:
+          'Le cuesta esperar tiempos ajenos. Cuando la energía no encuentra salida, se transforma en irritación o en un cambio brusco de rumbo.',
+      },
+    ],
+    strengths: ['Coraje', 'Generosidad', 'Iniciativa', 'Carisma'],
+    challenges: ['Impulsividad', 'Orgullo', 'Aburrimiento fácil', 'Reacciones desmedidas'],
+    love: 'Ama con intensidad y quiere reciprocidad en el mismo tono. Necesita admirar a su pareja y sentirse admirado; la rutina lo apaga más rápido que cualquier discusión, y una vida compartida sin proyecto lo inquieta.',
+    career:
+      'Brilla en roles de arranque y de exposición: emprender, dirigir equipos, competir, defender causas, actuar en público, trabajar en emergencias. Rinde poco en estructuras donde debe pedir permiso para cada decisión, y mucho cuando se le confía el rumbo.',
+    compatibility: {
+      best: [ChineseZodiacAnimal.HORSE, ChineseZodiacAnimal.DOG, ChineseZodiacAnimal.PIG],
+      challenging: [ChineseZodiacAnimal.MONKEY],
+    },
+    luck: { numbers: [1, 3, 4], colors: ['Azul', 'Gris', 'Naranja'], direction: 'Este' },
+  },
+
+  [ChineseZodiacAnimal.RABBIT]: {
+    tagline: 'La elegancia que resuelve sin levantar la voz',
+    intro: [
+      'El Conejo consigue por la vía suave lo que otros persiguen a los empujones. Es diplomático por naturaleza, atento al clima de una habitación antes de que alguien hable, y encuentra la salida elegante de los conflictos que parecían trabados. La tradición lo asocia a la Luna, a la prudencia y a una suerte que acompaña a quien no fuerza.',
+      'Su sensibilidad es su radar y también su punto débil: registra tensiones muy finas y se retira cuando el ambiente se vuelve hostil. Necesita belleza, calma y un refugio propio para recuperar energía, y desde ahí sostiene a los suyos con una constancia silenciosa.',
+    ],
+    personality: [
+      {
+        term: 'Diplomacia',
+        description:
+          'Negocia sin dejar heridos. Encuentra la formulación que permite a las dos partes ceder algo sin sentir que perdieron la dignidad.',
+      },
+      {
+        term: 'Sensibilidad estética',
+        description:
+          'Le importa cómo se ven y cómo se sienten los espacios y los vínculos. La armonía no le resulta un lujo, sino una condición para funcionar.',
+      },
+      {
+        term: 'Aversión al conflicto',
+        description:
+          'Prefiere retirarse antes que discutir, y ese silencio a veces deja problemas sin resolver durante mucho más tiempo que una conversación difícil.',
+      },
+    ],
+    strengths: ['Cortesía', 'Intuición social', 'Paciencia', 'Buen gusto'],
+    challenges: ['Evita confrontar', 'Susceptibilidad', 'Indecisión', 'Se guarda las molestias'],
+    love: 'Busca ternura, previsibilidad y un vínculo sin sobresaltos. Es un compañero atento a los detalles chicos, pero se aleja en silencio si siente dureza o brusquedad sostenida en el trato cotidiano.',
+    career:
+      'Funciona muy bien en diseño, salud, educación, mediación, atención al público, diplomacia y todo lo que requiera trato fino con personas. Prefiere ambientes cordiales y estables, donde su cuidado del detalle no compita contra la urgencia permanente.',
+    compatibility: {
+      best: [ChineseZodiacAnimal.GOAT, ChineseZodiacAnimal.PIG, ChineseZodiacAnimal.DOG],
+      challenging: [ChineseZodiacAnimal.ROOSTER],
+    },
+    luck: { numbers: [3, 4, 6], colors: ['Rosa', 'Violeta', 'Azul'], direction: 'Sudeste' },
+  },
+
+  [ChineseZodiacAnimal.DRAGON]: {
+    tagline: 'La ambición que arrastra a los demás con su entusiasmo',
+    intro: [
+      'El Dragón es el único animal mítico de la rueda china y el más celebrado: nacer en su año se considera una bendición. Encarna la energía que se muestra, el gesto grande, la confianza que convence antes de tener pruebas. Cuando entra en una sala, algo cambia en la temperatura del ambiente.',
+      'Piensa en grande y detesta lo mediocre, propio o ajeno. Esa exigencia lo lleva lejos y también lo vuelve impaciente con los tiempos lentos y con las tareas menudas. Su lealtad, cuando la entrega, es total y protectora: defiende a los suyos con la misma desmesura con la que persigue sus proyectos.',
+    ],
+    personality: [
+      {
+        term: 'Confianza expansiva',
+        description:
+          'Cree en lo que se propone antes de tener evidencia, y ese entusiasmo contagia a quienes lo rodean hasta volver posible lo improbable.',
+      },
+      {
+        term: 'Generosidad señorial',
+        description:
+          'Da sin llevar la cuenta, tanto tiempo como recursos, y espera a cambio reconocimiento más que devolución material.',
+      },
+      {
+        term: 'Intolerancia al detalle',
+        description:
+          'Se aburre con la letra chica y la delega apenas puede. Muchos de sus tropiezos nacen ahí y no en la idea original.',
+      },
+    ],
+    strengths: ['Visión amplia', 'Energía', 'Generosidad', 'Determinación'],
+    challenges: ['Soberbia', 'Impaciencia', 'Todo o nada', 'Descuida lo pequeño'],
+    love: 'Conquista con intensidad y necesita sentirse elegido cada día. Es un compañero espléndido y presente, siempre que la pareja tolere su necesidad de brillar y le devuelva admiración sincera.',
+    career:
+      'Se realiza donde hay escenario y decisión: dirección de empresas, política, espectáculo, arquitectura, ventas de alto vuelo, proyectos fundacionales. Necesita autonomía real; un cargo decorativo lo apaga más rápido que la falta de dinero.',
+    compatibility: {
+      best: [ChineseZodiacAnimal.RAT, ChineseZodiacAnimal.MONKEY, ChineseZodiacAnimal.ROOSTER],
+      challenging: [ChineseZodiacAnimal.DOG],
+    },
+    luck: { numbers: [1, 6, 7], colors: ['Dorado', 'Plateado', 'Blanco'], direction: 'Oeste' },
+  },
+
+  [ChineseZodiacAnimal.SNAKE]: {
+    tagline: 'La sabiduría que observa en silencio y actúa una sola vez',
+    intro: [
+      'La Serpiente es el signo de la reserva. Habla poco, mira mucho y guarda para sí lo que fue entendiendo, hasta que llega el momento exacto de moverse. La tradición china la asocia a la sabiduría, al misterio y a una elegancia que no necesita mostrarse para imponerse.',
+      'Detrás de esa calma hay una mente analítica que rara vez improvisa. Cuando decide, ya evaluó el escenario completo, y por eso sus movimientos parecen certeros a quien no vio el trabajo previo. Su intimidad es un territorio cerrado al que solo entran unos pocos elegidos.',
+    ],
+    personality: [
+      {
+        term: 'Perspicacia',
+        description:
+          'Percibe intenciones detrás de las palabras. Es difícil venderle una historia armada, porque escucha más los silencios que los argumentos.',
+      },
+      {
+        term: 'Discreción',
+        description:
+          'Administra la información con cuidado, incluso la propia. Prefiere que lo subestimen antes que exponer una carta sin necesidad.',
+      },
+      {
+        term: 'Posesividad',
+        description:
+          'Se apega con fuerza a lo que considera suyo y le cuesta compartirlo. Los celos aparecen antes que el reproche, y no siempre se dicen.',
+      },
+    ],
+    strengths: ['Intuición', 'Elegancia', 'Concentración', 'Autocontrol'],
+    challenges: ['Desconfianza', 'Reserva excesiva', 'Rencor', 'Tendencia a aislarse'],
+    love: 'Ama con hondura y exclusividad, sin necesidad de demostraciones públicas. Requiere pruebas de lealtad y una intimidad protegida; la traición, aun pequeña, la deja marcada mucho tiempo.',
+    career:
+      'Se destaca en investigación, psicología, finanzas, derecho, filosofía y todo oficio que premie el análisis paciente. Es una excelente asesora entre bambalinas y una negociadora temible cuando le toca cerrar el acuerdo.',
+    compatibility: {
+      best: [ChineseZodiacAnimal.OX, ChineseZodiacAnimal.ROOSTER, ChineseZodiacAnimal.MONKEY],
+      challenging: [ChineseZodiacAnimal.PIG],
+    },
+    luck: {
+      numbers: [2, 8, 9],
+      colors: ['Rojo', 'Negro', 'Amarillo claro'],
+      direction: 'Sudoeste',
+    },
+  },
+
+  [ChineseZodiacAnimal.HORSE]: {
+    tagline: 'La libertad hecha movimiento',
+    intro: [
+      'El Caballo necesita horizonte. Es entusiasta, franco y sociable, y se enciende con lo que recién empieza: un viaje, una idea, una conversación con alguien que acaba de conocer. La tradición china lo asocia al fuego que se ve de lejos y al galope que no tolera la brida apretada.',
+      'Su honestidad es directa, casi sin filtro, y eso lo hace transparente y a veces imprudente. Aprende haciendo, no leyendo instrucciones, y necesita sentir que puede irse para quedarse a gusto: la libertad no es un capricho suyo, es la condición de su compromiso.',
+    ],
+    personality: [
+      {
+        term: 'Entusiasmo contagioso',
+        description:
+          'Levanta el ánimo de un grupo con su energía y su humor. Es el que propone la salida y consigue que los demás salgan del sillón.',
+      },
+      {
+        term: 'Franqueza',
+        description:
+          'Dice lo que piensa en el momento en que lo piensa. Ahorra malentendidos y de vez en cuando abre alguno nuevo por falta de rodeos.',
+      },
+      {
+        term: 'Inquietud',
+        description:
+          'Cambia de foco cuando algo se vuelve previsible. Sostener lo empezado le exige un esfuerzo consciente que no le nace solo.',
+      },
+    ],
+    strengths: ['Optimismo', 'Sociabilidad', 'Independencia', 'Adaptabilidad'],
+    challenges: ['Dispersión', 'Impaciencia', 'Habla de más', 'Se aburre pronto'],
+    love: 'Se enamora rápido y con ganas, y sostiene el vínculo mientras haya aire y proyectos por delante. El control lo espanta; la complicidad y las aventuras compartidas lo fijan mucho más que las exigencias.',
+    career:
+      'Rinde en ventas, turismo, deporte, transporte, comunicación, capacitación y cualquier trabajo con movimiento y contacto humano. La oficina sin ventanas y la tarea repetitiva le rinden mal, aun cuando pague bien.',
+    compatibility: {
+      best: [ChineseZodiacAnimal.TIGER, ChineseZodiacAnimal.DOG, ChineseZodiacAnimal.GOAT],
+      challenging: [ChineseZodiacAnimal.RAT],
+    },
+    luck: { numbers: [2, 3, 7], colors: ['Amarillo', 'Verde'], direction: 'Sur' },
+  },
+
+  [ChineseZodiacAnimal.GOAT]: {
+    tagline: 'La sensibilidad que cuida y crea',
+    intro: [
+      'La Cabra es el signo del cuidado. Percibe el estado de ánimo ajeno antes de que se declare y acomoda su conducta para que nadie quede afuera. La tradición china la asocia a la compasión, al arte y a una vida de rebaño donde el bienestar del grupo pesa más que el propio protagonismo.',
+      'Es creativa y de mundo interior amplio, con una imaginación que necesita canal. Cuando no lo encuentra, esa energía se vuelve hacia adentro en forma de preocupación. Prefiere la seguridad de lo conocido y florece en entornos amables donde no tiene que defenderse todo el tiempo.',
+    ],
+    personality: [
+      {
+        term: 'Empatía',
+        description:
+          'Se pone en el lugar del otro casi sin esfuerzo y ofrece consuelo concreto. Es a quien el grupo llama cuando algo duele de verdad.',
+      },
+      {
+        term: 'Creatividad',
+        description:
+          'Piensa en imágenes, texturas y climas. Su aporte aparece en cómo se siente un resultado, no solo en si funciona.',
+      },
+      {
+        term: 'Necesidad de contención',
+        description:
+          'La crítica dura la desarma más de lo que muestra. Necesita un entorno que le confirme su valor para arriesgarse a proponer.',
+      },
+    ],
+    strengths: ['Amabilidad', 'Imaginación', 'Lealtad afectiva', 'Sentido estético'],
+    challenges: ['Preocupación crónica', 'Indecisión', 'Piel fina', 'Dependencia emocional'],
+    love: 'Se entrega con una devoción cálida y muy atenta a lo cotidiano. Necesita palabras de afirmación y un vínculo estable; la frialdad o la ironía sostenida le hacen más daño que una pelea abierta.',
+    career:
+      'Encuentra su lugar en el arte, el diseño, la enseñanza, la enfermería, la gastronomía, la jardinería y los oficios de cuidado. Trabaja mejor acompañada que al frente, y su aporte se nota en la calidad del clima además del resultado.',
+    compatibility: {
+      best: [ChineseZodiacAnimal.RABBIT, ChineseZodiacAnimal.PIG, ChineseZodiacAnimal.HORSE],
+      challenging: [ChineseZodiacAnimal.OX],
+    },
+    luck: { numbers: [2, 7], colors: ['Verde', 'Rojo', 'Violeta'], direction: 'Norte' },
+  },
+
+  [ChineseZodiacAnimal.MONKEY]: {
+    tagline: 'El ingenio que encuentra la solución impensada',
+    intro: [
+      'El Mono resuelve jugando. Es curioso, veloz y de una versatilidad que le permite entrar y salir de cualquier tema con soltura, casi siempre con humor de por medio. La tradición china lo asocia a la inventiva y a la astucia que se ríe del problema mientras lo desarma pieza por pieza.',
+      'Aprende por experimentación y se aburre cuando ya entendió cómo funciona algo. Ese apetito de novedad lo hace ingenioso y a veces inconstante: acumula habilidades dispares y necesita disciplina prestada para convertirlas en un oficio profundo en lugar de una colección de trucos.',
+    ],
+    personality: [
+      {
+        term: 'Inventiva',
+        description:
+          'Encuentra soluciones laterales que a nadie se le habían ocurrido, y suele llegar antes por un camino que parecía absurdo.',
+      },
+      {
+        term: 'Humor',
+        description:
+          'Desactiva tensiones con una broma en el momento justo. Su liviandad es una herramienta social, no una falta de seriedad.',
+      },
+      {
+        term: 'Inquietud mental',
+        description:
+          'Necesita estímulo constante. Sin desafíos nuevos empieza a moverse por moverse, y ahí llegan los cambios innecesarios.',
+      },
+    ],
+    strengths: ['Creatividad', 'Rapidez mental', 'Sociabilidad', 'Versatilidad'],
+    challenges: ['Inconstancia', 'Picardía', 'Dificultad para profundizar', 'Impaciencia'],
+    love: 'Enamora con juego, conversación y sorpresas. Necesita una pareja que le siga el ritmo y no le pida solemnidad; el vínculo se sostiene mientras haya complicidad y risas, y se enfría con la rutina rígida.',
+    career:
+      'Se destaca en tecnología, publicidad, comercio, entretenimiento, ingeniería y consultoría, donde el problema cambia seguido. Es un solucionador excelente en la urgencia y necesita apoyo para las etapas largas de mantenimiento.',
+    compatibility: {
+      best: [ChineseZodiacAnimal.RAT, ChineseZodiacAnimal.DRAGON, ChineseZodiacAnimal.SNAKE],
+      challenging: [ChineseZodiacAnimal.TIGER],
+    },
+    luck: { numbers: [1, 7, 8], colors: ['Blanco', 'Dorado', 'Azul'], direction: 'Noroeste' },
+  },
+
+  [ChineseZodiacAnimal.ROOSTER]: {
+    tagline: 'La precisión que anuncia el día en punto',
+    intro: [
+      'El Gallo es el signo del orden visible. Puntual, observador y directo, canta a la hora exacta y espera que el mundo responda con la misma exactitud. La tradición china lo asocia a la vigilancia: es quien avisa, quien nota lo que falta y quien no deja pasar el error por comodidad.',
+      'Cuida la forma tanto como el fondo: su apariencia, su discurso y su trabajo llevan la misma marca de prolijidad. Esa exigencia lo vuelve confiable y, cuando se le va la mano, crítico de más. Detrás de la franqueza hay un compromiso real con hacer las cosas bien.',
+    ],
+    personality: [
+      {
+        term: 'Meticulosidad',
+        description:
+          'Revisa lo que otros dan por hecho y encuentra la inconsistencia. Su ojo para el detalle evita problemas que nadie llegó a ver.',
+      },
+      {
+        term: 'Franqueza directa',
+        description:
+          'Dice lo que observa sin adornos. Se agradece cuando hay algo en juego y molesta cuando el otro esperaba contención.',
+      },
+      {
+        term: 'Orgullo del trabajo propio',
+        description:
+          'Le importa el reconocimiento de lo que hizo bien. No busca aplauso vacío, sino constancia de que su esfuerzo se registró.',
+      },
+    ],
+    strengths: ['Organización', 'Honestidad', 'Puntualidad', 'Compromiso'],
+    challenges: ['Crítica dura', 'Perfeccionismo', 'Vanidad', 'Poca tolerancia al desorden'],
+    love: 'Es un compañero fiel y presente, atento a lo práctico de la vida en común. Necesita reglas claras y acuerdos explícitos; la ambigüedad lo pone nervioso más que un desacuerdo dicho de frente.',
+    career:
+      'Brilla en administración, auditoría, control de calidad, medicina, gastronomía, peluquería, comunicación y todo oficio donde la prolijidad se note. Es quien deja el proceso documentado y el lugar mejor ordenado de lo que lo encontró.',
+    compatibility: {
+      best: [ChineseZodiacAnimal.OX, ChineseZodiacAnimal.SNAKE, ChineseZodiacAnimal.DRAGON],
+      challenging: [ChineseZodiacAnimal.RABBIT],
+    },
+    luck: { numbers: [5, 7, 8], colors: ['Dorado', 'Marrón', 'Amarillo'], direction: 'Sur' },
+  },
+
+  [ChineseZodiacAnimal.DOG]: {
+    tagline: 'La lealtad que no se negocia',
+    intro: [
+      'El Perro es el signo de la fidelidad y de la justicia. Elige un bando por convicción moral y se queda ahí, aun cuando conviene lo contrario. La tradición china lo asocia al guardián: escucha en la noche, avisa del peligro y pone el cuerpo por quienes están de su lado.',
+      'Tiene un sentido agudo de lo que está bien y lo que no, y le cuesta mirar hacia otro lado frente a un abuso. Esa vigilancia lo vuelve un compañero seguro y, hacia adentro, algo ansioso: se preocupa por adelantado y necesita señales de que el vínculo sigue firme.',
+    ],
+    personality: [
+      {
+        term: 'Lealtad',
+        description:
+          'Sostiene a los suyos en la dificultad, sin cálculo de conveniencia. La confianza que da es difícil de ganar y más difícil de perder.',
+      },
+      {
+        term: 'Sentido de la justicia',
+        description:
+          'Reacciona ante lo que considera injusto, incluso si no lo afecta directamente. Es el que interviene cuando el resto mira el piso.',
+      },
+      {
+        term: 'Cautela ansiosa',
+        description:
+          'Anticipa el peligro más de lo necesario. Esa alarma temprana protege al grupo y le cobra tranquilidad a él.',
+      },
+    ],
+    strengths: ['Honestidad', 'Solidaridad', 'Responsabilidad', 'Coraje moral'],
+    challenges: ['Pesimismo', 'Ansiedad', 'Rigidez moral', 'Cuesta perdonar'],
+    love: 'Ama de manera estable y sin dobleces, con una entrega que se prueba en los tramos difíciles. Necesita seguridad y transparencia; la duda instalada lo desgasta más que cualquier conflicto abierto.',
+    career:
+      'Encuentra sentido en el derecho, la docencia, la salud, la seguridad, el trabajo social, el sindicalismo y las causas colectivas. Trabaja con integridad aun sin supervisión y se vuelve el referente ético informal de su equipo.',
+    compatibility: {
+      best: [ChineseZodiacAnimal.TIGER, ChineseZodiacAnimal.HORSE, ChineseZodiacAnimal.RABBIT],
+      challenging: [ChineseZodiacAnimal.DRAGON],
+    },
+    luck: { numbers: [3, 4, 9], colors: ['Rojo', 'Verde', 'Violeta'], direction: 'Este' },
+  },
+
+  [ChineseZodiacAnimal.PIG]: {
+    tagline: 'La abundancia de quien disfruta y comparte',
+    intro: [
+      'El Cerdo cierra la rueda de doce años y lo hace con un signo de disfrute y sinceridad. Es generoso, tolerante y sin doble fondo: cree en la palabra ajena y le resulta ajeno el cálculo de la manipulación. La tradición china lo asocia a la abundancia, a la mesa compartida y a la buena fortuna que llega por la vía honesta.',
+      'Trabaja fuerte para darse una vida buena y no le ve ninguna virtud al sacrificio innecesario. Su optimismo lo sostiene en los tramos malos y, a veces, lo deja expuesto a quien abusa de su confianza; aun así, prefiere equivocarse creyendo antes que vivir sospechando de todos.',
+    ],
+    personality: [
+      {
+        term: 'Generosidad',
+        description:
+          'Comparte lo que tiene sin llevar registro. Su casa y su tiempo están disponibles para los suyos sin que haga falta pedirlo dos veces.',
+      },
+      {
+        term: 'Sinceridad',
+        description:
+          'Dice lo que siente y espera lo mismo. La intriga lo desorienta más que la mala noticia, porque no forma parte de su repertorio.',
+      },
+      {
+        term: 'Gusto por el placer',
+        description:
+          'Valora la comida, el descanso y la compañía como parte del sentido de la vida, no como recompensas que haya que merecer.',
+      },
+    ],
+    strengths: ['Bondad', 'Tolerancia', 'Optimismo', 'Laboriosidad'],
+    challenges: ['Ingenuidad', 'Postergación', 'Exceso de indulgencia', 'Evita conflictos'],
+    love: 'Es un compañero cálido, afectuoso y sin cálculo, que construye el vínculo alrededor de lo compartido. Necesita reciprocidad concreta: cuando siente que lo aprovechan, se va tarde pero sin volver.',
+    career:
+      'Se desempeña bien en gastronomía, comercio, hotelería, recursos humanos, medicina y oficios donde la calidez sea parte del servicio. Es un socio confiable que sostiene el ánimo del grupo y prospera cuando alguien lo ayuda a poner límites.',
+    compatibility: {
+      best: [ChineseZodiacAnimal.RABBIT, ChineseZodiacAnimal.GOAT, ChineseZodiacAnimal.TIGER],
+      challenging: [ChineseZodiacAnimal.SNAKE],
+    },
+    luck: { numbers: [2, 5, 8], colors: ['Amarillo', 'Gris', 'Marrón'], direction: 'Sudoeste' },
+  },
+};
+
+/**
+ * Obtiene el perfil estático de un animal del zodiaco chino.
+ */
+export function getChineseZodiacProfile(animal: ChineseZodiacAnimal): ChineseZodiacProfile {
+  return CHINESE_ZODIAC_PROFILES[animal];
+}
+
+/**
+ * Cuenta las palabras de texto que aporta un perfil.
+ *
+ * Sirve de guardarraíl en los tests: replica el criterio de conteo del script
+ * `check-indexable-content.mjs` sobre las secciones de texto de la ficha.
+ */
+export function getProfileWordCount(animal: ChineseZodiacAnimal): number {
+  const profile = CHINESE_ZODIAC_PROFILES[animal];
+  const text = [
+    profile.tagline,
+    ...profile.intro,
+    ...profile.personality.flatMap((trait) => [trait.term, trait.description]),
+    ...profile.strengths,
+    ...profile.challenges,
+    profile.love,
+    profile.career,
+  ].join(' ');
+
+  return text
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .filter((word) => word.length > 0).length;
+}

--- a/frontend/src/lib/utils/chinese-zodiac.test.ts
+++ b/frontend/src/lib/utils/chinese-zodiac.test.ts
@@ -2,16 +2,18 @@
  * Tests for Chinese Zodiac Utilities
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   getChineseZodiacInfo,
   getCurrentYear,
   isChineseZodiacAnimal,
   getAllChineseZodiacAnimals,
   getAllChineseZodiacInfo,
+  getAnimalBirthYears,
   getElementIcon,
   getElementForYear,
   CHINESE_ZODIAC_INFO,
+  CHINESE_BIRTH_YEARS_RANGE,
 } from '@/lib/utils/chinese-zodiac';
 import { ChineseZodiacAnimal } from '@/types/chinese-horoscope.types';
 
@@ -303,6 +305,66 @@ describe('chinese zodiac utilities', () => {
         expect(getElementForYear(baseYear + 8)).toBe(getElementForYear(baseYear + 9)); // earth/earth
       }
     });
+  });
+});
+
+describe('getAnimalBirthYears', () => {
+  it('devuelve años conocidos de cada animal', () => {
+    // Referencia: años del calendario chino ampliamente publicados.
+    expect(getAnimalBirthYears(ChineseZodiacAnimal.RAT)).toContain(2020);
+    expect(getAnimalBirthYears(ChineseZodiacAnimal.OX)).toContain(2021);
+    expect(getAnimalBirthYears(ChineseZodiacAnimal.TIGER)).toContain(2022);
+    expect(getAnimalBirthYears(ChineseZodiacAnimal.RABBIT)).toContain(2023);
+    expect(getAnimalBirthYears(ChineseZodiacAnimal.DRAGON)).toContain(2024);
+    expect(getAnimalBirthYears(ChineseZodiacAnimal.SNAKE)).toContain(2025);
+    expect(getAnimalBirthYears(ChineseZodiacAnimal.HORSE)).toContain(2026);
+    expect(getAnimalBirthYears(ChineseZodiacAnimal.GOAT)).toContain(2027);
+    expect(getAnimalBirthYears(ChineseZodiacAnimal.MONKEY)).toContain(2028);
+    expect(getAnimalBirthYears(ChineseZodiacAnimal.ROOSTER)).toContain(2029);
+    expect(getAnimalBirthYears(ChineseZodiacAnimal.DOG)).toContain(2030);
+    expect(getAnimalBirthYears(ChineseZodiacAnimal.PIG)).toContain(2031);
+  });
+
+  it('devuelve los años en orden ascendente y separados por el ciclo de 12', () => {
+    Object.values(ChineseZodiacAnimal).forEach((animal) => {
+      const years = getAnimalBirthYears(animal);
+
+      expect(years.length).toBeGreaterThanOrEqual(7);
+      years.forEach((year, index) => {
+        if (index > 0) {
+          expect(year - years[index - 1]).toBe(12);
+        }
+      });
+    });
+  });
+
+  it('mantiene todos los años dentro del rango declarado', () => {
+    Object.values(ChineseZodiacAnimal).forEach((animal) => {
+      getAnimalBirthYears(animal).forEach((year) => {
+        expect(year).toBeGreaterThanOrEqual(CHINESE_BIRTH_YEARS_RANGE.from);
+        expect(year).toBeLessThanOrEqual(CHINESE_BIRTH_YEARS_RANGE.to);
+      });
+    });
+  });
+
+  it('no repite un año entre dos animales distintos', () => {
+    const seen = new Map<number, ChineseZodiacAnimal>();
+
+    Object.values(ChineseZodiacAnimal).forEach((animal) => {
+      getAnimalBirthYears(animal).forEach((year) => {
+        expect(seen.get(year)).toBeUndefined();
+        seen.set(year, animal);
+      });
+    });
+  });
+
+  it('es determinista: no depende de la fecha actual', () => {
+    const before = getAnimalBirthYears(ChineseZodiacAnimal.DRAGON);
+    vi.setSystemTime(new Date('2099-06-15T00:00:00Z'));
+    const after = getAnimalBirthYears(ChineseZodiacAnimal.DRAGON);
+    vi.useRealTimers();
+
+    expect(after).toEqual(before);
   });
 });
 

--- a/frontend/src/lib/utils/chinese-zodiac.ts
+++ b/frontend/src/lib/utils/chinese-zodiac.ts
@@ -144,6 +144,50 @@ export function getAllChineseZodiacInfo(): ChineseZodiacInfo[] {
 }
 
 /**
+ * Rango de años que se listan como "años de nacimiento" de cada animal.
+ *
+ * Fijo a propósito: la ficha de `/horoscopo-chino/[animal]` se prerenderiza, así
+ * que la lista no puede depender de `new Date()` — el HTML horneado quedaría
+ * congelado en el año del build y mentiría al visitante.
+ */
+export const CHINESE_BIRTH_YEARS_RANGE = { from: 1936, to: 2043 } as const;
+
+/** Largo del ciclo del zodiaco chino. */
+const CHINESE_ZODIAC_CYCLE = 12;
+
+/**
+ * Años del calendario chino que corresponden a un animal, dentro de
+ * `CHINESE_BIRTH_YEARS_RANGE` y en orden ascendente.
+ *
+ * ⚠️ El año chino **no** arranca el 1 de enero sino con el Año Nuevo Chino
+ * (entre el 21 de enero y el 20 de febrero), así que quien nació en esa franja
+ * pertenece al animal del año anterior. La ficha lo aclara y deriva al
+ * calculador, que resuelve la fecha exacta contra la API.
+ *
+ * @example
+ * ```typescript
+ * getAnimalBirthYears(ChineseZodiacAnimal.DRAGON);
+ * // [1940, 1952, 1964, 1976, 1988, 2000, 2012, 2024, 2036]
+ * ```
+ */
+export function getAnimalBirthYears(animal: ChineseZodiacAnimal): number[] {
+  // La rueda arranca en la Rata: 1936 fue año de la Rata, así que el índice del
+  // animal en el enum es directamente su desplazamiento sobre el inicio del rango.
+  const offset = getAllChineseZodiacAnimals().indexOf(animal);
+  const years: number[] = [];
+
+  for (
+    let year = CHINESE_BIRTH_YEARS_RANGE.from + offset;
+    year <= CHINESE_BIRTH_YEARS_RANGE.to;
+    year += CHINESE_ZODIAC_CYCLE
+  ) {
+    years.push(year);
+  }
+
+  return years;
+}
+
+/**
  * Elemento icons para Wu Xing (5 elementos chinos)
  */
 const ELEMENT_ICONS: Record<string, string> = {


### PR DESCRIPTION
## Resumen

`/horoscopo-chino/[animal]` servía **3 palabras propias** al crawler en sus 12 URLs — el peor caso del sitio. Ahora sirve **355–401**.

La causa era la diagnosticada en el backlog: el panel interactivo usa `useSearchParams()` y, sin un límite de `<Suspense>`, Next deopta el prerender de **toda** la ruta. Además `CHINESE_ZODIAC_INFO` no alcanzaba como contenido (son ~10 palabras: nombre, emoji, elemento y tres adjetivos), así que hubo que escribir la ficha.

Referencia: `docs/BACKLOG_SEO_ADSENSE_2026_08.md` → T-SEO-002.

## Cambios

- **`chinese-zodiac-profiles.data.ts`** — contenido estático, tipado y centralizado (patrón de `service-intros.data.ts`): titular, dos párrafos de introducción, tres rasgos explicados, fortalezas, desafíos, amor, trabajo, compatibilidades y datos de suerte. **Único por animal.**
- **`AnimalProfile`** (server component) — renderiza esa ficha. Incluye enlazado interno: cada compatibilidad linkea a la ficha del otro animal.
- **`AnimalHoroscopeRoute`** (server component) — valida el segmento, sirve la ficha y monta el panel dentro de `<Suspense>`. El "Todos los animales" pasó de `router.push` a un `<Link>` real, rastreable.
- **`AnimalHoroscopePage` → `AnimalHoroscopePanel`** — ya no es la página; conserva selector, modal de elemento y predicción. Perdió el branch de "Animal no válido", que ahora vive en el servidor (una sola fuente de verdad).
- **El modal de elemento ya no se auto-abre** — tapaba la ficha con el overlay y, peor, el `aria-hidden` que Radix pone en el resto del documento sacaba las ~380 palabras nuevas del árbol de accesibilidad. Ahora hay un aviso inline con *Elegir mi elemento* (mismo modal, mismo handler) y el enlace al calculador. Cierra el tercer bullet del alcance.
- **`getAnimalBirthYears`** — deriva los años del ciclo de 12 sobre un rango fijo (1936–2043) en vez de hardcodearlos. Rango fijo a propósito: con `new Date()` el HTML prerenderizado quedaría congelado en el año del build. La ficha aclara que el año chino empieza con el Año Nuevo Chino y deriva al calculador.
- **`ChineseHoroscopeDetail`** baja su `h1` a `h2`: el `h1` de la página es el de la ficha.

## Verificación

Medido contra el build de producción, con el chrome medido en **39 palabras** (`/admin` como línea base):

| URL | Antes | Ahora |
| --- | --- | --- |
| `/horoscopo-chino/rat` | 3 | **401** |
| `/horoscopo-chino/ox` | 3 | **389** |
| `/horoscopo-chino/pig` | 3 | **386** |
| `/horoscopo-chino/rabbit` | 3 | **384** |
| `/horoscopo-chino/tiger` | 3 | **380** |
| `/horoscopo-chino/goat` | 3 | **379** |
| `/horoscopo-chino/dragon` | 3 | **376** |
| `/horoscopo-chino/rooster` | 3 | **374** |
| `/horoscopo-chino/dog` | 3 | **371** |
| `/horoscopo-chino/horse` | 3 | **365** |
| `/horoscopo-chino/snake` | 3 | **358** |
| `/horoscopo-chino/monkey` | 3 | **355** |

`npm run check:indexable -- --base-url http://localhost:3099` (el guardarraíl de T-SEO-001): **12/12 en ✅**.

El build las lista como `●` (SSG) con `revalidate` de 1 día, los 12 `generateStaticParams` emitidos.

Títulos y canonical intactos (T-PROD-020, verificado en el HTML servido): `Horóscopo Chino: Rata`, `: Dragón`, `: Cerdo`, cada uno con su canonical propio.

## Criterios de aceptación

- [x] Las 12 URLs superan las 150 palabras propias → 355–401.
- [x] El selector de elemento y la predicción siguen funcionando (cambia *cuándo* se abre el modal, no *qué* hace).
- [x] `getChineseZodiacMetadata` sigue dando títulos únicos por animal.

## Ciclo de calidad

- [x] `npm run format`
- [x] `npm run lint:fix` — 0 errores
- [x] `npm run type-check`
- [x] `npm run test:run` — **5722 pasan**, 0 fallan
- [x] `npm run build`
- [x] `node scripts/validate-architecture.js` — ✅
- [x] `npm run check:indexable` contra el build

## Notas

- Los tests son también un **guardarraíl de contenido**: `MIN_PROFILE_WORDS` falla si un perfil baja de 200 palabras, y hay tests de unicidad de párrafos entre animales, de reciprocidad de las afinidades y de que el choque sea el opuesto de la rueda de 12.
- El **soft-404** de `/horoscopo-chino/inventado-xyz` (responde 200) sigue vivo: es T-SEO-006, fuera de alcance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)