### PR TITLE
feat(seo): contenido indexable en los 11 listados y hubs (T-SEO-003)

### DIFF
--- a/docs/BACKLOG_SEO_ADSENSE_2026_08.md
+++ b/docs/BACKLOG_SEO_ADSENSE_2026_08.md
@@ -39,10 +39,12 @@ Muestra estratificada de 62 de las 178 URLs del sitemap, midiendo **palabras pro
 | Fichas de ritual y servicio | 9 | 243–422 | ✅ |
 | Horóscopo chino por animal | 12 | 3 → **355–401** | ✅ T-SEO-002 (10-ago) |
 | **Signos del horóscopo** | **12** | **31** | ❌ T-SEO-004 |
-| **Listados y hubs** (`/premium` 3, `/servicios` 5, `/explorar` 20, `/enciclopedia/tarot` 24, `/enciclopedia/guias` 13) | **5** | 3–24 | ❌ T-SEO-003 |
+| Listados y hubs (`/premium`, `/servicios`, `/explorar`, `/enciclopedia/tarot`, `/enciclopedia/guias`, `/enciclopedia`, `/enciclopedia/astrologia` + 3 listados astro, `/contacto`) | 11 | 3–70 → **177–822** | ✅ T-SEO-003 (10-ago) |
 
 **29 de 62 URLs muestreadas superan las 150 palabras propias** (antes de este trabajo: 13).
 Con T-SEO-002 cerrada, **41 de 62**: los 12 animales del horóscopo chino pasaron de 3 a 355–401.
+Con T-SEO-003 cerrada, la corrida completa del guardarraíl da **153 de 178 URLs** sobre las 120
+palabras: quedan los 12 signos (T-SEO-004) y 13 fichas entre 109 y 119.
 
 ### El patrón que ya funciona (replicalo, no inventes otro)
 
@@ -143,7 +145,7 @@ lógica en `app/`.
 | --- | --- | --- | --- | --- |
 | T-SEO-001 | Guardarraíl automático de contenido indexable ✅ | Frontend/CI | 🔴 Crítica | 2 pts |
 | T-SEO-002 | Horóscopo chino por animal: 12 URLs sirven 3 palabras ✅ | Frontend | 🔴 Crítica | 3 pts |
-| T-SEO-003 | Listados y hubs sin contenido para el crawler | Frontend | 🟠 Alta | 2 pts |
+| T-SEO-003 | Listados y hubs sin contenido para el crawler ✅ | Frontend | 🟠 Alta | 2 pts |
 | T-SEO-004 | Signos del horóscopo: ficha estática del signo | Frontend | 🟠 Alta | 2 pts |
 | T-SEO-005 | El build de Docker no usa lockfile (deriva de dependencias) | Infra | 🟠 Alta | 2 pts |
 | T-SEO-006 | Los `notFound()` devuelven 200 (soft-404) | Frontend | 🟡 Media | 1.5 pts |
@@ -335,6 +337,7 @@ existía solo para no reabrir el modal descartado.
 ## T-SEO-003: Listados y Hubs sin Contenido para el Crawler
 
 **Prioridad:** 🟠 Alta · **Estimación:** 2 pts · **Dependencias:** ninguna
+**Estado:** ✅ COMPLETADA (10-ago-2026)
 
 ### Problema
 
@@ -353,24 +356,76 @@ sirve 3 palabras.
 
 Mismo patrón del punto *El patrón que ya funciona*, aplicado a listados en vez de fichas:
 
-- [ ] `/enciclopedia/tarot` — la ruta ya es server; resolver `getCards()` y pasar por `initialData` a
+- [x] `/enciclopedia/tarot` — la ruta ya es server; resolver `getCards()` y pasar por `initialData` a
       `EnciclopediaContent`.
-- [ ] `/enciclopedia/guias` — ídem con `GuiasContent`.
-- [ ] `/servicios` — ídem con `ServiciosPage`.
-- [ ] `/explorar` — listado de tarotistas; ojo que el endpoint es **paginado** (ver contrato en
+- [x] `/enciclopedia/guias` — ídem con `GuiasContent`.
+- [x] `/servicios` — ídem con `ServiciosPage`.
+- [x] `/explorar` — listado de tarotistas; ojo que el endpoint es **paginado** (ver contrato en
       `.github/copilot-instructions.md`): sembrar solo la primera página.
-- [ ] `/premium` — revisar por qué sirve 3 palabras: si el contenido de planes viene de la API, sembrarlo;
-      si es estático, entender qué lo está bloqueando.
-- [ ] **Sumados por T-SEO-001** (la muestra manual no los había medido): `/enciclopedia` 70,
+- [x] `/premium` — revisar por qué sirve 3 palabras: si el contenido de planes viene de la API, sembrarlo;
+      si es estático, entender qué lo está bloqueando. **Era lo segundo**: ver *Notas técnicas*.
+- [x] **Sumados por T-SEO-001** (la muestra manual no los había medido): `/enciclopedia` 70,
       `/enciclopedia/astrologia` 70, `/enciclopedia/astrologia/casas` 26, `/enciclopedia/astrologia/planetas` 18,
       `/enciclopedia/astrologia/signos` 23 y `/contacto` 34. Los cinco primeros son hubs de listado, mismo
       patrón; `/contacto` es un formulario y quizá amerite texto propio en vez de sembrado.
 
 ### Criterios de aceptación
 
-- [ ] Las 11 rutas superan las 120 palabras propias, verificado con
-      `npm run check:indexable -- --base-url https://auguriatarot.com`.
-- [ ] Sin regresión en la interactividad (filtros, búsqueda, tabs).
+- [x] Las 11 rutas superan las 120 palabras propias, verificado con
+      `npm run check:indexable -- --base-url http://localhost:3099` contra el build de producción en
+      Docker (chrome medido en 39 palabras):
+
+      | Ruta | Antes | Ahora |
+      | --- | --- | --- |
+      | `/premium` | 3 | **277** |
+      | `/servicios` | 5 | **255** |
+      | `/enciclopedia/guias` | 13 | **427** |
+      | `/enciclopedia/astrologia/planetas` | 18 | **595** |
+      | `/explorar` | 20 | **199** |
+      | `/enciclopedia/astrologia/signos` | 23 | **649** |
+      | `/enciclopedia/tarot` | 24 | **511** |
+      | `/enciclopedia/astrologia/casas` | 26 | **822** |
+      | `/contacto` | 34 | **177** |
+      | `/enciclopedia` | 70 | **260** |
+      | `/enciclopedia/astrologia` | 70 | **244** |
+
+      El total del sitio pasó de **48 URLs bajo el umbral a 25**: quedan los 12 signos (T-SEO-004) y
+      las 13 fichas al borde (109–119), ninguna de esta tarea.
+- [x] Sin regresión en la interactividad (filtros, búsqueda, tabs): los tests de `/explorar`
+      (búsqueda con debounce, chips de especialidad, estado vacío, navegación al perfil) y de la
+      enciclopedia siguen verdes, adaptados al segundo argumento de los hooks.
+
+### Notas técnicas
+
+- **`/premium` no era un problema de sembrado.** Toda la página esperaba a `usePublicPlans` detrás de un
+  esqueleto de pantalla completa, así que la comparativa, las FAQ y el "sin compromiso" —contenido
+  estático que no depende de la API— no llegaban nunca al crawler. Ahora lo único que espera es el
+  número del precio (`PriceSkeleton`). El sembrado se agregó igual, para que el HTML salga con el precio
+  real.
+- **Dos mecanismos, no uno.** Sembrar resuelve el caso feliz, pero deja el contenido de cada URL atado a
+  que la API responda durante el build. Por eso cada ruta suma además un bloque editorial propio
+  ([listing-intros.data.ts](../frontend/src/lib/constants/listing-intros.data.ts) +
+  [ListingIntro.tsx](../frontend/src/components/common/ListingIntro.tsx)): texto escrito, único por ruta,
+  que se renderiza siempre en el servidor. Es el piso garantizado —130 palabras mínimo, verificadas por
+  `listing-intros.data.test.ts`— y de paso evita que estas URLs sean listas de enlaces sin texto propio,
+  que es exactamente lo que Google llama contenido de poco valor.
+- **Los listados degradan, las fichas no.** `resolveListingData` devuelve `undefined` si la API falla, al
+  revés de `resolveRouteResource`, que propaga. La diferencia es deliberada y está documentada en
+  [route-data.ts](../frontend/src/lib/metadata/route-data.ts): una ficha sin su recurso no tiene nada que
+  mostrar; un listado tiene su introducción y el cliente reintenta al montar. `getArticlesByCategories`
+  aplica el mismo criterio por categoría: una caída no deja sin contenido a las otras seis guías.
+- **`initialDataUpdatedAt: 0` donde el dato cambia** (planes, servicios, tarotistas) y no donde es
+  estático (cartas, artículos), siguiendo el criterio de T-PROD-024.
+- **`/explorar` dejó de ser un client component.** El `useRouter` que la hacía cliente entera vive ahora
+  en `ExplorarContent`; la ruta resuelve la primera página del endpoint paginado. El sembrado se aplica
+  **solo con los filtros por defecto**: con búsqueda o especialidad activas la clave de caché es otra y
+  sembrarla con el listado sin filtrar mostraría resultados que no corresponden.
+- **`GUIDE_CATEGORIES` se movió a `encyclopedia-article.types.ts`**: la ruta (server) y `GuiasContent`
+  (cliente) necesitan la misma lista, y el server component no debería importar el módulo cliente solo
+  para leer una constante.
+- **ISR:** 1 día para la enciclopedia (contenido estático, igual que las fichas) y 1 hora para
+  `/premium`, `/servicios` y `/explorar`, donde precios y listados se editan desde el admin.
+- **El soft-404 sigue vivo** (11 rutas responden 200): es T-SEO-006, fuera de alcance acá.
 
 ---
 

--- a/frontend/src/app/contacto/page.test.tsx
+++ b/frontend/src/app/contacto/page.test.tsx
@@ -118,5 +118,14 @@ describe('ContactoPage', () => {
       renderPage();
       expect(screen.getByTestId('contact-accent')).toBeInTheDocument();
     });
+
+    it('⚠️ T-SEO-003: renderiza contenido propio sobre qué se responde por acá', () => {
+      renderPage();
+
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'Antes de escribirnos' })
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('listing-intro')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/app/contacto/page.tsx
+++ b/frontend/src/app/contacto/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from 'next';
 import { Mail, Sparkles } from 'lucide-react';
 
+import { ListingIntro } from '@/components/common/ListingIntro';
 import { Reveal } from '@/components/common/Reveal';
 import { ContactForm } from '@/components/features/contact/ContactForm';
 import { CONFIG } from '@/lib/constants';
+import { LISTING_INTROS } from '@/lib/constants/listing-intros.data';
 import { STATIC_PAGE_METADATA } from '@/lib/metadata/page-metadata';
 
 export const metadata: Metadata = STATIC_PAGE_METADATA.contacto;
@@ -18,6 +20,10 @@ export const metadata: Metadata = STATIC_PAGE_METADATA.contacto;
  *
  * El envío es real desde T-PROD-014 (`POST /contact`): ya no hay disclaimer de
  * "envío no implementado".
+ *
+ * Servía 34 palabras propias —el formulario es todo `input`, y un `input` no es
+ * texto para el crawler—, así que abajo va contenido propio sobre qué se
+ * responde por acá y qué no (T-SEO-003).
  */
 export default function ContactoPage() {
   return (
@@ -71,6 +77,10 @@ export default function ContactoPage() {
               </p>
             </div>
           </div>
+        </Reveal>
+
+        <Reveal index={3}>
+          <ListingIntro intro={LISTING_INTROS.contacto} className="p-0" />
         </Reveal>
       </div>
     </div>

--- a/frontend/src/app/enciclopedia/astrologia/casas/page.test.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/casas/page.test.tsx
@@ -28,7 +28,14 @@ vi.mock('next/link', () => ({
 const mockUseArticlesByCategory = vi.fn();
 
 vi.mock('@/hooks/api/useEncyclopediaArticles', () => ({
-  useArticlesByCategory: (category: ArticleCategory) => mockUseArticlesByCategory(category),
+  useArticlesByCategory: (category: ArticleCategory, initialData?: ArticleSummary[]) =>
+    mockUseArticlesByCategory(category, initialData),
+}));
+
+const mockGetArticlesByCategory = vi.fn();
+
+vi.mock('@/lib/api/encyclopedia-articles-api', () => ({
+  getArticlesByCategory: (category: ArticleCategory) => mockGetArticlesByCategory(category),
 }));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -61,36 +68,66 @@ function buildArticle(id: number, slug: string, nameEs: string): ArticleSummary 
 describe('CasasPage (/enciclopedia/astrologia/casas)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetArticlesByCategory.mockResolvedValue([]);
   });
 
-  it('debe mostrar el listado de casas cuando hay datos', () => {
+  it('debe mostrar el listado de casas cuando hay datos', async () => {
     const casas = [
       buildArticle(1, 'primera-casa', 'Primera Casa'),
       buildArticle(2, 'segunda-casa', 'Segunda Casa'),
     ];
     mockUseArticlesByCategory.mockReturnValue({ data: casas, isLoading: false, error: null });
 
-    renderWithProviders(<CasasPage />);
+    renderWithProviders(await CasasPage());
 
     expect(screen.getByText('Primera Casa')).toBeInTheDocument();
     expect(screen.getByText('Segunda Casa')).toBeInTheDocument();
   });
 
-  it('links de casas deben apuntar a la ruta correcta', () => {
+  it('links de casas deben apuntar a la ruta correcta', async () => {
     const casas = [buildArticle(1, 'primera-casa', 'Primera Casa')];
     mockUseArticlesByCategory.mockReturnValue({ data: casas, isLoading: false, error: null });
 
-    renderWithProviders(<CasasPage />);
+    renderWithProviders(await CasasPage());
 
     const link = screen.getByRole('link', { name: /primera casa/i });
     expect(link).toHaveAttribute('href', '/enciclopedia/astrologia/casas/primera-casa');
   });
 
-  it('debe llamar a useArticlesByCategory con ASTROLOGICAL_HOUSE', () => {
+  it('debe llamar a useArticlesByCategory con ASTROLOGICAL_HOUSE', async () => {
     mockUseArticlesByCategory.mockReturnValue({ data: [], isLoading: false, error: null });
 
-    renderWithProviders(<CasasPage />);
+    renderWithProviders(await CasasPage());
 
-    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.ASTROLOGICAL_HOUSE);
+    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.ASTROLOGICAL_HOUSE, []);
+  });
+
+  it('⚠️ T-SEO-003: resuelve el listado en el servidor y lo siembra en el cliente', async () => {
+    const articulos = [buildArticle(1, 'un-slug', 'Un Artículo')];
+    mockGetArticlesByCategory.mockResolvedValue(articulos);
+    mockUseArticlesByCategory.mockReturnValue({ data: articulos, isLoading: false, error: null });
+
+    renderWithProviders(await CasasPage());
+
+    expect(mockGetArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.ASTROLOGICAL_HOUSE);
+    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(
+      ArticleCategory.ASTROLOGICAL_HOUSE,
+      articulos
+    );
+  });
+
+  it('⚠️ T-SEO-003: si la API falla, la ruta sigue sirviendo su contenido propio', async () => {
+    mockGetArticlesByCategory.mockRejectedValue(new Error('API caída'));
+    mockUseArticlesByCategory.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    renderWithProviders(await CasasPage());
+
+    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(
+      ArticleCategory.ASTROLOGICAL_HOUSE,
+      undefined
+    );
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Doce casas, doce áreas de la vida' })
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/enciclopedia/astrologia/casas/page.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/casas/page.tsx
@@ -1,23 +1,40 @@
 import type { Metadata } from 'next';
 
+import { ListingIntro } from '@/components/common/ListingIntro';
 import { ArticleListPageContent } from '@/components/features/encyclopedia/ArticleListPageContent';
+import { getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
+import { LISTING_INTROS } from '@/lib/constants/listing-intros.data';
 import { STATIC_PAGE_METADATA } from '@/lib/metadata/page-metadata';
+import { resolveListingData } from '@/lib/metadata/route-data';
 import { ArticleCategory } from '@/types/encyclopedia-article.types';
 
 /**
  * Casas Astrales List Page
  *
  * Route: /enciclopedia/astrologia/casas
+ *
+ * Servía 26 palabras propias: el listado llegaba por el cliente (T-SEO-003).
  */
 export const metadata: Metadata = STATIC_PAGE_METADATA.enciclopediaCasas;
 
-export default function CasasPage() {
+/** Los artículos son contenido estático; un día de ISR alcanza. */
+export const revalidate = 86400;
+
+export default async function CasasPage() {
+  const initialArticles = await resolveListingData(() =>
+    getArticlesByCategory(ArticleCategory.ASTROLOGICAL_HOUSE)
+  );
+
   return (
-    <ArticleListPageContent
-      category={ArticleCategory.ASTROLOGICAL_HOUSE}
-      title="Casas Astrales"
-      subtitle="Conoce las 12 casas astrales y los aspectos de la vida que rigen."
-      detailHrefPrefix="/enciclopedia/astrologia/casas"
-    />
+    <>
+      <ArticleListPageContent
+        category={ArticleCategory.ASTROLOGICAL_HOUSE}
+        title="Casas Astrales"
+        subtitle="Conoce las 12 casas astrales y los aspectos de la vida que rigen."
+        detailHrefPrefix="/enciclopedia/astrologia/casas"
+        initialArticles={initialArticles}
+      />
+      <ListingIntro intro={LISTING_INTROS.enciclopediaCasas} />
+    </>
   );
 }

--- a/frontend/src/app/enciclopedia/astrologia/page.test.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/page.test.tsx
@@ -59,4 +59,12 @@ describe('AstrologiaPage (/enciclopedia/astrologia)', () => {
       '/enciclopedia/astrologia/casas'
     );
   });
+
+  it('⚠️ T-SEO-003: renderiza la introducción editorial indexable del hub', () => {
+    render(<AstrologiaPage />);
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Los tres ejes de una carta astral' })
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/enciclopedia/astrologia/page.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 
+import { ListingIntro } from '@/components/common/ListingIntro';
 import { AstrologyHubContent } from '@/components/features/encyclopedia/AstrologyHubContent';
+import { LISTING_INTROS } from '@/lib/constants/listing-intros.data';
 import { STATIC_PAGE_METADATA } from '@/lib/metadata/page-metadata';
 
 /**
@@ -8,9 +10,17 @@ import { STATIC_PAGE_METADATA } from '@/lib/metadata/page-metadata';
  *
  * Route: /enciclopedia/astrologia
  * Hub de astrología con banda de marca y enlaces a signos, planetas y casas.
+ *
+ * Servía 70 palabras propias: tres tarjetas y el encabezado. La introducción
+ * editorial le da contenido propio (T-SEO-003).
  */
 export const metadata: Metadata = STATIC_PAGE_METADATA.enciclopediaAstrologia;
 
 export default function AstrologiaPage() {
-  return <AstrologyHubContent />;
+  return (
+    <>
+      <AstrologyHubContent />
+      <ListingIntro intro={LISTING_INTROS.enciclopediaAstrologia} />
+    </>
+  );
 }

--- a/frontend/src/app/enciclopedia/astrologia/planetas/page.test.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/planetas/page.test.tsx
@@ -28,7 +28,14 @@ vi.mock('next/link', () => ({
 const mockUseArticlesByCategory = vi.fn();
 
 vi.mock('@/hooks/api/useEncyclopediaArticles', () => ({
-  useArticlesByCategory: (category: ArticleCategory) => mockUseArticlesByCategory(category),
+  useArticlesByCategory: (category: ArticleCategory, initialData?: ArticleSummary[]) =>
+    mockUseArticlesByCategory(category, initialData),
+}));
+
+const mockGetArticlesByCategory = vi.fn();
+
+vi.mock('@/lib/api/encyclopedia-articles-api', () => ({
+  getArticlesByCategory: (category: ArticleCategory) => mockGetArticlesByCategory(category),
 }));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -61,33 +68,57 @@ function buildArticle(id: number, slug: string, nameEs: string): ArticleSummary 
 describe('PlanetasPage (/enciclopedia/astrologia/planetas)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetArticlesByCategory.mockResolvedValue([]);
   });
 
-  it('debe mostrar el listado de planetas cuando hay datos', () => {
+  it('debe mostrar el listado de planetas cuando hay datos', async () => {
     const planetas = [buildArticle(1, 'mercurio', 'Mercurio'), buildArticle(2, 'venus', 'Venus')];
     mockUseArticlesByCategory.mockReturnValue({ data: planetas, isLoading: false, error: null });
 
-    renderWithProviders(<PlanetasPage />);
+    renderWithProviders(await PlanetasPage());
 
     expect(screen.getByText('Mercurio')).toBeInTheDocument();
     expect(screen.getByText('Venus')).toBeInTheDocument();
   });
 
-  it('links de planetas deben apuntar a la ruta correcta', () => {
+  it('links de planetas deben apuntar a la ruta correcta', async () => {
     const planetas = [buildArticle(1, 'mercurio', 'Mercurio')];
     mockUseArticlesByCategory.mockReturnValue({ data: planetas, isLoading: false, error: null });
 
-    renderWithProviders(<PlanetasPage />);
+    renderWithProviders(await PlanetasPage());
 
     const link = screen.getByRole('link', { name: /mercurio/i });
     expect(link).toHaveAttribute('href', '/enciclopedia/astrologia/planetas/mercurio');
   });
 
-  it('debe llamar a useArticlesByCategory con PLANET', () => {
+  it('debe llamar a useArticlesByCategory con PLANET', async () => {
     mockUseArticlesByCategory.mockReturnValue({ data: [], isLoading: false, error: null });
 
-    renderWithProviders(<PlanetasPage />);
+    renderWithProviders(await PlanetasPage());
 
-    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.PLANET);
+    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.PLANET, []);
+  });
+
+  it('⚠️ T-SEO-003: resuelve el listado en el servidor y lo siembra en el cliente', async () => {
+    const articulos = [buildArticle(1, 'un-slug', 'Un Artículo')];
+    mockGetArticlesByCategory.mockResolvedValue(articulos);
+    mockUseArticlesByCategory.mockReturnValue({ data: articulos, isLoading: false, error: null });
+
+    renderWithProviders(await PlanetasPage());
+
+    expect(mockGetArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.PLANET);
+    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.PLANET, articulos);
+  });
+
+  it('⚠️ T-SEO-003: si la API falla, la ruta sigue sirviendo su contenido propio', async () => {
+    mockGetArticlesByCategory.mockRejectedValue(new Error('API caída'));
+    mockUseArticlesByCategory.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    renderWithProviders(await PlanetasPage());
+
+    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.PLANET, undefined);
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Personales, sociales y generacionales' })
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/enciclopedia/astrologia/planetas/page.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/planetas/page.tsx
@@ -1,23 +1,40 @@
 import type { Metadata } from 'next';
 
+import { ListingIntro } from '@/components/common/ListingIntro';
 import { ArticleListPageContent } from '@/components/features/encyclopedia/ArticleListPageContent';
+import { getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
+import { LISTING_INTROS } from '@/lib/constants/listing-intros.data';
 import { STATIC_PAGE_METADATA } from '@/lib/metadata/page-metadata';
+import { resolveListingData } from '@/lib/metadata/route-data';
 import { ArticleCategory } from '@/types/encyclopedia-article.types';
 
 /**
  * Planetas List Page
  *
  * Route: /enciclopedia/astrologia/planetas
+ *
+ * Servía 18 palabras propias: el listado llegaba por el cliente (T-SEO-003).
  */
 export const metadata: Metadata = STATIC_PAGE_METADATA.enciclopediaPlanetas;
 
-export default function PlanetasPage() {
+/** Los artículos son contenido estático; un día de ISR alcanza. */
+export const revalidate = 86400;
+
+export default async function PlanetasPage() {
+  const initialArticles = await resolveListingData(() =>
+    getArticlesByCategory(ArticleCategory.PLANET)
+  );
+
   return (
-    <ArticleListPageContent
-      category={ArticleCategory.PLANET}
-      title="Planetas"
-      subtitle="Descubre los 10 planetas astrológicos y su influencia."
-      detailHrefPrefix="/enciclopedia/astrologia/planetas"
-    />
+    <>
+      <ArticleListPageContent
+        category={ArticleCategory.PLANET}
+        title="Planetas"
+        subtitle="Descubre los 10 planetas astrológicos y su influencia."
+        detailHrefPrefix="/enciclopedia/astrologia/planetas"
+        initialArticles={initialArticles}
+      />
+      <ListingIntro intro={LISTING_INTROS.enciclopediaPlanetas} />
+    </>
   );
 }

--- a/frontend/src/app/enciclopedia/astrologia/signos/page.test.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/signos/page.test.tsx
@@ -28,7 +28,14 @@ vi.mock('next/link', () => ({
 const mockUseArticlesByCategory = vi.fn();
 
 vi.mock('@/hooks/api/useEncyclopediaArticles', () => ({
-  useArticlesByCategory: (category: ArticleCategory) => mockUseArticlesByCategory(category),
+  useArticlesByCategory: (category: ArticleCategory, initialData?: ArticleSummary[]) =>
+    mockUseArticlesByCategory(category, initialData),
+}));
+
+const mockGetArticlesByCategory = vi.fn();
+
+vi.mock('@/lib/api/encyclopedia-articles-api', () => ({
+  getArticlesByCategory: (category: ArticleCategory) => mockGetArticlesByCategory(category),
 }));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -61,33 +68,57 @@ function buildArticle(id: number, slug: string, nameEs: string): ArticleSummary 
 describe('SignosPage (/enciclopedia/astrologia/signos)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetArticlesByCategory.mockResolvedValue([]);
   });
 
-  it('debe mostrar el listado de signos cuando hay datos', () => {
+  it('debe mostrar el listado de signos cuando hay datos', async () => {
     const signos = [buildArticle(1, 'aries', 'Aries'), buildArticle(2, 'tauro', 'Tauro')];
     mockUseArticlesByCategory.mockReturnValue({ data: signos, isLoading: false, error: null });
 
-    renderWithProviders(<SignosPage />);
+    renderWithProviders(await SignosPage());
 
     expect(screen.getByText('Aries')).toBeInTheDocument();
     expect(screen.getByText('Tauro')).toBeInTheDocument();
   });
 
-  it('links de signos deben apuntar a la ruta correcta', () => {
+  it('links de signos deben apuntar a la ruta correcta', async () => {
     const signos = [buildArticle(1, 'aries', 'Aries')];
     mockUseArticlesByCategory.mockReturnValue({ data: signos, isLoading: false, error: null });
 
-    renderWithProviders(<SignosPage />);
+    renderWithProviders(await SignosPage());
 
     const link = screen.getByRole('link', { name: /aries/i });
     expect(link).toHaveAttribute('href', '/enciclopedia/astrologia/signos/aries');
   });
 
-  it('debe llamar a useArticlesByCategory con ZODIAC_SIGN', () => {
+  it('debe llamar a useArticlesByCategory con ZODIAC_SIGN', async () => {
     mockUseArticlesByCategory.mockReturnValue({ data: [], isLoading: false, error: null });
 
-    renderWithProviders(<SignosPage />);
+    renderWithProviders(await SignosPage());
 
-    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.ZODIAC_SIGN);
+    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.ZODIAC_SIGN, []);
+  });
+
+  it('⚠️ T-SEO-003: resuelve el listado en el servidor y lo siembra en el cliente', async () => {
+    const articulos = [buildArticle(1, 'un-slug', 'Un Artículo')];
+    mockGetArticlesByCategory.mockResolvedValue(articulos);
+    mockUseArticlesByCategory.mockReturnValue({ data: articulos, isLoading: false, error: null });
+
+    renderWithProviders(await SignosPage());
+
+    expect(mockGetArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.ZODIAC_SIGN);
+    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.ZODIAC_SIGN, articulos);
+  });
+
+  it('⚠️ T-SEO-003: si la API falla, la ruta sigue sirviendo su contenido propio', async () => {
+    mockGetArticlesByCategory.mockRejectedValue(new Error('API caída'));
+    mockUseArticlesByCategory.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    renderWithProviders(await SignosPage());
+
+    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.ZODIAC_SIGN, undefined);
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Cómo se ordenan los doce signos' })
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/enciclopedia/astrologia/signos/page.tsx
+++ b/frontend/src/app/enciclopedia/astrologia/signos/page.tsx
@@ -1,23 +1,40 @@
 import type { Metadata } from 'next';
 
+import { ListingIntro } from '@/components/common/ListingIntro';
 import { ArticleListPageContent } from '@/components/features/encyclopedia/ArticleListPageContent';
+import { getArticlesByCategory } from '@/lib/api/encyclopedia-articles-api';
+import { LISTING_INTROS } from '@/lib/constants/listing-intros.data';
 import { STATIC_PAGE_METADATA } from '@/lib/metadata/page-metadata';
+import { resolveListingData } from '@/lib/metadata/route-data';
 import { ArticleCategory } from '@/types/encyclopedia-article.types';
 
 /**
  * Signos Zodiacales List Page
  *
  * Route: /enciclopedia/astrologia/signos
+ *
+ * Servía 23 palabras propias: el listado llegaba por el cliente (T-SEO-003).
  */
 export const metadata: Metadata = STATIC_PAGE_METADATA.enciclopediaSignos;
 
-export default function SignosPage() {
+/** Los artículos son contenido estático; un día de ISR alcanza. */
+export const revalidate = 86400;
+
+export default async function SignosPage() {
+  const initialArticles = await resolveListingData(() =>
+    getArticlesByCategory(ArticleCategory.ZODIAC_SIGN)
+  );
+
   return (
-    <ArticleListPageContent
-      category={ArticleCategory.ZODIAC_SIGN}
-      title="Signos Zodiacales"
-      subtitle="Explora los 12 signos del zodiaco y sus características."
-      detailHrefPrefix="/enciclopedia/astrologia/signos"
-    />
+    <>
+      <ArticleListPageContent
+        category={ArticleCategory.ZODIAC_SIGN}
+        title="Signos Zodiacales"
+        subtitle="Explora los 12 signos del zodiaco y sus características."
+        detailHrefPrefix="/enciclopedia/astrologia/signos"
+        initialArticles={initialArticles}
+      />
+      <ListingIntro intro={LISTING_INTROS.enciclopediaSignos} />
+    </>
   );
 }

--- a/frontend/src/app/enciclopedia/guias/page.test.tsx
+++ b/frontend/src/app/enciclopedia/guias/page.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import GuiasPage from './page';
-import { ArticleCategory } from '@/types/encyclopedia-article.types';
+import { ArticleCategory, GUIDE_CATEGORIES } from '@/types/encyclopedia-article.types';
 import type { ArticleSummary } from '@/types/encyclopedia-article.types';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
@@ -32,10 +32,18 @@ vi.mock('next/image', () => ({
   ),
 }));
 
+const mockGetArticlesByCategories = vi.fn();
+
+vi.mock('@/lib/api/encyclopedia-articles-api', () => ({
+  getArticlesByCategories: (categories: ArticleCategory[]) =>
+    mockGetArticlesByCategories(categories),
+}));
+
 const mockUseArticlesByCategory = vi.fn();
 
 vi.mock('@/hooks/api/useEncyclopediaArticles', () => ({
-  useArticlesByCategory: (category: ArticleCategory) => mockUseArticlesByCategory(category),
+  useArticlesByCategory: (category: ArticleCategory, initialData?: ArticleSummary[]) =>
+    mockUseArticlesByCategory(category, initialData),
 }));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -73,9 +81,10 @@ function buildGuideArticle(
 describe('GuiasPage (/enciclopedia/guias)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetArticlesByCategories.mockResolvedValue({});
   });
 
-  it('debe mostrar el listado de guías cuando hay datos', () => {
+  it('debe mostrar el listado de guías cuando hay datos', async () => {
     const guias = [
       buildGuideArticle(
         1,
@@ -92,13 +101,13 @@ describe('GuiasPage (/enciclopedia/guias)', () => {
       return { data: [], isLoading: false };
     });
 
-    renderWithProviders(<GuiasPage />);
+    renderWithProviders(await GuiasPage());
 
     expect(screen.getByText('Guía de Numerología')).toBeInTheDocument();
     expect(screen.getByText('Guía del Péndulo')).toBeInTheDocument();
   });
 
-  it('links de guías deben apuntar a la ruta /enciclopedia/guias/[slug]', () => {
+  it('links de guías deben apuntar a la ruta /enciclopedia/guias/[slug]', async () => {
     const guias = [
       buildGuideArticle(
         1,
@@ -112,13 +121,13 @@ describe('GuiasPage (/enciclopedia/guias)', () => {
       return { data: [], isLoading: false };
     });
 
-    renderWithProviders(<GuiasPage />);
+    renderWithProviders(await GuiasPage());
 
     const link = screen.getByRole('link', { name: /guía de numerología/i });
     expect(link).toHaveAttribute('href', '/enciclopedia/guias/guia-numerologia');
   });
 
-  it('debe incluir la Guía del Tarot en el listado', () => {
+  it('debe incluir la Guía del Tarot en el listado', async () => {
     const tarotGuide = buildGuideArticle(
       10,
       'guia-tarot',
@@ -130,23 +139,23 @@ describe('GuiasPage (/enciclopedia/guias)', () => {
       return { data: [], isLoading: false };
     });
 
-    renderWithProviders(<GuiasPage />);
+    renderWithProviders(await GuiasPage());
 
     const link = screen.getByRole('link', { name: /guía del tarot/i });
     expect(link).toHaveAttribute('href', '/enciclopedia/guias/guia-tarot');
   });
 
-  it('debe consultar la categoría GUIDE_TAROT y ubicarla primera', () => {
+  it('debe consultar la categoría GUIDE_TAROT y ubicarla primera', async () => {
     mockUseArticlesByCategory.mockReturnValue({ data: [], isLoading: false });
 
-    renderWithProviders(<GuiasPage />);
+    renderWithProviders(await GuiasPage());
 
     const requestedCategories = mockUseArticlesByCategory.mock.calls.map((call) => call[0]);
     expect(requestedCategories).toContain(ArticleCategory.GUIDE_TAROT);
     expect(requestedCategories[0]).toBe(ArticleCategory.GUIDE_TAROT);
   });
 
-  it('debe renderizar la tarjeta de la Guía del Tarot con thumbnail temático e imagen con alt', () => {
+  it('debe renderizar la tarjeta de la Guía del Tarot con thumbnail temático e imagen con alt', async () => {
     const tarotGuide = buildGuideArticle(
       10,
       'guia-tarot',
@@ -158,14 +167,14 @@ describe('GuiasPage (/enciclopedia/guias)', () => {
       return { data: [], isLoading: false };
     });
 
-    renderWithProviders(<GuiasPage />);
+    renderWithProviders(await GuiasPage());
 
     const image = screen.getByTestId('next-image');
     expect(image).toHaveAttribute('src', expect.stringContaining('guia-tarot-hero.webp'));
     expect(image).toHaveAccessibleName(expect.stringMatching(/tarot/i));
   });
 
-  it('debe mostrar un chip de categoría dorado y el CTA "Leer guía"', () => {
+  it('debe mostrar un chip de categoría dorado y el CTA "Leer guía"', async () => {
     const tarotGuide = buildGuideArticle(
       10,
       'guia-tarot',
@@ -177,13 +186,13 @@ describe('GuiasPage (/enciclopedia/guias)', () => {
       return { data: [], isLoading: false };
     });
 
-    renderWithProviders(<GuiasPage />);
+    renderWithProviders(await GuiasPage());
 
     expect(screen.getByText('Tarot')).toBeInTheDocument();
     expect(screen.getByText(/leer guía/i)).toBeInTheDocument();
   });
 
-  it('debe usar texto oscuro sobre el chip dorado para contraste AA (T-ENC-009)', () => {
+  it('debe usar texto oscuro sobre el chip dorado para contraste AA (T-ENC-009)', async () => {
     const tarotGuide = buildGuideArticle(
       10,
       'guia-tarot',
@@ -195,7 +204,7 @@ describe('GuiasPage (/enciclopedia/guias)', () => {
       return { data: [], isLoading: false };
     });
 
-    renderWithProviders(<GuiasPage />);
+    renderWithProviders(await GuiasPage());
 
     // Cada guía renderiza su propio chip; el test fija un único guía mockeado,
     // pero usamos getAllByTestId para no romper si se añaden más guías.
@@ -204,7 +213,7 @@ describe('GuiasPage (/enciclopedia/guias)', () => {
     expect(chip).not.toHaveClass('text-secondary-foreground');
   });
 
-  it('debe preferir el imageUrl del backend cuando está disponible', () => {
+  it('debe preferir el imageUrl del backend cuando está disponible', async () => {
     const numerologyGuide: ArticleSummary = {
       ...buildGuideArticle(
         1,
@@ -220,14 +229,14 @@ describe('GuiasPage (/enciclopedia/guias)', () => {
       return { data: [], isLoading: false };
     });
 
-    renderWithProviders(<GuiasPage />);
+    renderWithProviders(await GuiasPage());
 
     const image = screen.getByTestId('next-image');
     expect(image).toHaveAttribute('src', '/images/enciclopedia/guia-numerologia.webp');
     expect(image).toHaveAccessibleName(expect.stringMatching(/guía de numerología/i));
   });
 
-  it('debe renderizar el hero temático de la Guía de Numerología (T-ENC-011)', () => {
+  it('debe renderizar el hero temático de la Guía de Numerología (T-ENC-011)', async () => {
     const numerologyGuide = buildGuideArticle(
       1,
       'guia-numerologia',
@@ -240,10 +249,42 @@ describe('GuiasPage (/enciclopedia/guias)', () => {
       return { data: [], isLoading: false };
     });
 
-    renderWithProviders(<GuiasPage />);
+    renderWithProviders(await GuiasPage());
 
     const image = screen.getByTestId('next-image');
     expect(image).toHaveAttribute('src', expect.stringContaining('guia-numerologia-hero.webp'));
     expect(screen.queryByTestId('guia-thumb-fallback')).not.toBeInTheDocument();
+  });
+
+  it('⚠️ T-SEO-003: resuelve las siete categorías en el servidor y las siembra', async () => {
+    const tarotGuide = buildGuideArticle(
+      1,
+      'guia-tarot',
+      'Guía del Tarot',
+      ArticleCategory.GUIDE_TAROT
+    );
+    mockGetArticlesByCategories.mockResolvedValue({
+      [ArticleCategory.GUIDE_TAROT]: [tarotGuide],
+    });
+    mockUseArticlesByCategory.mockReturnValue({ data: [], isLoading: false });
+
+    renderWithProviders(await GuiasPage());
+
+    expect(mockGetArticlesByCategories).toHaveBeenCalledWith(GUIDE_CATEGORIES);
+    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(ArticleCategory.GUIDE_TAROT, [
+      tarotGuide,
+    ]);
+    expect(mockUseArticlesByCategory).toHaveBeenCalledWith(
+      ArticleCategory.GUIDE_PENDULUM,
+      undefined
+    );
+  });
+
+  it('⚠️ T-SEO-003: renderiza la introducción editorial indexable', async () => {
+    mockUseArticlesByCategory.mockReturnValue({ data: [], isLoading: false });
+
+    renderWithProviders(await GuiasPage());
+
+    expect(screen.getByTestId('listing-intro')).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/enciclopedia/guias/page.tsx
+++ b/frontend/src/app/enciclopedia/guias/page.tsx
@@ -1,16 +1,34 @@
 import type { Metadata } from 'next';
 
+import { ListingIntro } from '@/components/common/ListingIntro';
 import { GuiasContent } from '@/components/features/encyclopedia/GuiasContent';
+import { getArticlesByCategories } from '@/lib/api/encyclopedia-articles-api';
+import { LISTING_INTROS } from '@/lib/constants/listing-intros.data';
 import { STATIC_PAGE_METADATA } from '@/lib/metadata/page-metadata';
+import { GUIDE_CATEGORIES } from '@/types/encyclopedia-article.types';
 
 /**
  * Guías List Page
  *
  * Route: /enciclopedia/guias
  * Listado de las 7 guías prácticas de espiritualidad.
+ *
+ * Servía 13 palabras propias: las siete tarjetas llegaban por el cliente
+ * (T-SEO-003). Ahora la ruta resuelve las siete categorías en el servidor y
+ * `GuiasContent` siembra React Query con ellas.
  */
 export const metadata: Metadata = STATIC_PAGE_METADATA.enciclopediaGuias;
 
-export default function GuiasPage() {
-  return <GuiasContent />;
+/** Las guías son contenido estático; un día de ISR alcanza. */
+export const revalidate = 86400;
+
+export default async function GuiasPage() {
+  const initialArticlesByCategory = await getArticlesByCategories(GUIDE_CATEGORIES);
+
+  return (
+    <>
+      <GuiasContent initialArticlesByCategory={initialArticlesByCategory} />
+      <ListingIntro intro={LISTING_INTROS.enciclopediaGuias} />
+    </>
+  );
 }

--- a/frontend/src/app/enciclopedia/page.test.tsx
+++ b/frontend/src/app/enciclopedia/page.test.tsx
@@ -136,4 +136,12 @@ describe('EnciclopediaPage (Hub principal)', () => {
     const hub = screen.getByTestId('encyclopedia-hub');
     expect(hub.textContent ?? '').not.toMatch(/[🃏⭐📚]/u);
   });
+
+  it('⚠️ T-SEO-003: renderiza la introducción editorial indexable del hub', () => {
+    renderWithProviders(<EnciclopediaPage />);
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Cómo usar la Enciclopedia Mística' })
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/enciclopedia/page.tsx
+++ b/frontend/src/app/enciclopedia/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 
+import { ListingIntro } from '@/components/common/ListingIntro';
 import { EnciclopediaHubContent } from '@/components/features/encyclopedia/EnciclopediaHubContent';
+import { LISTING_INTROS } from '@/lib/constants/listing-intros.data';
 import { STATIC_PAGE_METADATA } from '@/lib/metadata/page-metadata';
 
 /**
@@ -9,9 +11,18 @@ import { STATIC_PAGE_METADATA } from '@/lib/metadata/page-metadata';
  * Route: /enciclopedia
  * Hub principal que muestra las 3 secciones: Tarot, Astrología, Guías.
  * All business logic is delegated to EnciclopediaHubContent component.
+ *
+ * El hub ya se renderizaba entero en el servidor, pero eran 70 palabras: tres
+ * tarjetas y poco más. La introducción editorial le da contenido propio
+ * (T-SEO-003).
  */
 export const metadata: Metadata = STATIC_PAGE_METADATA.enciclopedia;
 
 export default function EnciclopediaPage() {
-  return <EnciclopediaHubContent />;
+  return (
+    <>
+      <EnciclopediaHubContent />
+      <ListingIntro intro={LISTING_INTROS.enciclopedia} />
+    </>
+  );
 }

--- a/frontend/src/app/enciclopedia/tarot/page.test.tsx
+++ b/frontend/src/app/enciclopedia/tarot/page.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import EnciclopediaTarotPage from './page';
+import { ArcanaType, type CardSummary } from '@/types/encyclopedia.types';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -14,14 +15,35 @@ vi.mock('next/navigation', () => ({
   }),
 }));
 
+const mockUseCards = vi.fn((_filters?: unknown, _initialData?: unknown) => ({
+  data: [] as CardSummary[],
+  isLoading: false,
+}));
+
 vi.mock('@/hooks/api/useEncyclopedia', () => ({
-  useCards: () => ({ data: [], isLoading: false }),
+  useCards: (filters: unknown, initialData: unknown) => mockUseCards(filters, initialData),
   useMajorArcana: () => ({ data: [], isLoading: false }),
   useCardsBySuit: () => ({ data: [], isLoading: false }),
   useSearchCards: () => ({ data: [], isLoading: false }),
 }));
 
+const mockGetCards = vi.fn();
+
+vi.mock('@/lib/api/encyclopedia-api', () => ({
+  getCards: () => mockGetCards(),
+}));
+
 // ─── Test setup ───────────────────────────────────────────────────────────────
+
+const card: CardSummary = {
+  id: 1,
+  slug: 'el-loco',
+  nameEs: 'El Loco',
+  arcanaType: ArcanaType.MAJOR,
+  number: 0,
+  suit: null,
+  thumbnailUrl: '/images/tarot/major/00-the-fool.jpg',
+};
 
 function createTestQueryClient() {
   return new QueryClient({
@@ -39,11 +61,37 @@ function renderWithProviders(ui: React.ReactElement) {
 describe('EnciclopediaTarotPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseCards.mockReturnValue({ data: [], isLoading: false });
+    mockGetCards.mockResolvedValue([card]);
   });
 
-  it('debe renderizar el contenido de la enciclopedia de tarot', () => {
-    renderWithProviders(<EnciclopediaTarotPage />);
+  it('debe renderizar el contenido de la enciclopedia de tarot', async () => {
+    renderWithProviders(await EnciclopediaTarotPage());
 
     expect(screen.getByText('Enciclopedia del Tarot')).toBeInTheDocument();
+  });
+
+  it('⚠️ T-SEO-003: resuelve las cartas en el servidor y las siembra en el cliente', async () => {
+    renderWithProviders(await EnciclopediaTarotPage());
+
+    expect(mockGetCards).toHaveBeenCalledTimes(1);
+    expect(mockUseCards).toHaveBeenCalledWith(undefined, [card]);
+  });
+
+  it('⚠️ T-SEO-003: si la API falla, la ruta sigue sirviendo su contenido propio', async () => {
+    mockGetCards.mockRejectedValue(new Error('API caída'));
+
+    renderWithProviders(await EnciclopediaTarotPage());
+
+    expect(mockUseCards).toHaveBeenCalledWith(undefined, undefined);
+    expect(screen.getByTestId('listing-intro')).toBeInTheDocument();
+  });
+
+  it('⚠️ T-SEO-003: renderiza la introducción editorial indexable', async () => {
+    renderWithProviders(await EnciclopediaTarotPage());
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Las 78 cartas, carta por carta' })
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/enciclopedia/tarot/page.tsx
+++ b/frontend/src/app/enciclopedia/tarot/page.tsx
@@ -1,17 +1,35 @@
 import type { Metadata } from 'next';
 
+import { ListingIntro } from '@/components/common/ListingIntro';
 import { EnciclopediaContent } from '@/components/features/encyclopedia/EnciclopediaContent';
+import { getCards } from '@/lib/api/encyclopedia-api';
+import { LISTING_INTROS } from '@/lib/constants/listing-intros.data';
 import { STATIC_PAGE_METADATA } from '@/lib/metadata/page-metadata';
+import { resolveListingData } from '@/lib/metadata/route-data';
 
 /**
  * Enciclopedia Tarot Page
  *
  * Route: /enciclopedia/tarot
  * Listado de las 78 cartas del tarot.
- * All business logic is delegated to EnciclopediaContent component.
+ *
+ * Servía 24 palabras propias: el listado llegaba por el cliente, así que el
+ * crawler solo veía el encabezado y el esqueleto (T-SEO-003). Ahora la ruta
+ * resuelve las cartas en el servidor y `EnciclopediaContent` siembra React Query
+ * con ellas. La introducción editorial es el piso que queda aunque la API falle.
  */
 export const metadata: Metadata = STATIC_PAGE_METADATA.enciclopediaTarot;
 
-export default function EnciclopediaTarotPage() {
-  return <EnciclopediaContent />;
+/** El mazo no cambia; un día de ISR alcanza, igual que en las fichas. */
+export const revalidate = 86400;
+
+export default async function EnciclopediaTarotPage() {
+  const initialCards = await resolveListingData(() => getCards());
+
+  return (
+    <>
+      <EnciclopediaContent initialCards={initialCards} />
+      <ListingIntro intro={LISTING_INTROS.enciclopediaTarot} />
+    </>
+  );
 }

--- a/frontend/src/app/explorar/page.test.tsx
+++ b/frontend/src/app/explorar/page.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import ExplorarPage from './page';
-import type { Tarotista } from '@/types';
+import type { PaginatedTarotistas, Tarotista } from '@/types';
 
 // Mock Next.js router
 vi.mock('next/navigation', () => ({
@@ -13,6 +13,14 @@ vi.mock('next/navigation', () => ({
 // Mock useTarotistas hook
 vi.mock('@/hooks/api/useTarotistas', () => ({
   useTarotistas: vi.fn(),
+}));
+
+// La ruta es un server component desde T-SEO-003: resuelve la primera página
+// del listado y se la pasa al componente cliente.
+const mockGetTarotistas = vi.fn();
+
+vi.mock('@/lib/api/tarotistas-api', () => ({
+  getTarotistas: () => mockGetTarotistas(),
 }));
 
 const mockTarotistas: Tarotista[] = [
@@ -78,8 +86,17 @@ function renderWithProviders(ui: React.ReactElement) {
 describe('ExplorarPage', () => {
   const mockPush = vi.fn();
 
+  const seededPage: PaginatedTarotistas = {
+    data: mockTarotistas,
+    total: 3,
+    page: 1,
+    limit: 10,
+    totalPages: 1,
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetTarotistas.mockResolvedValue(seededPage);
     (useRouter as ReturnType<typeof vi.fn>).mockReturnValue({
       push: mockPush,
     });
@@ -94,7 +111,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       expect(screen.getByText('Nuestros Guías Espirituales')).toBeInTheDocument();
     });
@@ -107,7 +124,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       expect(screen.getByText('Encuentra al mentor ideal para tu camino')).toBeInTheDocument();
     });
@@ -120,7 +137,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       const title = screen.getByText('Nuestros Guías Espirituales');
       expect(title.className).toContain('font-serif');
@@ -136,7 +153,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       const searchInput = screen.getByPlaceholderText(/buscar/i);
       expect(searchInput).toBeInTheDocument();
@@ -150,7 +167,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       const filterButtons = screen.getAllByRole('button');
       const filterTexts = filterButtons.map((btn) => btn.textContent);
@@ -171,7 +188,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       const todosChip = screen.getByText('Todos');
       expect(todosChip.className).toContain('bg-primary');
@@ -185,7 +202,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       const filterButtons = screen.getAllByRole('button');
       const amorChip = filterButtons.find((btn) => btn.textContent === 'Amor');
@@ -209,7 +226,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       const skeletons = screen.getAllByTestId('skeleton-tarotist-photo');
       expect(skeletons.length).toBeGreaterThan(0);
@@ -223,7 +240,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       await waitFor(() => {
         expect(screen.getByText('Luna Mística')).toBeInTheDocument();
@@ -240,7 +257,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      const { container } = renderWithProviders(<ExplorarPage />);
+      const { container } = renderWithProviders(await ExplorarPage());
 
       const grid = container.querySelector('.grid');
       expect(grid?.className).toContain('grid-cols-1');
@@ -256,7 +273,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       await waitFor(() => {
         const verPerfilButtons = screen.getAllByText('Ver Perfil');
@@ -276,7 +293,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       await waitFor(() => {
         expect(screen.getByText('No encontramos guías con ese criterio')).toBeInTheDocument();
@@ -291,7 +308,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       await waitFor(() => {
         expect(screen.getByText('Limpiar filtros')).toBeInTheDocument();
@@ -306,7 +323,7 @@ describe('ExplorarPage', () => {
         error: null,
       });
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       await waitFor(() => {
         const clearButton = screen.getByText('Limpiar filtros');
@@ -330,7 +347,7 @@ describe('ExplorarPage', () => {
 
       (useTarotistas as ReturnType<typeof vi.fn>).mockImplementation(mockUseTarotistas);
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       const searchInput = screen.getByPlaceholderText(/buscar/i);
       fireEvent.change(searchInput, { target: { value: 'Luna' } });
@@ -339,7 +356,8 @@ describe('ExplorarPage', () => {
       await waitFor(
         () => {
           expect(mockUseTarotistas).toHaveBeenCalledWith(
-            expect.objectContaining({ search: 'Luna' })
+            expect.objectContaining({ search: 'Luna' }),
+            undefined
           );
         },
         { timeout: 500 }
@@ -358,7 +376,7 @@ describe('ExplorarPage', () => {
 
       (useTarotistas as ReturnType<typeof vi.fn>).mockImplementation(mockUseTarotistas);
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       const filterButtons = screen.getAllByRole('button');
       const amorChip = filterButtons.find((btn) => btn.textContent === 'Amor');
@@ -369,7 +387,8 @@ describe('ExplorarPage', () => {
 
       await waitFor(() => {
         expect(mockUseTarotistas).toHaveBeenCalledWith(
-          expect.objectContaining({ especialidad: 'Amor' })
+          expect.objectContaining({ especialidad: 'Amor' }),
+          undefined
         );
       });
     });
@@ -384,7 +403,7 @@ describe('ExplorarPage', () => {
 
       (useTarotistas as ReturnType<typeof vi.fn>).mockImplementation(mockUseTarotistas);
 
-      renderWithProviders(<ExplorarPage />);
+      renderWithProviders(await ExplorarPage());
 
       // Select a specialty first
       const filterButtons = screen.getAllByRole('button');
@@ -396,7 +415,8 @@ describe('ExplorarPage', () => {
 
       await waitFor(() => {
         expect(mockUseTarotistas).toHaveBeenCalledWith(
-          expect.objectContaining({ especialidad: 'Amor' })
+          expect.objectContaining({ especialidad: 'Amor' }),
+          undefined
         );
       });
 
@@ -408,8 +428,44 @@ describe('ExplorarPage', () => {
       fireEvent.click(todosChip);
 
       await waitFor(() => {
-        expect(mockUseTarotistas).toHaveBeenCalledWith(expect.objectContaining({}));
+        expect(mockUseTarotistas).toHaveBeenCalledWith(expect.objectContaining({}), seededPage);
       });
+    });
+  });
+
+  describe('Contenido indexable (T-SEO-003)', () => {
+    it('⚠️ resuelve la primera página en el servidor y la siembra en el cliente', async () => {
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      const mockUseTarotistas = vi.fn().mockReturnValue({
+        data: seededPage,
+        isLoading: false,
+        error: null,
+      });
+      (useTarotistas as ReturnType<typeof vi.fn>).mockImplementation(mockUseTarotistas);
+
+      renderWithProviders(await ExplorarPage());
+
+      expect(mockGetTarotistas).toHaveBeenCalledTimes(1);
+      expect(mockUseTarotistas).toHaveBeenCalledWith(expect.objectContaining({}), seededPage);
+      expect(screen.getByText('Luna Mística')).toBeInTheDocument();
+    });
+
+    it('⚠️ si la API falla, la ruta sigue sirviendo su contenido propio', async () => {
+      mockGetTarotistas.mockRejectedValue(new Error('API caída'));
+      const { useTarotistas } = await import('@/hooks/api/useTarotistas');
+      const mockUseTarotistas = vi.fn().mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: null,
+      });
+      (useTarotistas as ReturnType<typeof vi.fn>).mockImplementation(mockUseTarotistas);
+
+      renderWithProviders(await ExplorarPage());
+
+      expect(mockUseTarotistas).toHaveBeenCalledWith(expect.objectContaining({}), undefined);
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'Cómo elegir un guía espiritual' })
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/explorar/page.tsx
+++ b/frontend/src/app/explorar/page.tsx
@@ -1,24 +1,28 @@
-'use client';
-
-import { useRouter } from 'next/navigation';
-import { TarotistasExplorer } from '@/components/features/marketplace';
+import { ListingIntro } from '@/components/common/ListingIntro';
+import { ExplorarContent } from '@/components/features/marketplace';
+import { getTarotistas } from '@/lib/api/tarotistas-api';
+import { LISTING_INTROS } from '@/lib/constants/listing-intros.data';
+import { resolveListingData } from '@/lib/metadata/route-data';
 
 /**
  * Explorar Page - Tarotistas Marketplace
  *
  * Public page that displays the marketplace of tarotistas.
- * All business logic is delegated to TarotistasExplorer component.
+ *
+ * Servía 20 palabras propias: la ruta era un client component y el listado
+ * llegaba por el cliente (T-SEO-003). Ahora resuelve en el servidor la
+ * **primera página** —el endpoint es paginado— y `ExplorarContent` la siembra.
+ * La navegación al perfil vive en ese componente cliente.
  */
-export default function ExplorarPage() {
-  const router = useRouter();
+export const revalidate = 3600;
 
-  const handleViewProfile = (id: number) => {
-    router.push(`/tarotistas/${id}`);
-  };
+export default async function ExplorarPage() {
+  const initialTarotistas = await resolveListingData(() => getTarotistas());
 
   return (
-    <div className="bg-bg-main min-h-screen p-8">
-      <TarotistasExplorer onViewProfile={handleViewProfile} />
-    </div>
+    <>
+      <ExplorarContent initialTarotistas={initialTarotistas} />
+      <ListingIntro intro={LISTING_INTROS.explorar} />
+    </>
   );
 }

--- a/frontend/src/app/premium/page.test.tsx
+++ b/frontend/src/app/premium/page.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import PremiumRoute from './page';
+import type { PlanConfig } from '@/types/admin.types';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockFetchPublicPlans = vi.fn();
+
+vi.mock('@/lib/api/public-plans-api', () => ({
+  fetchPublicPlans: () => mockFetchPublicPlans(),
+}));
+
+// La página en sí ya está cubierta por `PremiumPage.test.tsx`; acá interesa qué
+// le pasa la ruta.
+const mockPremiumPage = vi.fn();
+
+vi.mock('@/components/features/premium', () => ({
+  PremiumPage: (props: { initialPlans?: PlanConfig[] }) => {
+    mockPremiumPage(props);
+    return <div data-testid="premium-page">{props.initialPlans?.length ?? 0}</div>;
+  },
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const premiumPlan = {
+  id: 2,
+  planType: 'premium',
+  name: 'Premium',
+  description: 'Todo el potencial del tarot',
+  price: 4999,
+} as PlanConfig;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('PremiumRoute (/premium)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchPublicPlans.mockResolvedValue([premiumPlan]);
+  });
+
+  it('⚠️ T-SEO-003: resuelve los planes en el servidor y los siembra en el cliente', async () => {
+    render(await PremiumRoute());
+
+    expect(mockFetchPublicPlans).toHaveBeenCalledTimes(1);
+    expect(mockPremiumPage).toHaveBeenCalledWith({ initialPlans: [premiumPlan] });
+  });
+
+  it('⚠️ T-SEO-003: si la API falla, la ruta igual renderiza la página', async () => {
+    // El contenido estático —comparativa y FAQ— ya no depende de los planes.
+    mockFetchPublicPlans.mockRejectedValue(new Error('API caída'));
+
+    render(await PremiumRoute());
+
+    expect(mockPremiumPage).toHaveBeenCalledWith({ initialPlans: undefined });
+    expect(screen.getByTestId('premium-page')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/premium/page.tsx
+++ b/frontend/src/app/premium/page.tsx
@@ -1,10 +1,27 @@
 import type { Metadata } from 'next';
 
 import { PremiumPage } from '@/components/features/premium';
+import { fetchPublicPlans } from '@/lib/api/public-plans-api';
 import { STATIC_PAGE_METADATA } from '@/lib/metadata/page-metadata';
+import { resolveListingData } from '@/lib/metadata/route-data';
 
+/**
+ * Página de planes.
+ *
+ * Route: /premium
+ *
+ * Servía **3 palabras propias**, el peor caso del sitio junto con el horóscopo
+ * chino: la comparativa, las FAQ y el resto del contenido estático estaban
+ * detrás de un esqueleto que esperaba a `usePublicPlans` (T-SEO-003). Ahora la
+ * ruta resuelve los planes en el servidor y el contenido ya no depende de eso.
+ */
 export const metadata: Metadata = STATIC_PAGE_METADATA.premium;
 
-export default function PremiumRoute() {
-  return <PremiumPage />;
+/** El precio se edita desde el admin: una hora de ISR. */
+export const revalidate = 3600;
+
+export default async function PremiumRoute() {
+  const initialPlans = await resolveListingData(fetchPublicPlans);
+
+  return <PremiumPage initialPlans={initialPlans} />;
 }

--- a/frontend/src/app/servicios/page.test.tsx
+++ b/frontend/src/app/servicios/page.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import ServiciosRoute from './page';
+import type { HolisticService } from '@/types';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const mockGetHolisticServices = vi.fn();
+
+vi.mock('@/lib/api/holistic-services-api', () => ({
+  getHolisticServices: () => mockGetHolisticServices(),
+}));
+
+// El catálogo en sí ya está cubierto por `ServiciosPage.test.tsx`; acá interesa
+// qué le pasa la ruta.
+const mockServiciosPage = vi.fn();
+
+vi.mock('@/components/features/holistic-services', () => ({
+  ServiciosPage: (props: { initialServices?: HolisticService[] }) => {
+    mockServiciosPage(props);
+    return <div data-testid="servicios-page">{props.initialServices?.length ?? 0}</div>;
+  },
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const service = {
+  id: 1,
+  name: 'Árbol Genealógico',
+  slug: 'arbol-genealogico',
+  shortDescription: 'Sanación a través del árbol genealógico familiar',
+  priceArs: 15000,
+  durationMinutes: 90,
+  sessionType: 'family_tree',
+  imageUrl: null,
+  displayOrder: 1,
+  isActive: true,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+} as HolisticService;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ServiciosRoute (/servicios)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetHolisticServices.mockResolvedValue([service]);
+  });
+
+  it('⚠️ T-SEO-003: resuelve el catálogo en el servidor y lo siembra en el cliente', async () => {
+    render(await ServiciosRoute());
+
+    expect(mockGetHolisticServices).toHaveBeenCalledTimes(1);
+    expect(mockServiciosPage).toHaveBeenCalledWith({ initialServices: [service] });
+  });
+
+  it('⚠️ T-SEO-003: si la API falla, la ruta sigue sirviendo su contenido propio', async () => {
+    mockGetHolisticServices.mockRejectedValue(new Error('API caída'));
+
+    render(await ServiciosRoute());
+
+    expect(mockServiciosPage).toHaveBeenCalledWith({ initialServices: undefined });
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Cómo funcionan los servicios holísticos' })
+    ).toBeInTheDocument();
+  });
+
+  it('renderiza la introducción editorial indexable', async () => {
+    render(await ServiciosRoute());
+
+    expect(screen.getByTestId('listing-intro')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/servicios/page.tsx
+++ b/frontend/src/app/servicios/page.tsx
@@ -2,14 +2,32 @@
  * Servicios Holísticos - Catalog Page
  *
  * Public page listing all available holistic services.
+ *
+ * Servía 5 palabras propias: el catálogo llegaba por el cliente, así que el
+ * crawler veía el título y seis esqueletos (T-SEO-003). Ahora la ruta resuelve
+ * los servicios en el servidor y `ServiciosPage` siembra React Query con ellos.
  */
 import type { Metadata } from 'next';
 
+import { ListingIntro } from '@/components/common/ListingIntro';
 import { ServiciosPage } from '@/components/features/holistic-services';
+import { getHolisticServices } from '@/lib/api/holistic-services-api';
+import { LISTING_INTROS } from '@/lib/constants/listing-intros.data';
 import { STATIC_PAGE_METADATA } from '@/lib/metadata/page-metadata';
+import { resolveListingData } from '@/lib/metadata/route-data';
 
 export const metadata: Metadata = STATIC_PAGE_METADATA.servicios;
 
-export default function ServiciosRoute() {
-  return <ServiciosPage />;
+/** El catálogo y los precios se editan desde el admin: una hora de ISR. */
+export const revalidate = 3600;
+
+export default async function ServiciosRoute() {
+  const initialServices = await resolveListingData(getHolisticServices);
+
+  return (
+    <>
+      <ServiciosPage initialServices={initialServices} />
+      <ListingIntro intro={LISTING_INTROS.servicios} />
+    </>
+  );
 }

--- a/frontend/src/components/common/ListingIntro.test.tsx
+++ b/frontend/src/components/common/ListingIntro.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ListingIntro } from './ListingIntro';
+import type { ListingIntroData } from '@/lib/constants/listing-intros.data';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const intro: ListingIntroData = {
+  title: 'Qué vas a encontrar acá',
+  lead: 'Un párrafo de entrada que explica la sección.',
+  sections: [
+    { heading: 'Cómo leerlo', body: 'Primer bloque explicativo de la sección.' },
+    { heading: 'Por dónde seguir', body: 'Segundo bloque explicativo de la sección.' },
+  ],
+  links: [{ label: 'Ver el tarot', href: '/enciclopedia/tarot' }],
+};
+
+describe('ListingIntro', () => {
+  it('renderiza el título como encabezado de segundo nivel', () => {
+    render(<ListingIntro intro={intro} />);
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Qué vas a encontrar acá' })
+    ).toBeVisible();
+  });
+
+  it('⚠️ T-SEO-003: renderiza el lead y el cuerpo de cada sección en el HTML', () => {
+    render(<ListingIntro intro={intro} />);
+
+    expect(screen.getByText('Un párrafo de entrada que explica la sección.')).toBeVisible();
+    expect(screen.getByText('Primer bloque explicativo de la sección.')).toBeVisible();
+    expect(screen.getByText('Segundo bloque explicativo de la sección.')).toBeVisible();
+  });
+
+  it('renderiza los encabezados de sección como h3', () => {
+    render(<ListingIntro intro={intro} />);
+
+    expect(screen.getByRole('heading', { level: 3, name: 'Cómo leerlo' })).toBeVisible();
+    expect(screen.getByRole('heading', { level: 3, name: 'Por dónde seguir' })).toBeVisible();
+  });
+
+  it('renderiza los enlaces internos como anclas reales para que el crawler los recorra', () => {
+    render(<ListingIntro intro={intro} />);
+
+    expect(screen.getByRole('link', { name: 'Ver el tarot' })).toHaveAttribute(
+      'href',
+      '/enciclopedia/tarot'
+    );
+  });
+
+  it('funciona sin enlaces', () => {
+    render(<ListingIntro intro={{ ...intro, links: undefined }} />);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByTestId('listing-intro')).toBeInTheDocument();
+  });
+
+  it('acepta clases adicionales', () => {
+    render(<ListingIntro intro={intro} className="mt-10" />);
+
+    expect(screen.getByTestId('listing-intro')).toHaveClass('mt-10');
+  });
+});

--- a/frontend/src/components/common/ListingIntro.tsx
+++ b/frontend/src/components/common/ListingIntro.tsx
@@ -1,0 +1,69 @@
+// 1. React & Next.js
+import Link from 'next/link';
+
+// 6. Utils & types
+import { cn } from '@/lib/utils';
+import type { ListingIntroData } from '@/lib/constants/listing-intros.data';
+
+/**
+ * ListingIntro
+ *
+ * Bloque editorial de una ruta de listado o hub (T-SEO-003). Sin `'use client'`
+ * a propósito: es el contenido que tiene que llegar al crawler aunque la API no
+ * responda y aunque el listado de arriba se quede en su esqueleto.
+ *
+ * El texto vive en `listing-intros.data.ts`, no acá: así el guardarraíl de
+ * palabras y de unicidad puede verificarlo sin renderizar nada.
+ *
+ * @example
+ * ```tsx
+ * import { LISTING_INTROS } from '@/lib/constants/listing-intros.data';
+ *
+ * <ListingIntro intro={LISTING_INTROS.enciclopediaTarot} />
+ * ```
+ */
+export interface ListingIntroProps {
+  /** Contenido a renderizar. */
+  intro: ListingIntroData;
+  /** Clases CSS adicionales. */
+  className?: string;
+}
+
+export function ListingIntro({ intro, className }: ListingIntroProps) {
+  const { title, lead, sections, links } = intro;
+
+  return (
+    <section
+      data-testid="listing-intro"
+      className={cn('container mx-auto px-4 pt-4 pb-12', className)}
+    >
+      <div className="border-border bg-card mx-auto max-w-3xl rounded-2xl border p-6 sm:p-8">
+        <h2 className="text-card-foreground font-serif text-2xl font-bold">{title}</h2>
+        <p className="text-muted-foreground mt-3 leading-relaxed">{lead}</p>
+
+        <div className="mt-6 grid gap-6 sm:grid-cols-2">
+          {sections.map((section) => (
+            <div key={section.heading}>
+              <h3 className="text-card-foreground font-semibold">{section.heading}</h3>
+              <p className="text-muted-foreground mt-2 text-sm leading-relaxed">{section.body}</p>
+            </div>
+          ))}
+        </div>
+
+        {links && links.length > 0 && (
+          <nav className="border-border mt-6 flex flex-wrap gap-x-6 gap-y-2 border-t pt-4">
+            {links.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="text-secondary focus-visible:ring-secondary rounded-sm text-sm font-medium underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:outline-none"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/features/encyclopedia/ArticleListPageContent.tsx
+++ b/frontend/src/components/features/encyclopedia/ArticleListPageContent.tsx
@@ -20,6 +20,12 @@ interface ArticleListPageContentProps {
   subtitle: string;
   /** Base path for detail URLs — slug will be appended: `${detailHrefPrefix}/${slug}` */
   detailHrefPrefix: string;
+  /**
+   * Artículos resueltos por la ruta en el servidor (T-SEO-003). Siembran la
+   * caché para que el HTML que ve Googlebot traiga la lista en vez de seis
+   * esqueletos: los tres listados servían entre 18 y 26 palabras propias.
+   */
+  initialArticles?: ArticleSummary[];
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
@@ -61,8 +67,9 @@ export function ArticleListPageContent({
   title,
   subtitle,
   detailHrefPrefix,
+  initialArticles,
 }: ArticleListPageContentProps) {
-  const { data: articles, isLoading } = useArticlesByCategory(category);
+  const { data: articles, isLoading } = useArticlesByCategory(category, initialArticles);
 
   const isAstro = isAstroCategory(category);
   const heroImage = isAstro ? getAstroCategoryHero(category) : undefined;

--- a/frontend/src/components/features/encyclopedia/EnciclopediaContent.tsx
+++ b/frontend/src/components/features/encyclopedia/EnciclopediaContent.tsx
@@ -15,6 +15,19 @@ import {
   useSearchCards,
 } from '@/hooks/api/useEncyclopedia';
 import { ArcanaType, Suit } from '@/types/encyclopedia.types';
+import type { CardSummary } from '@/types/encyclopedia.types';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface EnciclopediaContentProps {
+  /**
+   * Cartas resueltas por la ruta en el servidor (T-SEO-003). Siembran la vista
+   * por defecto —todas las cartas— para que el HTML que ve Googlebot traiga el
+   * listado en vez del esqueleto. Los filtros y la búsqueda siguen pidiendo a la
+   * API con su propia clave de caché.
+   */
+  initialCards?: CardSummary[];
+}
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -32,7 +45,7 @@ import { ArcanaType, Suit } from '@/types/encyclopedia.types';
  * - `searchQuery`: debounced query used for API calls (updated only via onSearch callback)
  * This separation ensures the debounce in EncyclopediaSearchBar is actually effective.
  */
-export function EnciclopediaContent() {
+export function EnciclopediaContent({ initialCards }: EnciclopediaContentProps = {}) {
   const [selectedCategory, setSelectedCategory] = useState<ArcanaType | undefined>(undefined);
   const [selectedSuit, setSelectedSuit] = useState<Suit | null>(null);
   // inputValue: controlled input state (immediate, no debounce)
@@ -42,7 +55,7 @@ export function EnciclopediaContent() {
 
   // ─── Queries ─────────────────────────────────────────────────────────────
 
-  const allCards = useCards();
+  const allCards = useCards(undefined, initialCards);
   const majorCards = useMajorArcana();
   const suitCards = useCardsBySuit(selectedSuit ?? Suit.WANDS);
   const searchResults = useSearchCards(searchQuery);

--- a/frontend/src/components/features/encyclopedia/GuiasContent.tsx
+++ b/frontend/src/components/features/encyclopedia/GuiasContent.tsx
@@ -9,7 +9,7 @@ import { Reveal } from '@/components/common';
 // 6. Utils & types
 import { useArticlesByCategory } from '@/hooks/api/useEncyclopediaArticles';
 import { ROUTES } from '@/lib/constants/routes';
-import { ArticleCategory } from '@/types/encyclopedia-article.types';
+import { ArticleCategory, GUIDE_CATEGORIES } from '@/types/encyclopedia-article.types';
 import type { ArticleSummary } from '@/types/encyclopedia-article.types';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -36,19 +36,6 @@ const THUMB_OVERLAY =
 const GOLD_FILLET = 'linear-gradient(90deg, transparent, #d69e2e, transparent)';
 const CREAM = '#f9f7f2';
 const CREAM_MUTED = 'rgba(249, 247, 242, 0.72)';
-
-/**
- * Guide categories, in display order. The Tarot guide stays first (BUG-017 fix).
- */
-const GUIDE_CATEGORIES: ArticleCategory[] = [
-  ArticleCategory.GUIDE_TAROT,
-  ArticleCategory.GUIDE_NUMEROLOGY,
-  ArticleCategory.GUIDE_PENDULUM,
-  ArticleCategory.GUIDE_BIRTH_CHART,
-  ArticleCategory.GUIDE_RITUAL,
-  ArticleCategory.GUIDE_HOROSCOPE,
-  ArticleCategory.GUIDE_CHINESE,
-];
 
 /**
  * Per-category editorial theme: short gold chip label and a themed thumbnail.
@@ -216,11 +203,13 @@ export function GuiaCard({ article }: GuiaCardProps) {
 function CategorySection({
   category,
   categoryIndex,
+  initialArticles,
 }: {
   category: ArticleCategory;
   categoryIndex: number;
+  initialArticles?: ArticleSummary[];
 }) {
-  const { data: articles } = useArticlesByCategory(category);
+  const { data: articles } = useArticlesByCategory(category, initialArticles);
   return (
     <>
       {(articles ?? []).map((article, articleIndex) => (
@@ -243,7 +232,16 @@ function CategorySection({
  * título Cormorant, snippet y CTA), reemplazando las filas planas previas
  * (T-ENC-006 / hallazgo ENC-005). Usa una llamada al hook por categoría.
  */
-export function GuiasContent() {
+export interface GuiasContentProps {
+  /**
+   * Guías resueltas por la ruta en el servidor, indexadas por categoría
+   * (T-SEO-003). Siembran cada `CategorySection` para que el HTML que ve
+   * Googlebot traiga las siete tarjetas en vez de una grilla vacía.
+   */
+  initialArticlesByCategory?: Partial<Record<ArticleCategory, ArticleSummary[]>>;
+}
+
+export function GuiasContent({ initialArticlesByCategory }: GuiasContentProps = {}) {
   return (
     <div className="container mx-auto px-4 py-8">
       {/* Banda de cabecera con identidad de marca */}
@@ -278,7 +276,12 @@ export function GuiasContent() {
       {/* Grid de tarjetas — reveal fade-up escalonado al entrar en viewport */}
       <div className="grid gap-6 md:grid-cols-2">
         {GUIDE_CATEGORIES.map((category, categoryIndex) => (
-          <CategorySection key={category} category={category} categoryIndex={categoryIndex} />
+          <CategorySection
+            key={category}
+            category={category}
+            categoryIndex={categoryIndex}
+            initialArticles={initialArticlesByCategory?.[category]}
+          />
         ))}
       </div>
     </div>

--- a/frontend/src/components/features/holistic-services/ServiciosPage.test.tsx
+++ b/frontend/src/components/features/holistic-services/ServiciosPage.test.tsx
@@ -239,4 +239,22 @@ describe('ServiciosPage', () => {
 
     expect(screen.queryByTestId('mis-servicios-link')).not.toBeInTheDocument();
   });
+
+  describe('Sembrado desde el servidor (T-SEO-003)', () => {
+    it('⚠️ pasa el catálogo sembrado al hook para que el HTML no salga vacío', () => {
+      vi.mocked(useHolisticServicesHook.useHolisticServices).mockReturnValue({
+        data: mockServices,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useHolisticServicesHook.useHolisticServices>);
+
+      render(<ServiciosPage initialServices={mockServices} />, { wrapper });
+
+      expect(vi.mocked(useHolisticServicesHook.useHolisticServices)).toHaveBeenCalledWith(
+        mockServices
+      );
+      expect(screen.getByTestId('servicios-grid')).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/features/holistic-services/ServiciosPage.tsx
+++ b/frontend/src/components/features/holistic-services/ServiciosPage.tsx
@@ -15,12 +15,22 @@ import { ErrorDisplay } from '@/components/ui/error-display';
 import { useHolisticServices } from '@/hooks/api/useHolisticServices';
 import { useAuthStore } from '@/stores/authStore';
 import { ROUTES } from '@/lib/constants/routes';
+import type { HolisticService } from '@/types/holistic-service.types';
 import { ServiceCard } from './ServiceCard';
 
 const SKELETON_COUNT = 6;
 
-export function ServiciosPage() {
-  const { data: services, isLoading, isError, refetch } = useHolisticServices();
+export interface ServiciosPageProps {
+  /**
+   * Catálogo resuelto por la ruta en el servidor (T-SEO-003). Sin esto la
+   * página servía 5 palabras propias: el crawler veía el título y seis
+   * esqueletos.
+   */
+  initialServices?: HolisticService[];
+}
+
+export function ServiciosPage({ initialServices }: ServiciosPageProps = {}) {
+  const { data: services, isLoading, isError, refetch } = useHolisticServices(initialServices);
   const { isAuthenticated } = useAuthStore();
 
   return (

--- a/frontend/src/components/features/marketplace/ExplorarContent.tsx
+++ b/frontend/src/components/features/marketplace/ExplorarContent.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+// 1. React & Next.js
+import { useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+// 5. Components (ui → features)
+import { TarotistasExplorer } from './TarotistasExplorer';
+// 6. Utils & types
+import type { PaginatedTarotistas } from '@/types';
+
+/**
+ * ExplorarContent
+ *
+ * Parte cliente de `/explorar`. Existe desde T-SEO-003: la ruta era un client
+ * component entero por este `useRouter`, así que el crawler recibía 20 palabras.
+ * Ahora la ruta es un server component que resuelve la primera página del
+ * listado y este componente solo aporta la navegación al perfil.
+ */
+export interface ExplorarContentProps {
+  /** Primera página del listado, resuelta en el servidor. */
+  initialTarotistas?: PaginatedTarotistas;
+}
+
+export function ExplorarContent({ initialTarotistas }: ExplorarContentProps) {
+  const router = useRouter();
+
+  const handleViewProfile = useCallback(
+    (id: number) => {
+      router.push(`/tarotistas/${id}`);
+    },
+    [router]
+  );
+
+  return (
+    <div className="bg-bg-main min-h-screen p-8" data-testid="explorar-content">
+      <TarotistasExplorer onViewProfile={handleViewProfile} initialTarotistas={initialTarotistas} />
+    </div>
+  );
+}

--- a/frontend/src/components/features/marketplace/TarotistasExplorer.tsx
+++ b/frontend/src/components/features/marketplace/TarotistasExplorer.tsx
@@ -9,6 +9,7 @@ import { SkeletonCard } from '@/components/ui/skeleton-card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import type { PaginatedTarotistas } from '@/types';
 
 const SPECIALTIES = ['Todos', 'Amor', 'Dinero', 'Carrera', 'Salud', 'Espiritual'] as const;
 
@@ -18,6 +19,12 @@ const SPECIALTIES = ['Todos', 'Amor', 'Dinero', 'Carrera', 'Salud', 'Espiritual'
 export interface TarotistasExplorerProps {
   /** Callback when a tarotista profile is clicked */
   onViewProfile: (id: number) => void;
+  /**
+   * Primera página del listado, resuelta por la ruta en el servidor
+   * (T-SEO-003). Solo siembra la vista sin filtros: con búsqueda o especialidad
+   * la clave de caché es otra y hay que pedirle a la API.
+   */
+  initialTarotistas?: PaginatedTarotistas;
 }
 
 /**
@@ -32,7 +39,7 @@ export interface TarotistasExplorerProps {
  * - Loading skeleton states
  * - Empty state with clear filters action
  */
-export function TarotistasExplorer({ onViewProfile }: TarotistasExplorerProps) {
+export function TarotistasExplorer({ onViewProfile, initialTarotistas }: TarotistasExplorerProps) {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedSpecialty, setSelectedSpecialty] = useState<string>('Todos');
 
@@ -45,8 +52,12 @@ export function TarotistasExplorer({ onViewProfile }: TarotistasExplorerProps) {
     especialidad: selectedSpecialty !== 'Todos' ? selectedSpecialty : undefined,
   };
 
+  // El sembrado del servidor corresponde al listado sin filtrar: aplicarlo con
+  // filtros activos mostraría resultados que no coinciden con lo pedido.
+  const isDefaultView = !filters.search && !filters.especialidad;
+
   // Fetch tarotistas with filters
-  const { data, isLoading } = useTarotistas(filters);
+  const { data, isLoading } = useTarotistas(filters, isDefaultView ? initialTarotistas : undefined);
 
   const handleClearFilters = () => {
     setSearchTerm('');

--- a/frontend/src/components/features/marketplace/index.ts
+++ b/frontend/src/components/features/marketplace/index.ts
@@ -13,6 +13,9 @@ export type { SessionCardProps } from './SessionCard';
 export { TarotistaCard } from './TarotistaCard';
 export type { TarotistaCardProps } from './TarotistaCard';
 
+export { ExplorarContent } from './ExplorarContent';
+export type { ExplorarContentProps } from './ExplorarContent';
+
 export { TarotistasExplorer } from './TarotistasExplorer';
 export type { TarotistasExplorerProps } from './TarotistasExplorer';
 

--- a/frontend/src/components/features/premium/PremiumPage.test.tsx
+++ b/frontend/src/components/features/premium/PremiumPage.test.tsx
@@ -104,7 +104,7 @@ vi.mock('@/stores/authStore', () => ({
 // Mock public plans hook
 const mockUsePlans = vi.fn();
 vi.mock('@/hooks/api/usePublicPlans', () => ({
-  usePublicPlans: () => mockUsePlans(),
+  usePublicPlans: (initialData?: PlanConfig[]) => mockUsePlans(initialData),
 }));
 
 // Query client factory
@@ -127,13 +127,40 @@ describe('PremiumPage', () => {
   });
 
   describe('Loading state', () => {
-    it('should render loading skeleton when plans are loading', () => {
+    it('should render loading skeleton for the price when plans are loading', () => {
       mockAuthStore.mockReturnValue({ user: null, isAuthenticated: false });
       mockUsePlans.mockReturnValue({ data: undefined, isLoading: true, isError: false });
 
       renderWithProviders(<PremiumPage />);
 
       expect(screen.getByTestId('premium-page-loading')).toBeInTheDocument();
+    });
+
+    it('⚠️ T-SEO-003: el contenido estático se renderiza aunque los planes no hayan cargado', () => {
+      // La página servía 3 palabras propias: un esqueleto de pantalla completa
+      // tapaba la comparativa y las FAQ hasta que respondiera la API.
+      mockAuthStore.mockReturnValue({ user: null, isAuthenticated: false });
+      mockUsePlans.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+
+      renderWithProviders(<PremiumPage />);
+
+      expect(screen.getByTestId('plan-comparison')).toBeInTheDocument();
+      expect(screen.getByTestId('faq-section')).toBeInTheDocument();
+      expect(screen.getByText('¿Puedo cancelar en cualquier momento?')).toBeInTheDocument();
+      expect(screen.getByText('Sin compromiso')).toBeInTheDocument();
+    });
+
+    it('⚠️ T-SEO-003: pasa los planes sembrados por la ruta al hook', () => {
+      mockAuthStore.mockReturnValue({ user: null, isAuthenticated: false });
+      mockUsePlans.mockReturnValue({
+        data: [mockFreePlan, mockPremiumPlan],
+        isLoading: false,
+        isError: false,
+      });
+
+      renderWithProviders(<PremiumPage initialPlans={[mockFreePlan, mockPremiumPlan]} />);
+
+      expect(mockUsePlans).toHaveBeenCalledWith([mockFreePlan, mockPremiumPlan]);
     });
   });
 

--- a/frontend/src/components/features/premium/PremiumPage.tsx
+++ b/frontend/src/components/features/premium/PremiumPage.tsx
@@ -101,18 +101,16 @@ function ComparisonCell({ value }: { value: PlanCell }) {
   );
 }
 
-function PremiumPageSkeleton() {
-  return (
-    <div data-testid="premium-page-loading" className="container mx-auto max-w-5xl px-4 py-10">
-      <Skeleton className="mb-8 h-64 w-full rounded-2xl" />
-      <Skeleton className="mx-auto mb-10 h-8 w-2/3" />
-      <div className="mx-auto grid max-w-3xl gap-8 md:grid-cols-2">
-        {[1, 2].map((i) => (
-          <Skeleton key={i} className="h-80 rounded-xl" />
-        ))}
-      </div>
-    </div>
-  );
+/**
+ * Marcador del precio mientras se resuelven los planes.
+ *
+ * Antes toda la página esperaba a la API detrás de un esqueleto de pantalla
+ * completa, así que `/premium` servía 3 palabras propias: justo la URL que mira
+ * un revisor de AdSense para entender el modelo de negocio (T-SEO-003). Ahora lo
+ * único que espera es el número.
+ */
+function PriceSkeleton() {
+  return <Skeleton data-testid="premium-page-loading" className="mx-auto h-10 w-32" />;
 }
 
 interface PremiumCtaButtonProps {
@@ -188,12 +186,16 @@ function PremiumCtaButton({ premiumPlan, testId, onDark = false }: PremiumCtaBut
 // Main Component
 // ============================================================================
 
-export function PremiumPage() {
-  const { data: plans, isLoading } = usePublicPlans();
+export interface PremiumPageProps {
+  /**
+   * Planes resueltos por la ruta en el servidor (T-SEO-003): el HTML sale con el
+   * precio real en vez de esperar a la API en el cliente.
+   */
+  initialPlans?: PlanConfig[];
+}
 
-  if (isLoading) {
-    return <PremiumPageSkeleton />;
-  }
+export function PremiumPage({ initialPlans }: PremiumPageProps = {}) {
+  const { data: plans, isLoading } = usePublicPlans(initialPlans);
 
   const freePlan = plans?.find((p) => p.planType === 'free');
   const premiumPlan = plans?.find((p) => p.planType === 'premium');
@@ -263,10 +265,16 @@ export function PremiumPage() {
                 <h3 className="text-card-foreground mb-2 font-serif text-2xl font-bold">
                   {premiumPlan?.name ?? 'Premium'}
                 </h3>
-                <p className="text-foreground mb-4 text-4xl font-bold">
-                  {premiumPlan ? formatPriceArs(premiumPlan.price) : '---'}
-                  <span className="text-muted-foreground text-lg font-normal">/mes</span>
-                </p>
+                {isLoading ? (
+                  <div className="mb-4">
+                    <PriceSkeleton />
+                  </div>
+                ) : (
+                  <p className="text-foreground mb-4 text-4xl font-bold">
+                    {premiumPlan ? formatPriceArs(premiumPlan.price) : '---'}
+                    <span className="text-muted-foreground text-lg font-normal">/mes</span>
+                  </p>
+                )}
                 <p className="text-muted-foreground text-sm">
                   {premiumPlan?.description ?? 'Desbloquea todo el potencial'}
                 </p>

--- a/frontend/src/hooks/api/useEncyclopedia.test.ts
+++ b/frontend/src/hooks/api/useEncyclopedia.test.ts
@@ -374,3 +374,37 @@ describe('encyclopediaKeys', () => {
     expect(encyclopediaKeys.navigation('the-fool')).toContain('the-fool');
   });
 });
+
+// ============================================================================
+// Sembrado desde el servidor (T-SEO-003)
+// ============================================================================
+
+describe('useCards — sembrado desde el servidor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('⚠️ T-SEO-003: sirve las cartas sembradas en el primer render, sin esqueleto', () => {
+    const { result } = renderHook(() => useCards(undefined, [mockCardSummary]), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toEqual([mockCardSummary]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('no refetchea al montar: el listado de la enciclopedia es contenido estático', () => {
+    renderHook(() => useCards(undefined, [mockCardSummary]), { wrapper: createWrapper() });
+
+    expect(vi.mocked(encyclopediaApi.getCards)).not.toHaveBeenCalled();
+  });
+
+  it('sin sembrado sigue pidiendo las cartas a la API', async () => {
+    vi.mocked(encyclopediaApi.getCards).mockResolvedValue([mockCardSummary]);
+
+    const { result } = renderHook(() => useCards(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(vi.mocked(encyclopediaApi.getCards)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/api/useEncyclopedia.ts
+++ b/frontend/src/hooks/api/useEncyclopedia.ts
@@ -14,7 +14,7 @@ import {
   getRelatedCards,
   getCardNavigation,
 } from '@/lib/api/encyclopedia-api';
-import type { CardDetail, CardFilters, Suit } from '@/types/encyclopedia.types';
+import type { CardDetail, CardFilters, CardSummary, Suit } from '@/types/encyclopedia.types';
 
 const STALE_TIME_STATIC = 1000 * 60 * 60; // 1 hour — static encyclopedia data
 const STALE_TIME_SEARCH = 1000 * 60 * 5; // 5 minutes — search results
@@ -34,11 +34,18 @@ export const encyclopediaKeys = {
 
 // ─── Hooks ────────────────────────────────────────────────────────────────────
 
-export function useCards(filters?: CardFilters) {
+/**
+ * @param initialData cartas ya resueltas por la ruta `/enciclopedia/tarot` en el
+ *   servidor. Siembra la caché para que el primer render —el HTML que ve
+ *   Googlebot— traiga el listado en vez del esqueleto (T-SEO-003). Con
+ *   `STALE_TIME_STATIC` no dispara refetch inmediato: el mazo no cambia.
+ */
+export function useCards(filters?: CardFilters, initialData?: CardSummary[]) {
   return useQuery({
     queryKey: encyclopediaKeys.cards(filters),
     queryFn: () => getCards(filters),
     staleTime: STALE_TIME_STATIC,
+    initialData,
   });
 }
 

--- a/frontend/src/hooks/api/useEncyclopediaArticles.test.ts
+++ b/frontend/src/hooks/api/useEncyclopediaArticles.test.ts
@@ -309,3 +309,41 @@ describe('articleKeys', () => {
     expect(articleKeys.search('aries')).toContain('encyclopedia');
   });
 });
+
+// ============================================================================
+// Sembrado desde el servidor (T-SEO-003)
+// ============================================================================
+
+describe('useArticlesByCategory — sembrado desde el servidor', () => {
+  const seededArticle: ArticleSummary = {
+    id: 99,
+    slug: 'aries',
+    nameEs: 'Aries',
+    category: ArticleCategory.ZODIAC_SIGN,
+    snippet: 'El primer signo del zodiaco.',
+    imageUrl: null,
+    sortOrder: 1,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('⚠️ T-SEO-003: sirve los artículos sembrados en el primer render, sin esqueleto', () => {
+    const { result } = renderHook(
+      () => useArticlesByCategory(ArticleCategory.ZODIAC_SIGN, [seededArticle]),
+      { wrapper: createWrapper() }
+    );
+
+    expect(result.current.data).toEqual([seededArticle]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('no refetchea al montar: los artículos son contenido estático', () => {
+    renderHook(() => useArticlesByCategory(ArticleCategory.ZODIAC_SIGN, [seededArticle]), {
+      wrapper: createWrapper(),
+    });
+
+    expect(vi.mocked(encyclopediaArticlesApi.getArticlesByCategory)).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/api/useEncyclopediaArticles.ts
+++ b/frontend/src/hooks/api/useEncyclopediaArticles.ts
@@ -11,7 +11,11 @@ import {
   getArticlesByCategory,
   globalSearch,
 } from '@/lib/api/encyclopedia-articles-api';
-import type { ArticleCategory, ArticleDetail } from '@/types/encyclopedia-article.types';
+import type {
+  ArticleCategory,
+  ArticleDetail,
+  ArticleSummary,
+} from '@/types/encyclopedia-article.types';
 
 const STALE_TIME_STATIC = 1000 * 60 * 60; // 1 hour — static encyclopedia content
 
@@ -52,12 +56,19 @@ export function useArticle(slug: string, initialData?: ArticleDetail) {
   });
 }
 
-export function useArticlesByCategory(category: ArticleCategory) {
+/**
+ * @param initialData artículos ya resueltos por la ruta de listado en el
+ *   servidor. Siembra la caché para que el primer render —el HTML que ve
+ *   Googlebot— traiga la lista en vez del esqueleto (T-SEO-003). Con
+ *   `STALE_TIME_STATIC` no dispara refetch inmediato: son artículos estáticos.
+ */
+export function useArticlesByCategory(category: ArticleCategory, initialData?: ArticleSummary[]) {
   return useQuery({
     queryKey: articleKeys.byCategory(category),
     queryFn: () => getArticlesByCategory(category),
     staleTime: STALE_TIME_STATIC,
     enabled: !!category,
+    initialData,
   });
 }
 

--- a/frontend/src/hooks/api/useHolisticServices.test.tsx
+++ b/frontend/src/hooks/api/useHolisticServices.test.tsx
@@ -289,3 +289,36 @@ describe('useHolisticServices Hooks', () => {
     });
   });
 });
+
+// ============================================================================
+// Sembrado desde el servidor (T-SEO-003)
+// ============================================================================
+
+describe('useHolisticServices — sembrado desde el servidor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('⚠️ T-SEO-003: sirve el catálogo sembrado en el primer render, sin esqueleto', () => {
+    const { result } = renderHook(() => useHolisticServices([mockService]), {
+      wrapper: createWrapper(createTestQueryClient()),
+    });
+
+    expect(result.current.data).toEqual([mockService]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('⚠️ refetchea igual al montar: el precio y el catálogo cambian desde el admin', async () => {
+    // `initialDataUpdatedAt: 0` — sin eso, el `staleTime` dejaría fija la copia
+    // horneada en el HTML hasta que expire el ISR.
+    vi.mocked(holisticApi.getHolisticServices).mockResolvedValue([mockService]);
+
+    renderHook(() => useHolisticServices([mockService]), {
+      wrapper: createWrapper(createTestQueryClient()),
+    });
+
+    await waitFor(() =>
+      expect(vi.mocked(holisticApi.getHolisticServices)).toHaveBeenCalledTimes(1)
+    );
+  });
+});

--- a/frontend/src/hooks/api/useHolisticServices.ts
+++ b/frontend/src/hooks/api/useHolisticServices.ts
@@ -5,7 +5,7 @@
  */
 'use client';
 
-import type { HolisticServiceDetail } from '@/types/holistic-service.types';
+import type { HolisticService, HolisticServiceDetail } from '@/types/holistic-service.types';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getHolisticServices,
@@ -39,13 +39,20 @@ export const holisticServiceQueryKeys = {
 
 /**
  * Hook to fetch the full holistic services catalog
+ * @param initialData catálogo resuelto por la ruta `/servicios` en el servidor
+ *   (T-SEO-003): el primer render trae los servicios en vez del esqueleto.
  * @returns TanStack Query result with array of active services
  */
-export function useHolisticServices() {
+export function useHolisticServices(initialData?: HolisticService[]) {
   return useQuery({
     queryKey: holisticServiceQueryKeys.lists(),
     queryFn: getHolisticServices,
     staleTime: 5 * 60 * 1000, // 5 minutes - catalog changes infrequently
+    initialData,
+    // El catálogo y los precios cambian desde el admin: sin esto, `initialData` se
+    // estampa como recién traído y con el `staleTime` el cliente NO refetchea al
+    // montar, así que la copia horneada en el HTML quedaría fija hasta el ISR.
+    initialDataUpdatedAt: 0,
   });
 }
 

--- a/frontend/src/hooks/api/usePublicPlans.test.ts
+++ b/frontend/src/hooks/api/usePublicPlans.test.ts
@@ -165,3 +165,30 @@ describe('usePublicPlans', () => {
     expect(result.current.isStale).toBe(false);
   });
 });
+
+// ============================================================================
+// Sembrado desde el servidor (T-SEO-003)
+// ============================================================================
+
+describe('usePublicPlans — sembrado desde el servidor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('⚠️ T-SEO-003: sirve los planes sembrados en el primer render, sin esqueleto', () => {
+    const { result } = renderHook(() => usePublicPlans([mockFreePlan]), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toEqual([mockFreePlan]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('⚠️ refetchea igual al montar: el precio del plan cambia desde el admin', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: [mockFreePlan] });
+
+    renderHook(() => usePublicPlans([mockFreePlan]), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(vi.mocked(apiClient.get)).toHaveBeenCalledTimes(1));
+  });
+});

--- a/frontend/src/hooks/api/usePublicPlans.ts
+++ b/frontend/src/hooks/api/usePublicPlans.ts
@@ -33,10 +33,15 @@ export const publicPlansQueryKeys = {
  * const premiumPlan = plans?.find(p => p.planType === 'premium');
  * ```
  */
-export function usePublicPlans() {
+export function usePublicPlans(initialData?: PlanConfig[]) {
   return useQuery<PlanConfig[]>({
     queryKey: publicPlansQueryKeys.all,
     queryFn: fetchPublicPlans,
     staleTime: 5 * 60 * 1000, // 5 minutes — plan config changes rarely
+    initialData,
+    // El precio del plan cambia desde el admin: sin esto, `initialData` se estampa
+    // como recién traído y con el `staleTime` el cliente NO refetchea al montar,
+    // así que el precio horneado en el HTML quedaría fijo hasta que expire el ISR.
+    initialDataUpdatedAt: 0,
   });
 }

--- a/frontend/src/hooks/api/useTarotistas.test.ts
+++ b/frontend/src/hooks/api/useTarotistas.test.ts
@@ -256,3 +256,52 @@ describe('useTarotistaDetail', () => {
     expect(result.current.data?.añosExperiencia).toBeNull();
   });
 });
+
+// ============================================================================
+// Sembrado desde el servidor (T-SEO-003)
+// ============================================================================
+
+describe('useTarotistas — sembrado desde el servidor', () => {
+  const seeded: PaginatedTarotistas = {
+    data: [
+      {
+        id: 7,
+        nombrePublico: 'Estrella Guía',
+        bio: 'Guía espiritual con quince años de experiencia',
+        especialidades: ['Espiritual'],
+        fotoPerfil: 'https://example.com/estrella.jpg',
+        ratingPromedio: 4.9,
+        totalLecturas: 200,
+        totalReviews: 100,
+        añosExperiencia: 15,
+        idiomas: ['Español'],
+        createdAt: '2024-01-01T00:00:00Z',
+      },
+    ],
+    total: 1,
+    page: 1,
+    limit: 10,
+    totalPages: 1,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('⚠️ T-SEO-003: sirve la primera página sembrada en el primer render, sin esqueleto', () => {
+    const { result } = renderHook(() => useTarotistas(undefined, seeded), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toEqual(seeded);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('⚠️ refetchea igual al montar: el rating y el listado cambian', async () => {
+    vi.mocked(tarotistasApi.getTarotistas).mockResolvedValue(seeded);
+
+    renderHook(() => useTarotistas(undefined, seeded), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(vi.mocked(tarotistasApi.getTarotistas)).toHaveBeenCalledTimes(1));
+  });
+});

--- a/frontend/src/hooks/api/useTarotistas.ts
+++ b/frontend/src/hooks/api/useTarotistas.ts
@@ -8,7 +8,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { getTarotistas, getTarotistaById } from '@/lib/api/tarotistas-api';
-import type { TarotistaFilters } from '@/types';
+import type { PaginatedTarotistas, TarotistaFilters } from '@/types';
 
 // ============================================================================
 // Query Keys (for consistency and type safety)
@@ -29,13 +29,21 @@ export const tarotistaQueryKeys = {
 /**
  * Hook to fetch paginated list of tarotistas with optional filters
  * @param filters - Optional filters (search, especialidad, orderBy, page, limit)
+ * @param initialData primera página resuelta por la ruta `/explorar` en el
+ *   servidor (T-SEO-003). Solo debe pasarse cuando los filtros son los del
+ *   primer render: con otros filtros la clave de caché es otra y sembrarla con
+ *   el listado sin filtrar mostraría resultados que no corresponden.
  * @returns TanStack Query result with tarotistas data
  */
-export function useTarotistas(filters?: TarotistaFilters) {
+export function useTarotistas(filters?: TarotistaFilters, initialData?: PaginatedTarotistas) {
   return useQuery({
     queryKey: tarotistaQueryKeys.list(filters),
     queryFn: () => getTarotistas(filters),
     staleTime: 5 * 60 * 1000, // 5 minutes - catalog data doesn't change often
+    initialData,
+    // El listado y las valoraciones cambian: sin esto, `initialData` se estampa
+    // como recién traído y con el `staleTime` el cliente NO refetchea al montar.
+    initialDataUpdatedAt: 0,
   });
 }
 

--- a/frontend/src/lib/api/encyclopedia-articles-api.test.ts
+++ b/frontend/src/lib/api/encyclopedia-articles-api.test.ts
@@ -8,6 +8,7 @@ import {
   getArticleSnippet,
   getArticle,
   getArticlesByCategory,
+  getArticlesByCategories,
   globalSearch,
 } from './encyclopedia-articles-api';
 import { ArticleCategory } from '@/types/encyclopedia-article.types';
@@ -196,5 +197,57 @@ describe('encyclopedia articles API functions', () => {
       expect(result.articles).toHaveLength(0);
       expect(result.total).toBe(0);
     });
+  });
+});
+
+// ============================================================================
+// Sembrado de listados desde el servidor (T-SEO-003)
+// ============================================================================
+
+describe('getArticlesByCategories', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const article = {
+    id: 1,
+    slug: 'guia-tarot',
+    nameEs: 'Guía del Tarot',
+    category: ArticleCategory.GUIDE_TAROT,
+    snippet: 'Cómo hacer una lectura de tarot.',
+    imageUrl: null,
+    sortOrder: 1,
+  };
+
+  it('resuelve todas las categorías pedidas y las devuelve indexadas', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: [article] });
+
+    const result = await getArticlesByCategories([
+      ArticleCategory.GUIDE_TAROT,
+      ArticleCategory.GUIDE_RITUAL,
+    ]);
+
+    expect(result[ArticleCategory.GUIDE_TAROT]).toEqual([article]);
+    expect(result[ArticleCategory.GUIDE_RITUAL]).toEqual([article]);
+    expect(vi.mocked(apiClient.get)).toHaveBeenCalledTimes(2);
+  });
+
+  it('⚠️ T-SEO-003: una categoría caída no deja sin contenido a las demás', async () => {
+    vi.mocked(apiClient.get)
+      .mockRejectedValueOnce(new Error('API caída'))
+      .mockResolvedValueOnce({ data: [article] });
+
+    const result = await getArticlesByCategories([
+      ArticleCategory.GUIDE_TAROT,
+      ArticleCategory.GUIDE_RITUAL,
+    ]);
+
+    expect(result[ArticleCategory.GUIDE_TAROT]).toBeUndefined();
+    expect(result[ArticleCategory.GUIDE_RITUAL]).toEqual([article]);
+  });
+
+  it('devuelve un objeto vacío si no se piden categorías', async () => {
+    await expect(getArticlesByCategories([])).resolves.toEqual({});
+    expect(vi.mocked(apiClient.get)).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/api/encyclopedia-articles-api.ts
+++ b/frontend/src/lib/api/encyclopedia-articles-api.ts
@@ -35,6 +35,38 @@ export async function getArticlesByCategory(category: ArticleCategory): Promise<
   return response.data;
 }
 
+/**
+ * Resuelve varias categorías en paralelo, para sembrar un listado desde el
+ * servidor (T-SEO-003 — lo usa `/enciclopedia/guias`, que muestra siete).
+ *
+ * Cada categoría degrada por separado: una que falle queda fuera del resultado
+ * y el cliente la vuelve a pedir, en vez de dejar sin contenido a las otras
+ * seis. Mismo criterio que `resolveListingData`.
+ */
+export async function getArticlesByCategories(
+  categories: ArticleCategory[]
+): Promise<Partial<Record<ArticleCategory, ArticleSummary[]>>> {
+  const resolved = await Promise.all(
+    categories.map(async (category) => {
+      try {
+        return { category, articles: await getArticlesByCategory(category) };
+      } catch {
+        return { category, articles: undefined };
+      }
+    })
+  );
+
+  return resolved.reduce<Partial<Record<ArticleCategory, ArticleSummary[]>>>(
+    (accumulator, { category, articles }) => {
+      if (articles) {
+        accumulator[category] = articles;
+      }
+      return accumulator;
+    },
+    {}
+  );
+}
+
 export async function globalSearch(term: string): Promise<GlobalSearchResult> {
   const params = new URLSearchParams({ q: term });
   const response = await apiClient.get<GlobalSearchResult>(

--- a/frontend/src/lib/constants/listing-intros.data.test.ts
+++ b/frontend/src/lib/constants/listing-intros.data.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  LISTING_INTROS,
+  MIN_LISTING_INTRO_WORDS,
+  getListingIntroWordCount,
+  type ListingIntroData,
+  type ListingIntroKey,
+} from './listing-intros.data';
+
+/**
+ * Guardarraíl de contenido indexable de los listados y hubs (T-SEO-003).
+ *
+ * Mismo criterio que `chinese-zodiac-profiles.data.test.ts`: si alguien recorta
+ * el texto, se entera acá y no en el próximo rechazo de AdSense.
+ */
+
+const KEYS = Object.keys(LISTING_INTROS) as ListingIntroKey[];
+
+/** Las 10 rutas que este bloque de contenido tiene que cubrir. */
+const RUTAS_ESPERADAS: ListingIntroKey[] = [
+  'enciclopedia',
+  'enciclopediaTarot',
+  'enciclopediaGuias',
+  'enciclopediaAstrologia',
+  'enciclopediaSignos',
+  'enciclopediaPlanetas',
+  'enciclopediaCasas',
+  'servicios',
+  'explorar',
+  'contacto',
+];
+
+function paragraphsOf(intro: ListingIntroData): string[] {
+  return [intro.lead, ...intro.sections.map((section) => section.body)];
+}
+
+describe('LISTING_INTROS', () => {
+  it('cubre exactamente las rutas delgadas de T-SEO-003', () => {
+    expect([...KEYS].sort()).toEqual([...RUTAS_ESPERADAS].sort());
+  });
+
+  it.each(RUTAS_ESPERADAS)('%s aporta al menos MIN_LISTING_INTRO_WORDS palabras propias', (key) => {
+    expect(getListingIntroWordCount(LISTING_INTROS[key])).toBeGreaterThanOrEqual(
+      MIN_LISTING_INTRO_WORDS
+    );
+  });
+
+  it.each(RUTAS_ESPERADAS)('%s tiene título, lead y al menos dos secciones', (key) => {
+    const intro = LISTING_INTROS[key];
+
+    expect(intro.title.trim().length).toBeGreaterThan(0);
+    expect(intro.lead.trim().length).toBeGreaterThan(0);
+    expect(intro.sections.length).toBeGreaterThanOrEqual(2);
+    intro.sections.forEach((section) => {
+      expect(section.heading.trim().length).toBeGreaterThan(0);
+      expect(section.body.trim().length).toBeGreaterThan(0);
+    });
+  });
+
+  it('⚠️ no repite títulos entre rutas: dos URLs con el mismo texto son duplicadas', () => {
+    const titles = KEYS.map((key) => LISTING_INTROS[key].title);
+
+    expect(new Set(titles).size).toBe(titles.length);
+  });
+
+  it('⚠️ no repite ningún párrafo entre rutas', () => {
+    const paragraphs = KEYS.flatMap((key) => paragraphsOf(LISTING_INTROS[key]));
+
+    expect(new Set(paragraphs).size).toBe(paragraphs.length);
+  });
+
+  it('no deja un enlace interno sin texto ni destino', () => {
+    KEYS.forEach((key) => {
+      LISTING_INTROS[key].links?.forEach((link) => {
+        expect(link.label.trim().length).toBeGreaterThan(0);
+        expect(link.href.startsWith('/')).toBe(true);
+      });
+    });
+  });
+});
+
+describe('getListingIntroWordCount', () => {
+  it('suma el lead y el cuerpo de cada sección', () => {
+    const intro: ListingIntroData = {
+      title: 'Título de prueba',
+      lead: 'Una dos tres',
+      sections: [
+        { heading: 'Encabezado', body: 'cuatro cinco' },
+        { heading: 'Otro', body: 'seis' },
+      ],
+    };
+
+    expect(getListingIntroWordCount(intro)).toBe(6);
+  });
+
+  it('no cuenta los espacios de más como palabras', () => {
+    const intro: ListingIntroData = {
+      title: 'Título',
+      lead: '  una   dos  ',
+      sections: [{ heading: 'Encabezado', body: '  tres ' }],
+    };
+
+    expect(getListingIntroWordCount(intro)).toBe(3);
+  });
+});

--- a/frontend/src/lib/constants/listing-intros.data.ts
+++ b/frontend/src/lib/constants/listing-intros.data.ts
@@ -1,0 +1,277 @@
+/**
+ * Contenido indexable de los listados y hubs públicos (T-SEO-003).
+ *
+ * Las rutas de listado servían entre 3 y 70 palabras propias: el grueso de lo
+ * que muestran son datos que llegan por el cliente (cartas, artículos,
+ * servicios, tarotistas), así que el crawler veía el esqueleto. Sembrar esos
+ * datos desde el servidor resuelve la mayor parte, pero deja el contenido de
+ * cada URL atado a que la API responda durante el build.
+ *
+ * Este archivo es el **piso garantizado**: texto propio, escrito, que no depende
+ * de la API ni de la sesión y que se renderiza siempre en el servidor. Mismo
+ * criterio que `chinese-zodiac-profiles.data.ts` (T-SEO-002) y
+ * `service-intros.data.ts`: contenido rico y específico, centralizado en datos
+ * tipados en vez de incrustado en JSX.
+ *
+ * ⚠️ El texto de cada ruta debe ser **único**: dos URLs con el mismo párrafo son
+ * contenido duplicado para Google, que fue el problema original.
+ * `listing-intros.data.test.ts` lo verifica, igual que el mínimo de palabras.
+ */
+
+import { ROUTES } from './routes';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Un bloque temático dentro de la introducción. */
+export interface ListingIntroSection {
+  /** Encabezado del bloque (se renderiza como `h3`). */
+  heading: string;
+  /** Cuerpo del bloque. */
+  body: string;
+}
+
+/** Enlace interno al pie de la introducción. */
+export interface ListingIntroLink {
+  /** Texto del enlace. */
+  label: string;
+  /** Ruta interna (siempre empieza con `/`). */
+  href: string;
+}
+
+/** Introducción editorial de una ruta de listado o hub. */
+export interface ListingIntroData {
+  /** Título del bloque (se renderiza como `h2`; el `h1` es el de la página). */
+  title: string;
+  /** Párrafo de entrada. */
+  lead: string;
+  /** Bloques temáticos, al menos dos. */
+  sections: ListingIntroSection[];
+  /** Enlaces internos relacionados, para que el crawler siga recorriendo. */
+  links?: ListingIntroLink[];
+}
+
+/** Claves de las rutas cubiertas. */
+export type ListingIntroKey =
+  | 'enciclopedia'
+  | 'enciclopediaTarot'
+  | 'enciclopediaGuias'
+  | 'enciclopediaAstrologia'
+  | 'enciclopediaSignos'
+  | 'enciclopediaPlanetas'
+  | 'enciclopediaCasas'
+  | 'servicios'
+  | 'explorar'
+  | 'contacto';
+
+// ─── Guardarraíl ──────────────────────────────────────────────────────────────
+
+/**
+ * Mínimo de palabras propias que debe aportar cada introducción.
+ *
+ * El umbral del guardarraíl de T-SEO-001 es 120 palabras **de la página
+ * entera**. Se pide 130 acá para dejar margen: la introducción no es todo lo que
+ * la ruta renderiza, pero sí lo único garantizado cuando la API no responde.
+ */
+export const MIN_LISTING_INTRO_WORDS = 130;
+
+/** Palabras propias que aporta una introducción (lead + cuerpo de secciones). */
+export function getListingIntroWordCount(intro: ListingIntroData): number {
+  return [intro.lead, ...intro.sections.map((section) => section.body)]
+    .join(' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean).length;
+}
+
+// ─── Contenido ────────────────────────────────────────────────────────────────
+
+export const LISTING_INTROS: Record<ListingIntroKey, ListingIntroData> = {
+  enciclopedia: {
+    title: 'Cómo usar la Enciclopedia Mística',
+    lead: 'La enciclopedia reúne el material de referencia de Auguria en un solo lugar: el significado de las 78 cartas del tarot, los artículos de astrología y las guías prácticas que explican cómo se hace cada consulta. Está pensada para leerse suelta, sin orden obligatorio, y para volver a ella cada vez que aparece un término que no termina de cerrar.',
+    sections: [
+      {
+        heading: 'Tres secciones, tres profundidades',
+        body: 'Tarot funciona como diccionario: se entra por una carta puntual y se sale con su significado derecho, invertido y en combinación. Astrología es un curso corto repartido en signos, planetas y casas. Guías es el manual de uso: qué hace cada herramienta, cuándo conviene usarla y cómo interpretar el resultado.',
+      },
+      {
+        heading: 'Para quien recién empieza',
+        body: 'Conviene arrancar por la guía de tarot, seguir con los arcanos mayores y recién después mirar los menores, que son cuatro palos con lógica propia. En astrología el orden natural es signo, planeta y casa: el planeta dice qué función está en juego, el signo de qué manera se expresa y la casa en qué área de la vida se nota.',
+      },
+    ],
+    links: [
+      { label: 'Cartas del tarot', href: ROUTES.ENCICLOPEDIA_TAROT },
+      { label: 'Astrología', href: ROUTES.ENCICLOPEDIA_ASTROLOGIA },
+      { label: 'Guías prácticas', href: ROUTES.ENCICLOPEDIA_GUIAS },
+    ],
+  },
+
+  enciclopediaTarot: {
+    title: 'Las 78 cartas, carta por carta',
+    lead: 'El mazo de tarot se divide en 22 arcanos mayores y 56 menores. Los mayores narran las grandes etapas de un proceso —el impulso inicial, la crisis, el cierre—; los menores bajan esa historia a lo cotidiano y la reparten en cuatro palos. En este listado están las 78 con su ficha propia.',
+    sections: [
+      {
+        heading: 'Mayores y menores',
+        body: 'Un arcano mayor en la tirada marca el tema de fondo, y varios seguidos suelen indicar que la situación excede lo que la persona controla. Los menores, en cambio, hablan de hechos concretos y plazos cortos: son los que aterrizan la lectura en decisiones de esta semana.',
+      },
+      {
+        heading: 'Los cuatro palos',
+        body: 'Bastos es la acción, el impulso y el trabajo que empuja. Copas es el mundo afectivo y los vínculos. Espadas es el pensamiento, el conflicto y la palabra. Oros es el cuerpo, el dinero y todo lo que se puede contar. Cada palo va del as al diez y sigue con cuatro figuras.',
+      },
+    ],
+    links: [
+      { label: 'Guías prácticas', href: ROUTES.ENCICLOPEDIA_GUIAS },
+      { label: 'Volver a la enciclopedia', href: ROUTES.ENCICLOPEDIA },
+    ],
+  },
+
+  enciclopediaGuias: {
+    title: 'Guías prácticas, de la teoría al primer intento',
+    lead: 'Cada guía explica una herramienta completa de punta a punta: qué pregunta responde, qué necesita quien la consulta y cómo se lee el resultado sin quedarse en la superficie. Son textos de lectura corrida, pensados tanto para quien nunca hizo una consulta como para quien quiere ordenar lo que ya venía practicando.',
+    sections: [
+      {
+        heading: 'Qué cubren',
+        body: 'Hay una guía por cada práctica disponible en Auguria: tarot, numerología, péndulo, carta astral, rituales, horóscopo y horóscopo chino. Ninguna pide conocimientos previos y todas terminan en un ejemplo concreto, para que la teoría no quede colgada de definiciones.',
+      },
+      {
+        heading: 'Cómo aprovecharlas',
+        body: 'Conviene leer la guía antes de la primera consulta y volver a ella después, con el resultado a la vista: la segunda lectura es la que ordena el vocabulario. Cada guía enlaza a las fichas de la enciclopedia donde se amplía cada término que aparece en el camino.',
+      },
+    ],
+    links: [
+      { label: 'Cartas del tarot', href: ROUTES.ENCICLOPEDIA_TAROT },
+      { label: 'Astrología', href: ROUTES.ENCICLOPEDIA_ASTROLOGIA },
+    ],
+  },
+
+  enciclopediaAstrologia: {
+    title: 'Los tres ejes de una carta astral',
+    lead: 'Toda interpretación astrológica se apoya en tres piezas que se combinan: el signo, el planeta y la casa. Separarlas es lo que evita el error más común, que es leer el horóscopo como si el signo solar explicara por sí solo todo lo que le pasa a una persona.',
+    sections: [
+      {
+        heading: 'Qué aporta cada pieza',
+        body: 'El planeta indica la función en juego: la voluntad con el Sol, el afecto con Venus, la palabra con Mercurio. El signo describe el estilo con el que esa función se expresa. La casa señala el área concreta donde se nota: la pareja, el trabajo, la familia o el estudio.',
+      },
+      {
+        heading: 'Por qué el signo solar no alcanza',
+        body: 'El signo solar es apenas uno de los diez planetas de una carta. La Luna describe la vida emocional, el ascendente la primera impresión que alguien deja y Marte la forma de pelear. Dos personas del mismo signo con lunas distintas se parecen mucho menos de lo que promete un horóscopo diario.',
+      },
+    ],
+    links: [
+      { label: 'Signos zodiacales', href: ROUTES.ENCICLOPEDIA_ASTROLOGIA_SIGNOS },
+      { label: 'Planetas', href: ROUTES.ENCICLOPEDIA_ASTROLOGIA_PLANETAS },
+      { label: 'Casas astrales', href: ROUTES.ENCICLOPEDIA_ASTROLOGIA_CASAS },
+    ],
+  },
+
+  enciclopediaSignos: {
+    title: 'Cómo se ordenan los doce signos',
+    lead: 'Los doce signos no son doce etiquetas sueltas: forman un ciclo que puede recorrerse por elemento, por modalidad y por polaridad. Entender esas divisiones vuelve previsible buena parte de lo que después detalla cada ficha, y ahorra tener que memorizar doce listas de rasgos.',
+    sections: [
+      {
+        heading: 'Los cuatro elementos',
+        body: 'Fuego —Aries, Leo y Sagitario— aporta iniciativa. Tierra —Tauro, Virgo y Capricornio— aporta permanencia y resultados. Aire —Géminis, Libra y Acuario— aporta ideas y vínculos. Agua —Cáncer, Escorpio y Piscis— aporta emoción y memoria. Los signos de un mismo elemento se entienden entre sí casi sin traducción.',
+      },
+      {
+        heading: 'Las tres modalidades',
+        body: 'Los cardinales —Aries, Cáncer, Libra y Capricornio— abren cada estación y empujan lo nuevo. Los fijos —Tauro, Leo, Escorpio y Acuario— sostienen y resisten el cambio. Los mutables —Géminis, Virgo, Sagitario y Piscis— adaptan y cierran el ciclo antes de que empiece el siguiente.',
+      },
+    ],
+    links: [
+      { label: 'Planetas', href: ROUTES.ENCICLOPEDIA_ASTROLOGIA_PLANETAS },
+      { label: 'Casas astrales', href: ROUTES.ENCICLOPEDIA_ASTROLOGIA_CASAS },
+    ],
+  },
+
+  enciclopediaPlanetas: {
+    title: 'Personales, sociales y generacionales',
+    lead: 'La astrología clásica trabaja con diez planetas y los agrupa por la velocidad con la que recorren el zodiaco. Esa velocidad decide cuánto de una carta natal es propio de la persona y cuánto comparte con todos los que nacieron en los mismos años.',
+    sections: [
+      {
+        heading: 'Los planetas personales',
+        body: 'El Sol, la Luna, Mercurio, Venus y Marte cambian de signo en cuestión de días o semanas, así que describen lo particular de cada uno: la voluntad, la emoción, la manera de pensar, de querer y de actuar. Son los que más se reconocen en el día a día.',
+      },
+      {
+        heading: 'Sociales y generacionales',
+        body: 'Júpiter y Saturno tardan uno y casi tres años por signo: hablan de crecimiento y de límite, del lugar de cada uno en el mundo compartido. Urano, Neptuno y Plutón pasan años enteros en el mismo signo y describen el clima de época que le tocó a una generación.',
+      },
+    ],
+    links: [
+      { label: 'Signos zodiacales', href: ROUTES.ENCICLOPEDIA_ASTROLOGIA_SIGNOS },
+      { label: 'Casas astrales', href: ROUTES.ENCICLOPEDIA_ASTROLOGIA_CASAS },
+    ],
+  },
+
+  enciclopediaCasas: {
+    title: 'Doce casas, doce áreas de la vida',
+    lead: 'Si el planeta es el qué y el signo el cómo, la casa es el dónde. Las doce casas dividen la carta en ámbitos concretos —el cuerpo, el dinero, los estudios, la familia, la pareja, el trabajo— y dependen de la hora y del lugar de nacimiento, no solo de la fecha.',
+    sections: [
+      {
+        heading: 'Ángulos y ejes',
+        body: 'Las casas 1, 4, 7 y 10 son los ángulos y sostienen la estructura de la carta: la identidad, el origen familiar, los vínculos de a dos y la vocación pública. Las casas opuestas se leen de a pares, porque cada una compensa aquello que la otra tiende a exagerar.',
+      },
+      {
+        heading: 'Por qué hace falta la hora',
+        body: 'El ascendente se corre un grado cada cuatro minutos: dos personas nacidas el mismo día con dos horas de diferencia tienen las mismas posiciones planetarias repartidas en casas distintas. Sin hora de nacimiento se puede leer el signo de cada planeta, pero no el área donde se juega.',
+      },
+    ],
+    links: [
+      { label: 'Signos zodiacales', href: ROUTES.ENCICLOPEDIA_ASTROLOGIA_SIGNOS },
+      { label: 'Planetas', href: ROUTES.ENCICLOPEDIA_ASTROLOGIA_PLANETAS },
+    ],
+  },
+
+  servicios: {
+    title: 'Cómo funcionan los servicios holísticos',
+    lead: 'Los servicios holísticos son sesiones con una persona real, agendadas en un día y un horario concretos, distintas de las lecturas automáticas del sitio. Cada servicio tiene su ficha con la duración, el precio en pesos y el detalle de lo que incluye la sesión.',
+    sections: [
+      {
+        heading: 'Cómo se reserva',
+        body: 'Se elige el servicio, se abre su ficha y se selecciona un turno entre los disponibles del calendario. El pago se procesa antes de confirmar la reserva y queda registrado en la cuenta, junto con el detalle del turno y la vía de contacto acordada.',
+      },
+      {
+        heading: 'Qué esperar de una sesión',
+        body: 'Antes de reservar conviene leer la descripción completa: cada práctica trabaja sobre algo distinto y no todas sirven para la misma consulta. Ninguna sesión reemplaza atención médica ni psicológica, y así las presentamos: son acompañamientos, no tratamientos.',
+      },
+      {
+        heading: 'En qué se diferencian de una lectura del sitio',
+        body: 'Las lecturas de tarot, numerología y carta astral se generan al instante y se pueden repetir cuantas veces haga falta. Un servicio holístico ocupa una agenda y a otra persona: por eso tiene turno, precio y una duración pactada de antemano.',
+      },
+    ],
+    links: [
+      { label: 'Ver los guías espirituales', href: ROUTES.EXPLORAR },
+      { label: 'Guías prácticas', href: ROUTES.ENCICLOPEDIA_GUIAS },
+    ],
+  },
+
+  explorar: {
+    title: 'Cómo elegir un guía espiritual',
+    lead: 'Este listado reúne a los tarotistas y guías que atienden en Auguria. Cada perfil muestra su especialidad, los años de experiencia, la cantidad de lecturas realizadas y la valoración promedio de quienes ya consultaron, para que la elección no dependa solamente de la foto.',
+    sections: [
+      {
+        heading: 'Buscar por especialidad',
+        body: 'Los filtros acotan por tema: amor, dinero, carrera, salud o espiritual. Un guía especializado no adivina mejor que otro, pero conoce el vocabulario y las preguntas típicas de ese terreno, y eso se nota en el ida y vuelta de la sesión.',
+      },
+      {
+        heading: 'Qué mirar en un perfil',
+        body: 'La valoración promedio dice poco sin la cantidad de reseñas que la sostiene: cinco estrellas sobre tres opiniones pesan menos que cuatro y media sobre doscientas. La biografía es el otro dato útil, porque anticipa el estilo de la lectura, más directo o más acompañante.',
+      },
+    ],
+    links: [{ label: 'Servicios holísticos', href: ROUTES.SERVICIOS }],
+  },
+
+  contacto: {
+    title: 'Antes de escribirnos',
+    lead: 'El formulario llega directo al equipo de Auguria. Sirve para consultas sobre la cuenta, problemas con un pago o con una reserva, sugerencias sobre el sitio y pedidos de baja. Respondemos todos los mensajes por correo, dentro de las 24 a 48 horas hábiles.',
+    sections: [
+      {
+        heading: 'Qué conviene incluir',
+        body: 'Si el mensaje es por un pago o una reserva, ayuda mucho indicar el correo con el que está registrada la cuenta y la fecha de la operación. Con ese par de datos el caso se resuelve en un solo ida y vuelta en lugar de tres.',
+      },
+      {
+        heading: 'Lo que no se resuelve por acá',
+        body: 'Las consultas espirituales no se responden por el formulario: para eso están las lecturas del sitio y las sesiones con los guías. Tampoco pedimos ni recibimos datos de tarjeta por correo — ningún mensaje nuestro va a solicitarlos nunca.',
+      },
+    ],
+  },
+};

--- a/frontend/src/lib/metadata/route-data.test.ts
+++ b/frontend/src/lib/metadata/route-data.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AxiosError, AxiosHeaders } from 'axios';
 
-import { isNotFoundError, resolveRouteResource, safeStaticParams } from './route-data';
+import {
+  isNotFoundError,
+  resolveListingData,
+  resolveRouteResource,
+  safeStaticParams,
+} from './route-data';
 
 const mockNotFound = vi.fn(() => {
   throw new Error('NEXT_NOT_FOUND');
@@ -62,6 +67,31 @@ describe('resolveRouteResource', () => {
     const fetcher = () => Promise.reject(axiosErrorWithStatus(503));
 
     await expect(resolveRouteResource(fetcher)).rejects.toThrow('boom');
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveListingData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('devuelve el listado cuando la API responde', async () => {
+    await expect(resolveListingData(async () => [{ id: 1 }])).resolves.toEqual([{ id: 1 }]);
+  });
+
+  it('⚠️ T-SEO-003: degrada a undefined si la API falla, sin tumbar el listado', async () => {
+    // A diferencia de una ficha, un listado tiene contenido propio que sirve
+    // igual: fallar el render dejaría la ruta entera caída por un blip de API.
+    await expect(resolveListingData(() => Promise.reject(new Error('API caída')))).resolves.toBe(
+      undefined
+    );
+  });
+
+  it('no dispara notFound() cuando la API responde 404', async () => {
+    const fetcher = () => Promise.reject(axiosErrorWithStatus(404));
+
+    await expect(resolveListingData(fetcher)).resolves.toBe(undefined);
     expect(mockNotFound).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/metadata/route-data.ts
+++ b/frontend/src/lib/metadata/route-data.ts
@@ -43,6 +43,26 @@ export async function resolveRouteResource<T>(fetcher: () => Promise<T>): Promis
 }
 
 /**
+ * Resuelve los datos de una ruta de **listado**, degradando a `undefined` si la
+ * API falla (T-SEO-003).
+ *
+ * El criterio es el opuesto al de `resolveRouteResource`, y la diferencia es
+ * deliberada: una ficha sin su recurso no tiene nada que mostrar, así que
+ * conviene fallar fuerte antes que cachear un esqueleto. Un listado, en cambio,
+ * tiene contenido propio —su introducción editorial— que sirve igual, y el
+ * cliente reintenta el fetch al montar. Tirar abajo el render (y con él el
+ * prerender de la ruta) por un blip de la API sería peor que servir el listado
+ * vacío con su texto.
+ */
+export async function resolveListingData<T>(fetcher: () => Promise<T>): Promise<T | undefined> {
+  try {
+    return await fetcher();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Params de prerender que degradan a `[]` si la API no responde.
  *
  * Acá sí se traga el error: sin params la ruta pasa a renderizarse on-demand,

--- a/frontend/src/types/encyclopedia-article.types.ts
+++ b/frontend/src/types/encyclopedia-article.types.ts
@@ -54,6 +54,22 @@ export interface GlobalSearchResult {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
+/**
+ * Categorías de guía en orden de exhibición. La guía de Tarot va primera
+ * (BUG-017). Vive acá y no en `GuiasContent` porque la ruta `/enciclopedia/guias`
+ * —un server component— necesita la misma lista para sembrar el listado sin
+ * importar el componente cliente (T-SEO-003).
+ */
+export const GUIDE_CATEGORIES: ArticleCategory[] = [
+  ArticleCategory.GUIDE_TAROT,
+  ArticleCategory.GUIDE_NUMEROLOGY,
+  ArticleCategory.GUIDE_PENDULUM,
+  ArticleCategory.GUIDE_BIRTH_CHART,
+  ArticleCategory.GUIDE_RITUAL,
+  ArticleCategory.GUIDE_HOROSCOPE,
+  ArticleCategory.GUIDE_CHINESE,
+];
+
 export const ARTICLE_CATEGORY_LABELS: Record<ArticleCategory, string> = {
   [ArticleCategory.ZODIAC_SIGN]: 'Signos Zodiacales',
   [ArticleCategory.PLANET]: 'Planetas',


### PR DESCRIPTION
## Qué resuelve

Las 11 rutas de listado y hub servían entre **3 y 70 palabras propias**: mostraban datos que llegaban por el cliente, así que el crawler solo veía el esqueleto. `/premium` —la URL a la que va un revisor de AdSense a mirar el modelo de negocio— servía 3.

## Cómo

**Dos mecanismos, no uno.** Sembrar resuelve el caso feliz, pero deja el contenido de cada URL atado a que la API responda durante el build.

1. **Sembrado servidor → cliente** (patrón de T-PROD-024): la ruta resuelve el listado y el componente cliente siembra React Query con `initialData`. `initialDataUpdatedAt: 0` solo donde el dato cambia (planes, servicios, tarotistas), no donde es estático (cartas, artículos).
2. **Piso garantizado**: cada ruta suma un bloque editorial propio y único (`listing-intros.data.ts` + `ListingIntro`), que se renderiza siempre en el servidor. Mínimo de 130 palabras y unicidad de títulos y párrafos verificados por tests, igual que los perfiles de T-SEO-002.

### Casos que no eran "sembrar y listo"

- **`/premium`**: un esqueleto de pantalla completa tapaba la comparativa, las FAQ y el "sin compromiso" —contenido estático que no depende de la API— hasta que respondiera `usePublicPlans`. Ahora lo único que espera es el número del precio.
- **`/explorar`**: era un client component entero por un `useRouter`. Ese `useRouter` vive ahora en `ExplorarContent` y la ruta resuelve la **primera página** del endpoint paginado. El sembrado se aplica solo con los filtros por defecto: con búsqueda o especialidad activas la clave de caché es otra.
- **`/contacto`**: es un formulario, y un `input` no es texto para el crawler. Lleva contenido propio sobre qué se responde por ahí y qué no.

### Degradación

`resolveListingData` devuelve `undefined` si la API falla, al revés de `resolveRouteResource`, que propaga. Una ficha sin su recurso no tiene nada que mostrar; un listado tiene su introducción y el cliente reintenta al montar. `getArticlesByCategories` aplica el mismo criterio por categoría: una caída no deja sin contenido a las otras seis guías.

## Resultado medido

`npm run check:indexable -- --base-url http://localhost:3099` contra el build de producción en Docker (chrome medido en 39 palabras):

| Ruta | Antes | Ahora |
| --- | --- | --- |
| `/premium` | 3 | **277** |
| `/servicios` | 5 | **255** |
| `/enciclopedia/guias` | 13 | **427** |
| `/enciclopedia/astrologia/planetas` | 18 | **595** |
| `/explorar` | 20 | **199** |
| `/enciclopedia/astrologia/signos` | 23 | **649** |
| `/enciclopedia/tarot` | 24 | **511** |
| `/enciclopedia/astrologia/casas` | 26 | **822** |
| `/contacto` | 34 | **177** |
| `/enciclopedia` | 70 | **260** |
| `/enciclopedia/astrologia` | 70 | **244** |

El sitio pasó de **48 URLs bajo el umbral a 25**: quedan los 12 signos (T-SEO-004) y las 13 fichas al borde (109–119), ninguna de esta tarea.

## Validaciones

- [x] `npm run format`
- [x] `npm run lint:fix` (0 errores; 6 warnings preexistentes)
- [x] `npm run type-check`
- [x] `npm run test:run` — **444 archivos, 5796 tests en verde**
- [x] `npm run build` — las 11 rutas prerenderizadas (`○`/`●`)
- [x] `node scripts/validate-architecture.js`
- [x] `npm run check:indexable` contra el contenedor de producción
- [x] Sin regresión de interactividad: tests de búsqueda con debounce, chips de especialidad, estado vacío, tabs y navegación al perfil siguen verdes

Cierra **T-SEO-003** del [backlog SEO/AdSense](docs/BACKLOG_SEO_ADSENSE_2026_08.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)